### PR TITLE
feat(web): SEO structured data + /temas/ topic hub pages

### DIFF
--- a/packages/web/src/layouts/Base.astro
+++ b/packages/web/src/layouts/Base.astro
@@ -556,6 +556,7 @@ const resolvedOgUrl = resolvedCanonicalUrl ?? `${SITE_URL}${Astro.url.pathname}`
 			<button id="menu-toggle" class="menu-toggle" type="button" aria-label="Menú" aria-expanded="false">☰</button>
 			<div class="nav-links" id="nav-links">
 				<a href="/">Buscar</a>
+				<a href="/temas">Temas</a>
 				<a href="/mi-situacion" id="nav-mis-cambios" style="min-width:8ch">Mi situación</a>
 				<a href="/cambios">Cambios recientes</a>
 				<a href="/omnibus">Ómnibus</a>

--- a/packages/web/src/lib/escape.ts
+++ b/packages/web/src/lib/escape.ts
@@ -6,3 +6,9 @@ export function escapeHtml(s: string): string {
 		.replace(/>/g, "&gt;")
 		.replace(/"/g, "&quot;");
 }
+
+/** Safely serialize an object for use in `<script type="application/ld+json">`.
+ *  Escapes `<`, `>`, and `/` to prevent `</script>` injection. */
+export function safeJsonLd(obj: unknown): string {
+	return JSON.stringify(obj).replace(/</g, "\\u003c").replace(/>/g, "\\u003e");
+}

--- a/packages/web/src/lib/escape.ts
+++ b/packages/web/src/lib/escape.ts
@@ -8,7 +8,7 @@ export function escapeHtml(s: string): string {
 }
 
 /** Safely serialize an object for use in `<script type="application/ld+json">`.
- *  Escapes `<`, `>`, and `/` to prevent `</script>` injection. */
+ *  Escapes `<` and `>` to prevent `</script>` injection. */
 export function safeJsonLd(obj: unknown): string {
 	return JSON.stringify(obj).replace(/</g, "\\u003c").replace(/>/g, "\\u003e");
 }

--- a/packages/web/src/pages/laws/[id].astro
+++ b/packages/web/src/pages/laws/[id].astro
@@ -114,6 +114,23 @@ const RANK_LABELS: Record<string, string> = {
 	reglamento: "Reglamento",
 };
 
+// ELI legislation types for JSON-LD (schema.org/legislationType)
+const RANK_LEGISLATION_TYPES: Record<string, string> = {
+	constitucion: "Constitution",
+	ley_organica: "OrganicLaw",
+	ley: "Law",
+	real_decreto_ley: "RoyalDecreeLaw",
+	real_decreto_legislativo: "RoyalLegislativeDecree",
+	real_decreto: "RoyalDecree",
+	orden: "MinisterialOrder",
+	decreto: "Decree",
+	circular: "Circular",
+	resolucion: "Resolution",
+	acuerdo_internacional: "InternationalAgreement",
+	instruccion: "Instruction",
+	reglamento: "Regulation",
+};
+
 const STATUS_LABELS: Record<string, string> = {
 	vigente: "En vigor",
 	derogada: "Ya no está en vigor",
@@ -187,6 +204,8 @@ const seoDescription = [
 		...(law.estado === "vigente" || law.estado?.startsWith("derogad")
 			? { "legislationLegalForce": law.estado === "vigente" ? "InForce" : "NotInForce" }
 			: {}),
+		...(RANK_LEGISLATION_TYPES[law.rango] ? { "legislationType": RANK_LEGISLATION_TYPES[law.rango] } : {}),
+		...(materias.length > 0 ? { "about": materias.map(m => ({ "@type": "Thing", "name": m })) } : {}),
 		"inLanguage": "es",
 		"url": `https://leyabierta.es/laws/${id}`,
 		"isPartOf": { "@type": "WebSite", "@id": "https://leyabierta.es/#website" },
@@ -201,6 +220,20 @@ const seoDescription = [
 			{ "@type": "ListItem", "position": 2, "name": law.titulo, "item": `https://leyabierta.es/laws/${id}` }
 		]
 	})} />
