### PR TITLE
feat(web): SEO structured data — JSON-LD Legislation

### DIFF
--- a/packages/web/src/lib/escape.ts
+++ b/packages/web/src/lib/escape.ts
@@ -6,3 +6,9 @@ export function escapeHtml(s: string): string {
 		.replace(/>/g, "&gt;")
 		.replace(/"/g, "&quot;");
 }
+
+/** Safely serialize an object for use in `<script type="application/ld+json">`.
+ *  Escapes `<` and `>` to prevent `</script>` injection. */
+export function safeJsonLd(obj: unknown): string {
+	return JSON.stringify(obj).replace(/</g, "\\u003c").replace(/>/g, "\\u003e");
+}

--- a/packages/web/src/pages/laws/[id].astro
+++ b/packages/web/src/pages/laws/[id].astro
@@ -115,7 +115,7 @@ const RANK_LABELS: Record<string, string> = {
 	reglamento: "Reglamento",
 };
 
-// Custom text labels for legislationType (schema.org/LegislationType has no Spanish equivalents)
+// legislationType accepts free text (schema.org examples: "law", "decree", "loi organique")
 const RANK_LEGISLATION_TYPES: Record<string, string> = {
 	constitucion: "Constitution",
 	ley_organica: "OrganicLaw",

--- a/packages/web/src/pages/laws/[id].astro
+++ b/packages/web/src/pages/laws/[id].astro
@@ -4,6 +4,7 @@ import { promises as fs } from "node:fs";
 import MarkdownIt from "markdown-it";
 import sanitizeHtml from "sanitize-html";
 import Base from "../../layouts/Base.astro";
+import { safeJsonLd } from "../../lib/escape";
 import { getLaw, getOmnibusDetail, type OmnibusTopic } from "../../lib/api.ts";
 import { loadManifest } from "../../lib/manifest.ts";
 
@@ -114,6 +115,23 @@ const RANK_LABELS: Record<string, string> = {
 	reglamento: "Reglamento",
 };
 
+// ELI legislation types for JSON-LD (schema.org/legislationType)
+const RANK_LEGISLATION_TYPES: Record<string, string> = {
+	constitucion: "Constitution",
+	ley_organica: "OrganicLaw",
+	ley: "Law",
+	real_decreto_ley: "RoyalDecreeLaw",
+	real_decreto_legislativo: "RoyalLegislativeDecree",
+	real_decreto: "RoyalDecree",
+	orden: "MinisterialOrder",
+	decreto: "Decree",
+	circular: "Circular",
+	resolucion: "Resolution",
+	acuerdo_internacional: "InternationalAgreement",
+	instruccion: "Instruction",
+	reglamento: "Regulation",
+};
+
 const STATUS_LABELS: Record<string, string> = {
 	vigente: "En vigor",
 	derogada: "Ya no está en vigor",
@@ -174,7 +192,7 @@ const seoDescription = [
 	canonicalUrl={`/laws/${id}`}
 >
 	<!-- JSON-LD: Legislation -->
-	<script type="application/ld+json" set:html={JSON.stringify({
+	<script type="application/ld+json" set:html={safeJsonLd({
 		"@context": "https://schema.org",
 		"@type": "Legislation",
 		"name": law.titulo,
@@ -187,13 +205,15 @@ const seoDescription = [
 		...(law.estado === "vigente" || law.estado?.startsWith("derogad")
 			? { "legislationLegalForce": law.estado === "vigente" ? "InForce" : "NotInForce" }
 			: {}),
+		...(RANK_LEGISLATION_TYPES[law.rango] ? { "legislationType": RANK_LEGISLATION_TYPES[law.rango] } : {}),
+		...(materias.length > 0 ? { "about": materias.map(m => ({ "@type": "Thing", "name": m })) } : {}),
 		"inLanguage": "es",
 		"url": `https://leyabierta.es/laws/${id}`,
 		"isPartOf": { "@type": "WebSite", "@id": "https://leyabierta.es/#website" },
 		...(seoAbbreviations.length > 0 ? { "alternateName": seoAbbreviations } : {}),
 		...(law.fuente ? { "sameAs": law.fuente } : {})
 	})} />
-	<script type="application/ld+json" set:html={JSON.stringify({
+	<script type="application/ld+json" set:html={safeJsonLd({
 		"@context": "https://schema.org",
 		"@type": "BreadcrumbList",
 		"itemListElement": [

--- a/packages/web/src/pages/laws/[id].astro
+++ b/packages/web/src/pages/laws/[id].astro
@@ -115,7 +115,7 @@ const RANK_LABELS: Record<string, string> = {
 	reglamento: "Reglamento",
 };
 
-// ELI legislation types for JSON-LD (schema.org/legislationType)
+// Custom text labels for legislationType (schema.org/LegislationType has no Spanish equivalents)
 const RANK_LEGISLATION_TYPES: Record<string, string> = {
 	constitucion: "Constitution",
 	ley_organica: "OrganicLaw",


### PR DESCRIPTION
## Summary
- Add `safeJsonLd` helper in `escape.ts` — escapes `<` and `>` to prevent `</script>` injection in JSON-LD blocks
- Enrich existing Legislation JSON-LD with `legislationType` (ELI mapping from rank) and `about` (materias as `schema.org/Thing`)
- Replace raw `JSON.stringify` with `safeJsonLd` in both Legislation and BreadcrumbList schemas

Extracted from #7 — only the JSON-LD changes, without `/temas/` pages or FAQ schema.

## Test plan
- [ ] Verify JSON-LD renders correctly on law detail pages (view source, check `<script type="application/ld+json">`)
- [ ] Validate with Google Rich Results Test
- [ ] Confirm no `</script>` injection possible in titles with special characters

🤖 Generated with [Claude Code](https://claude.com/claude-code)