+	{citizenSummary && (
+		<script type="application/ld+json" set:html={JSON.stringify({
+			"@context": "https://schema.org",
+			"@type": "FAQPage",
+			"mainEntity": [{
+				"@type": "Question",
+				"name": `¿Qué dice la ${law.titulo}?`,
+				"acceptedAnswer": {
+					"@type": "Answer",
+					"text": citizenSummary
+				}
+			}]
+		})} />
+	)}
 	<style>
 		.back-link { font-size: 0.8125rem; color: var(--text-muted); }
 		.back-link:hover { color: var(--text-secondary); }

--- a/packages/web/src/pages/laws/[id].astro
+++ b/packages/web/src/pages/laws/[id].astro
@@ -4,6 +4,7 @@ import { promises as fs } from "node:fs";
 import MarkdownIt from "markdown-it";
 import sanitizeHtml from "sanitize-html";
 import Base from "../../layouts/Base.astro";
+import { safeJsonLd } from "../../lib/escape";
 import { getLaw, getOmnibusDetail, type OmnibusTopic } from "../../lib/api.ts";
 import { loadManifest } from "../../lib/manifest.ts";
 
@@ -168,7 +169,6 @@ if (abbrev) {
 	const numMatch = law.titulo.match(/(\d+\/\d{4})/);
 	if (numMatch) {
 		const full = numMatch[1]!; // "769/1987"
-		const short2 = full.replace(/\/(\d{2})\d{2}$/, "/$1"); // "769/19" — wrong
 		const short2digit = full.replace(/\/\d{2}(\d{2})$/, "/$1"); // "769/87"
 		seoAbbreviations.push(`${abbrev} ${full}`); // "RD 769/1987"
 		if (short2digit !== full) seoAbbreviations.push(`${abbrev} ${short2digit}`); // "RD 769/87"
@@ -191,7 +191,7 @@ const seoDescription = [
 	canonicalUrl={`/laws/${id}`}
 >
 	<!-- JSON-LD: Legislation -->
-	<script type="application/ld+json" set:html={JSON.stringify({
+	<script type="application/ld+json" set:html={safeJsonLd({
 		"@context": "https://schema.org",
 		"@type": "Legislation",
 		"name": law.titulo,
@@ -212,7 +212,7 @@ const seoDescription = [
 		...(seoAbbreviations.length > 0 ? { "alternateName": seoAbbreviations } : {}),
 		...(law.fuente ? { "sameAs": law.fuente } : {})
 	})} />
-	<script type="application/ld+json" set:html={JSON.stringify({
+	<script type="application/ld+json" set:html={safeJsonLd({
 		"@context": "https://schema.org",
 		"@type": "BreadcrumbList",
 		"itemListElement": [
@@ -221,7 +221,7 @@ const seoDescription = [
 		]
 	})} />
 	{citizenSummary && (
-		<script type="application/ld+json" set:html={JSON.stringify({
+		<script type="application/ld+json" set:html={safeJsonLd({
 			"@context": "https://schema.org",
 			"@type": "FAQPage",
 			"mainEntity": [{

--- a/packages/web/src/pages/reforma.astro
+++ b/packages/web/src/pages/reforma.astro
@@ -468,6 +468,22 @@ import Base from "../layouts/Base.astro";
 					contentDiv.innerHTML = html;
 					document.title = (hasHeadline ? reform.headline : law.title) + ' — Ley Abierta';
 
+					// Inject NewsArticle JSON-LD for SEO (Google Discover / News)
+					var jsonLd = document.createElement("script");
+					jsonLd.type = "application/ld+json";
+					jsonLd.textContent = JSON.stringify({
+						"@context": "https://schema.org",
+						"@type": "NewsArticle",
+						"headline": hasHeadline ? reform.headline : ("Reforma: " + law.title),
+						"datePublished": reform.date,
+						"dateModified": reform.date,
+						"author": { "@type": "Organization", "name": "Ley Abierta", "url": "https://leyabierta.es" },
+						"publisher": { "@type": "Organization", "@id": "https://leyabierta.es/#org" },
+						"mainEntityOfPage": window.location.href,
+						"description": reform.summary || ("Cambios en " + law.title + " publicados el " + formatDate(reform.date))
+					});
+					document.head.appendChild(jsonLd);
+
 					// ── Toggles ──
 					contentDiv.querySelectorAll('.block-change-header').forEach(function (hdr) {
 						hdr.addEventListener('click', function () {

--- a/packages/web/src/pages/sitemap.xml.ts
+++ b/packages/web/src/pages/sitemap.xml.ts
@@ -20,7 +20,7 @@ export const GET: APIRoute = async () => {
     <priority>1.0</priority>
   </url>`,
 		`  <url>
-    <loc>${SITE_URL}/temas</loc>
+    <loc>${SITE_URL}/temas/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>`,

--- a/packages/web/src/pages/sitemap.xml.ts
+++ b/packages/web/src/pages/sitemap.xml.ts
@@ -4,6 +4,7 @@
 
 import { getCollection } from "astro:content";
 import type { APIRoute } from "astro";
+import sectorData from "../../../shared/data/sector-materias.json";
 
 export const prerender = true;
 
@@ -18,7 +19,22 @@ export const GET: APIRoute = async () => {
     <changefreq>daily</changefreq>
     <priority>1.0</priority>
   </url>`,
+		`  <url>
+    <loc>${SITE_URL}/temas</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>`,
 	];
+
+	// Topic hub pages
+	for (const slug of Object.keys(sectorData.sectors)) {
+		if (slug === "otro") continue;
+		urls.push(`  <url>
+    <loc>${SITE_URL}/temas/${slug}/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.85</priority>
+  </url>`);
+	}
 
 	for (const law of laws) {
 		const d = law.data;

--- a/packages/web/src/pages/temas/[slug].astro
+++ b/packages/web/src/pages/temas/[slug].astro
@@ -1,6 +1,7 @@
 ---
 import { getCollection } from "astro:content";
 import Base from "../../layouts/Base.astro";
+import { safeJsonLd } from "../../lib/escape";
 import sectorData from "../../../../shared/data/sector-materias.json";
 
 const RANK_LABELS: Record<string, string> = {
@@ -41,7 +42,8 @@ const sectorLaws = allLaws
 	.filter(law => (law.data.materias ?? []).some(m => sectorMaterias.has(m)))
 	.sort((a, b) => {
 		// Sort by rank importance, then by date (newest first)
-		const rankDiff = RANK_ORDER.indexOf(a.data.rango) - RANK_ORDER.indexOf(b.data.rango);
+		const rankIdx = (r: string) => { const i = RANK_ORDER.indexOf(r); return i === -1 ? 99 : i; };
+		const rankDiff = rankIdx(a.data.rango) - rankIdx(b.data.rango);
 		if (rankDiff !== 0) return rankDiff;
 		return b.data.fecha_publicacion.localeCompare(a.data.fecha_publicacion);
 	});
@@ -77,7 +79,7 @@ const seoDescription = `${sectorLaws.length.toLocaleString("es")} leyes sobre ${
 	description={seoDescription}
 	canonicalUrl={`/temas/${slug}`}
 >
-	<script type="application/ld+json" set:html={JSON.stringify({
+	<script type="application/ld+json" set:html={safeJsonLd({
 		"@context": "https://schema.org",
 		"@type": "CollectionPage",
 		"name": `Legislación sobre ${sectorLabel.toLowerCase()} en España`,
@@ -262,8 +264,8 @@ const seoDescription = `${sectorLaws.length.toLocaleString("es")} leyes sobre ${
 	</div>
 
 	{hasMore && (
-		<a href={`/?materia=${encodeURIComponent((sector.materias as string[])[0])}`} class="more-link">
-			Ver las {sectorLaws.length.toLocaleString("es")} leyes &rarr;
+		<a href={`/?q=${encodeURIComponent(sectorLabel.toLowerCase())}`} class="more-link">
+			Buscar más leyes sobre {sectorLabel.toLowerCase()} &rarr;
 		</a>
 	)}
 

--- a/packages/web/src/pages/temas/[slug].astro
+++ b/packages/web/src/pages/temas/[slug].astro
@@ -35,6 +35,8 @@ const sector = (sectorData.sectors as Record<string, any>)[slug!];
 const sectorLabel = sector.label as string;
 const sectorMaterias = new Set<string>(sector.materias as string[]);
 
+const rankIdx = (r: string) => { const i = RANK_ORDER.indexOf(r); return i === -1 ? 99 : i; };
+
 const allLaws = await getCollection("laws");
 
 // Filter laws that match this sector's materias
@@ -42,7 +44,6 @@ const sectorLaws = allLaws
 	.filter(law => (law.data.materias ?? []).some(m => sectorMaterias.has(m)))
 	.sort((a, b) => {
 		// Sort by rank importance, then by date (newest first)
-		const rankIdx = (r: string) => { const i = RANK_ORDER.indexOf(r); return i === -1 ? 99 : i; };
 		const rankDiff = rankIdx(a.data.rango) - rankIdx(b.data.rango);
 		if (rankDiff !== 0) return rankDiff;
 		return b.data.fecha_publicacion.localeCompare(a.data.fecha_publicacion);
@@ -77,7 +78,7 @@ const seoDescription = `${sectorLaws.length.toLocaleString("es")} leyes sobre ${
 <Base
 	title={`Leyes sobre ${sectorLabel.toLowerCase()}`}
 	description={seoDescription}
-	canonicalUrl={`/temas/${slug}`}
+	canonicalUrl={`/temas/${slug}/`}
 >
 	<script type="application/ld+json" set:html={safeJsonLd({
 		"@context": "https://schema.org",

--- a/packages/web/src/pages/temas/[slug].astro
+++ b/packages/web/src/pages/temas/[slug].astro
@@ -1,0 +1,281 @@
+---
+import { getCollection } from "astro:content";
+import Base from "../../layouts/Base.astro";
+import sectorData from "../../../../shared/data/sector-materias.json";
+
+const RANK_LABELS: Record<string, string> = {
+	constitucion: "Constitución", ley_organica: "Ley Orgánica", ley: "Ley",
+	real_decreto_ley: "Decreto urgente", real_decreto_legislativo: "Decreto legislativo",
+	real_decreto: "Real Decreto", orden: "Orden", resolucion: "Resolución",
+	acuerdo_internacional: "Acuerdo internacional", circular: "Circular",
+	instruccion: "Instrucción", decreto: "Decreto", reglamento: "Reglamento",
+};
+
+const STATUS_LABELS: Record<string, string> = {
+	vigente: "En vigor",
+	derogada: "Ya no está en vigor",
+	parcialmente_derogada: "Parcialmente en vigor",
+};
+
+const RANK_ORDER = [
+	"constitucion", "ley_organica", "ley", "real_decreto_ley",
+	"real_decreto_legislativo", "real_decreto", "orden", "decreto",
+	"circular", "resolucion", "acuerdo_internacional", "instruccion", "reglamento",
+];
+
+export function getStaticPaths() {
+	return Object.entries(sectorData.sectors)
+		.filter(([key]) => key !== "otro")
+		.map(([slug]) => ({ params: { slug } }));
+}
+
+const { slug } = Astro.params;
+const sector = (sectorData.sectors as Record<string, any>)[slug!];
+const sectorLabel = sector.label as string;
+const sectorMaterias = new Set<string>(sector.materias as string[]);
+
+const allLaws = await getCollection("laws");
+
+// Filter laws that match this sector's materias
+const sectorLaws = allLaws
+	.filter(law => (law.data.materias ?? []).some(m => sectorMaterias.has(m)))
+	.sort((a, b) => {
+		// Sort by rank importance, then by date (newest first)
+		const rankDiff = RANK_ORDER.indexOf(a.data.rango) - RANK_ORDER.indexOf(b.data.rango);
+		if (rankDiff !== 0) return rankDiff;
+		return b.data.fecha_publicacion.localeCompare(a.data.fecha_publicacion);
+	});
+
+// Compute rank distribution for this sector
+const rankCounts = new Map<string, number>();
+let vigenteCount = 0;
+for (const law of sectorLaws) {
+	rankCounts.set(law.data.rango, (rankCounts.get(law.data.rango) ?? 0) + 1);
+	if (law.data.estado === "vigente") vigenteCount++;
+}
+const topRanks = [...rankCounts.entries()]
+	.sort((a, b) => b[1] - a[1])
+	.slice(0, 5);
+
+// Show first 100 laws, link to search for the rest
+const DISPLAY_LIMIT = 100;
+const displayLaws = sectorLaws.slice(0, DISPLAY_LIMIT);
+const hasMore = sectorLaws.length > DISPLAY_LIMIT;
+
+const MONTHS = ['enero','febrero','marzo','abril','mayo','junio','julio','agosto','septiembre','octubre','noviembre','diciembre'];
+function formatDate(iso: string): string {
+	if (!iso) return '';
+	const [y, m, d] = iso.split('-');
+	return `${parseInt(d!, 10)} de ${MONTHS[parseInt(m!, 10) - 1]} de ${y}`;
+}
+
+const seoDescription = `${sectorLaws.length.toLocaleString("es")} leyes sobre ${sectorLabel.toLowerCase()} en España. ${vigenteCount.toLocaleString("es")} en vigor. Consulta, compara versiones y entiende cada norma.`;
+---
+
+<Base
+	title={`Leyes sobre ${sectorLabel.toLowerCase()}`}
+	description={seoDescription}
+	canonicalUrl={`/temas/${slug}`}
+>
+	<script type="application/ld+json" set:html={JSON.stringify({
+		"@context": "https://schema.org",
+		"@type": "CollectionPage",
+		"name": `Legislación sobre ${sectorLabel.toLowerCase()} en España`,
+		"description": seoDescription,
+		"url": `https://leyabierta.es/temas/${slug}`,
+		"numberOfItems": sectorLaws.length,
+		"isPartOf": { "@type": "WebSite", "@id": "https://leyabierta.es/#website" },
+		"breadcrumb": {
+			"@type": "BreadcrumbList",
+			"itemListElement": [
+				{ "@type": "ListItem", "position": 1, "name": "Inicio", "item": "https://leyabierta.es/" },
+				{ "@type": "ListItem", "position": 2, "name": "Temas", "item": "https://leyabierta.es/temas" },
+				{ "@type": "ListItem", "position": 3, "name": sectorLabel, "item": `https://leyabierta.es/temas/${slug}` }
+			]
+		}
+	})} />
+
+	<style>
+		.back-link { font-size: 0.8125rem; color: var(--text-muted); }
+		.back-link:hover { color: var(--text-secondary); }
+
+		.tema-header { margin: 0.75rem 0 1.5rem; }
+		.tema-title {
+			font-family: var(--font-serif);
+			font-size: 1.5rem;
+			font-weight: 700;
+			line-height: 1.3;
+			margin-bottom: 0.5rem;
+		}
+		.tema-description {
+			font-size: 0.9375rem;
+			color: var(--text-secondary);
+			line-height: 1.6;
+			max-width: 42rem;
+		}
+
+		.tema-stats {
+			display: flex;
+			flex-wrap: wrap;
+			gap: 0.75rem;
+			margin-bottom: 2rem;
+		}
+		.stat-pill {
+			display: inline-flex;
+			align-items: center;
+			gap: 0.375rem;
+			padding: 0.375rem 0.875rem;
+			background: var(--surface);
+			border: 1px solid var(--border-light);
+			border-radius: 100px;
+			font-size: 0.8125rem;
+			color: var(--text-secondary);
+		}
+		.stat-pill strong {
+			color: var(--accent);
+			font-variant-numeric: tabular-nums;
+		}
+
+		.law-list {
+			display: flex;
+			flex-direction: column;
+			gap: 0.5rem;
+		}
+		.law-row {
+			display: flex;
+			gap: 0.75rem;
+			align-items: baseline;
+			padding: 0.875rem 1rem;
+			background: var(--surface);
+			border: 1px solid var(--border-light);
+			border-radius: 8px;
+			transition: border-color 0.15s;
+		}
+		.law-row:hover {
+			border-color: var(--accent);
+			text-decoration: none;
+		}
+		.law-row-rank {
+			font-size: 0.6875rem;
+			font-weight: 600;
+			color: var(--accent);
+			background: var(--accent-bg);
+			padding: 0.15rem 0.5rem;
+			border-radius: 4px;
+			white-space: nowrap;
+			flex-shrink: 0;
+		}
+		.law-row-title {
+			font-size: 0.875rem;
+			color: var(--text);
+			line-height: 1.4;
+			flex: 1;
+			min-width: 0;
+		}
+		.law-row-meta {
+			font-size: 0.75rem;
+			color: var(--text-muted);
+			white-space: nowrap;
+			flex-shrink: 0;
+		}
+
+		.more-link {
+			display: inline-flex;
+			align-items: center;
+			gap: 0.375rem;
+			margin-top: 1.5rem;
+			padding: 0.625rem 1.25rem;
+			background: var(--accent-bg);
+			color: var(--accent);
+			border-radius: 8px;
+			font-size: 0.875rem;
+			font-weight: 500;
+		}
+		.more-link:hover { text-decoration: none; background: var(--accent); color: #fff; }
+
+		.other-temas {
+			margin-top: 3rem;
+			padding-top: 2rem;
+			border-top: 1px solid var(--border-light);
+		}
+		.other-temas-heading {
+			font-size: 1rem;
+			font-weight: 600;
+			margin-bottom: 0.75rem;
+		}
+		.other-temas-list {
+			display: flex;
+			flex-wrap: wrap;
+			gap: 0.5rem;
+		}
+		.other-tema-tag {
+			display: inline-block;
+			padding: 0.3rem 0.75rem;
+			border: 1px solid var(--border);
+			border-radius: 100px;
+			font-size: 0.8125rem;
+			color: var(--text-secondary);
+		}
+		.other-tema-tag:hover {
+			background: var(--accent-bg);
+			color: var(--accent);
+			border-color: var(--accent);
+			text-decoration: none;
+		}
+
+		@media (max-width: 640px) {
+			.law-row { flex-direction: column; gap: 0.25rem; }
+			.law-row-meta { white-space: normal; }
+		}
+	</style>
+
+	<a href="/temas/" class="back-link">&larr; Todos los temas</a>
+
+	<div class="tema-header">
+		<h1 class="tema-title">Leyes sobre {sectorLabel.toLowerCase()}</h1>
+		<p class="tema-description">
+			{sectorLaws.length.toLocaleString("es")} normas relacionadas con {sectorLabel.toLowerCase()} en la legislación española.
+			{vigenteCount > 0 && <>{vigenteCount.toLocaleString("es")} están actualmente en vigor.</>}
+		</p>
+	</div>
+
+	<div class="tema-stats">
+		<span class="stat-pill"><strong>{sectorLaws.length.toLocaleString("es")}</strong> leyes</span>
+		<span class="stat-pill"><strong>{vigenteCount.toLocaleString("es")}</strong> en vigor</span>
+		{topRanks.slice(0, 3).map(([rank, count]) => (
+			<span class="stat-pill"><strong>{count}</strong> {RANK_LABELS[rank] ?? rank}</span>
+		))}
+	</div>
+
+	<div class="law-list">
+		{displayLaws.map(law => (
+			<a href={`/laws/${law.data.identificador}/`} class="law-row">
+				<span class="law-row-rank">{RANK_LABELS[law.data.rango] ?? law.data.rango}</span>
+				<span class="law-row-title">{law.data.titulo}</span>
+				<span class="law-row-meta">
+					<span class={`badge badge-${law.data.estado}`} style="font-size:0.625rem;padding:0.1rem 0.4rem">
+						{STATUS_LABELS[law.data.estado] ?? law.data.estado}
+					</span>
+				</span>
+			</a>
+		))}
+	</div>
+
+	{hasMore && (
+		<a href={`/?materia=${encodeURIComponent((sector.materias as string[])[0])}`} class="more-link">
+			Ver las {sectorLaws.length.toLocaleString("es")} leyes &rarr;
+		</a>
+	)}
+
+	<div class="other-temas">
+		<h2 class="other-temas-heading">Otros temas</h2>
+		<div class="other-temas-list">
+			{Object.entries(sectorData.sectors)
+				.filter(([key]) => key !== "otro" && key !== slug)
+				.map(([key, val]) => (
+					<a href={`/temas/${key}/`} class="other-tema-tag">{(val as any).shortLabel}</a>
+				))
+			}
+		</div>
+	</div>
+</Base>

--- a/packages/web/src/pages/temas/index.astro
+++ b/packages/web/src/pages/temas/index.astro
@@ -1,0 +1,137 @@
+---
+import { getCollection } from "astro:content";
+import Base from "../../layouts/Base.astro";
+import sectorData from "../../../../shared/data/sector-materias.json";
+
+const laws = await getCollection("laws");
+
+// Build a set of all materias across all laws for quick lookup
+const materiaToLawCount = new Map<string, number>();
+for (const law of laws) {
+	for (const m of law.data.materias ?? []) {
+		materiaToLawCount.set(m, (materiaToLawCount.get(m) ?? 0) + 1);
+	}
+}
+
+// Build sector stats
+const sectors = Object.entries(sectorData.sectors)
+	.filter(([key]) => key !== "otro")
+	.map(([slug, sector]) => {
+		const sectorMaterias = new Set((sector as any).materias as string[]);
+		// Count unique laws that have at least one materia in this sector
+		let lawCount = 0;
+		for (const law of laws) {
+			if ((law.data.materias ?? []).some(m => sectorMaterias.has(m))) {
+				lawCount++;
+			}
+		}
+		return {
+			slug,
+			label: (sector as any).label as string,
+			shortLabel: (sector as any).shortLabel as string,
+			lawCount,
+		};
+	})
+	.filter(s => s.lawCount > 0)
+	.sort((a, b) => b.lawCount - a.lawCount);
+
+const totalLaws = laws.length;
+---
+
+<Base
+	title="Temas legislativos"
+	description={`Explora la legislación española por temas: ${sectors.slice(0, 4).map(s => s.label.toLowerCase()).join(", ")} y más. Más de ${totalLaws.toLocaleString("es")} leyes organizadas por categoría.`}
+	canonicalUrl="/temas"
+>
+	<script type="application/ld+json" set:html={JSON.stringify({
+		"@context": "https://schema.org",
+		"@type": "CollectionPage",
+		"name": "Temas legislativos de España",
+		"description": `Índice de categorías temáticas de la legislación española. ${sectors.length} áreas con más de ${totalLaws.toLocaleString("es")} leyes.`,
+		"url": "https://leyabierta.es/temas",
+		"isPartOf": { "@type": "WebSite", "@id": "https://leyabierta.es/#website" },
+		"breadcrumb": {
+			"@type": "BreadcrumbList",
+			"itemListElement": [
+				{ "@type": "ListItem", "position": 1, "name": "Inicio", "item": "https://leyabierta.es/" },
+				{ "@type": "ListItem", "position": 2, "name": "Temas", "item": "https://leyabierta.es/temas" }
+			]
+		}
+	})} />
+
+	<style>
+		.temas-header {
+			margin-bottom: 2rem;
+		}
+		.temas-title {
+			font-family: var(--font-serif);
+			font-size: 1.75rem;
+			font-weight: 700;
+			margin-bottom: 0.5rem;
+		}
+		.temas-subtitle {
+			font-size: 0.9375rem;
+			color: var(--text-secondary);
+			line-height: 1.6;
+		}
+
+		.temas-grid {
+			display: grid;
+			grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+			gap: 1rem;
+		}
+
+		.tema-card {
+			display: flex;
+			flex-direction: column;
+			gap: 0.5rem;
+			padding: 1.25rem 1.5rem;
+			background: var(--surface);
+			border: 1px solid var(--border-light);
+			border-radius: 10px;
+			transition: border-color 0.15s, box-shadow 0.15s;
+		}
+		.tema-card:hover {
+			border-color: var(--accent);
+			box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
+			text-decoration: none;
+		}
+
+		.tema-label {
+			font-family: var(--font-serif);
+			font-size: 1.0625rem;
+			font-weight: 600;
+			color: var(--text);
+			line-height: 1.3;
+		}
+
+		.tema-count {
+			font-size: 0.8125rem;
+			color: var(--text-muted);
+		}
+
+		@media (max-width: 640px) {
+			.temas-grid {
+				grid-template-columns: 1fr;
+			}
+		}
+	</style>
+
+	<a href="/" style="font-size: 0.8125rem; color: var(--text-muted);">&larr; Inicio</a>
+	<div class="temas-header">
+		<h1 class="temas-title">Temas legislativos</h1>
+		<p class="temas-subtitle">
+			Explora las leyes de España organizadas por área temática.
+			Cada categoría agrupa las normas que regulan un sector concreto.
+		</p>
+	</div>
+
+	<div class="temas-grid">
+		{sectors.map(sector => (
+			<a href={`/temas/${sector.slug}/`} class="tema-card">
+				<span class="tema-label">{sector.label}</span>
+				<span class="tema-count">{sector.lawCount.toLocaleString("es")} leyes</span>
+			</a>
+		))}
+	</div>
+</Base>

--- a/packages/web/src/pages/temas/index.astro
+++ b/packages/web/src/pages/temas/index.astro
@@ -42,7 +42,7 @@ const totalLaws = laws.length;
 <Base
 	title="Temas legislativos"
 	description={`Explora la legislación española por temas: ${sectors.slice(0, 4).map(s => s.label.toLowerCase()).join(", ")} y más. Más de ${totalLaws.toLocaleString("es")} leyes organizadas por categoría.`}
-	canonicalUrl="/temas"
+	canonicalUrl="/temas/"
 >
 	<script type="application/ld+json" set:html={safeJsonLd({
 		"@context": "https://schema.org",

--- a/packages/web/src/pages/temas/index.astro
+++ b/packages/web/src/pages/temas/index.astro
@@ -1,6 +1,7 @@
 ---
 import { getCollection } from "astro:content";
 import Base from "../../layouts/Base.astro";
+import { safeJsonLd } from "../../lib/escape";
 import sectorData from "../../../../shared/data/sector-materias.json";
 
 const laws = await getCollection("laws");
@@ -43,7 +44,7 @@ const totalLaws = laws.length;
 	description={`Explora la legislación española por temas: ${sectors.slice(0, 4).map(s => s.label.toLowerCase()).join(", ")} y más. Más de ${totalLaws.toLocaleString("es")} leyes organizadas por categoría.`}
 	canonicalUrl="/temas"
 >
-	<script type="application/ld+json" set:html={JSON.stringify({
+	<script type="application/ld+json" set:html={safeJsonLd({
 		"@context": "https://schema.org",
 		"@type": "CollectionPage",
 		"name": "Temas legislativos de España",


### PR DESCRIPTION
## Summary

- **JSON-LD enriquecido**: añade `legislationType` (ELI) y `about` (materias como array de `Thing`) al schema `Legislation` de cada ley
- **FAQPage schema**: bloque condicional en leyes con citizen summary — pregunta "¿Qué dice la [título]?" con respuesta del resumen
- **NewsArticle schema**: inyección dinámica en páginas de reforma para Google Discover/News (headline, datePublished, publisher)
- **`/temas/` topic hubs**: índice de sectores temáticos + páginas por sector con leyes filtradas, stats, `CollectionPage` schema, `BreadcrumbList`, y links cruzados entre temas
- **Nav + Sitemap**: link "Temas" en navegación principal, todas las páginas de temas en el sitemap

Basado en `docs/seo-growth-strategy.md` acciones 1, 2, 6 y 7.

## Test plan

- [ ] Verificar JSON-LD de una ley con citizen summary en [Rich Results Test](https://search.google.com/test/rich-results)
- [ ] Verificar FAQPage markup en Rich Results Test
- [ ] Comprobar que `/temas/` renderiza el índice con conteos correctos
- [ ] Comprobar que `/temas/campo/` muestra leyes de agricultura ordenadas por rango
- [ ] Verificar sitemap incluye `/temas` y `/temas/[slug]/`
- [ ] Comprobar link "Temas" aparece en el nav

🤖 Generated with [Claude Code](https://claude.com/claude-code)