### PR TITLE
fix(rag): FK on citizen-summary insert + SSE keepalive on /ask/stream

### DIFF
--- a/packages/api/src/routes/ask.ts
+++ b/packages/api/src/routes/ask.ts
@@ -98,6 +98,11 @@ export function askRoutes(pipeline: RagPipeline | null) {
 					})) {
 						if (event.type === "chunk") {
 							yield `event: chunk\ndata: ${JSON.stringify(event.text)}\n\n`;
+						} else if (event.type === "keepalive") {
+							// SSE comment — clients ignore it, but proxies (Cloudflare
+							// Tunnel) see the bytes and keep the connection open during
+							// the long retrieval phase.
+							yield `: keepalive\n\n`;
 						} else {
 							yield `event: done\ndata: ${JSON.stringify({ citations: event.citations, meta: event.meta, declined: event.declined })}\n\n`;
 						}

--- a/packages/api/src/services/rag/pipeline.ts
+++ b/packages/api/src/services/rag/pipeline.ts
@@ -3024,11 +3024,12 @@ Responde SOLO con JSON.`,
 						.replace(/[\x00-\x1f]/g, "")
 						.trim();
 					if (sanitized) {
-						this.insertSummaryStmt.run(
-							article.normId,
-							article.blockId,
-							sanitized,
-						);
+						// blocks.block_id is the article-level id (e.g. "a10"); embeddings
+						// may carry sub-chunk ids (e.g. "a10__1") which would fail the FK.
+						const rootBlockId =
+							parseSubchunkId(article.blockId)?.parentBlockId ??
+							article.blockId;
+						this.insertSummaryStmt.run(article.normId, rootBlockId, sanitized);
 					}
 				})
 				.catch((err) => {

--- a/packages/api/src/services/rag/pipeline.ts
+++ b/packages/api/src/services/rag/pipeline.ts
@@ -1388,6 +1388,7 @@ export class RagPipeline {
 	 */
 	async *askStream(request: AskRequest): AsyncGenerator<
 		| { type: "chunk"; text: string }
+		| { type: "keepalive" }
 		| {
 				type: "done";
 				citations: Citation[];
@@ -1403,7 +1404,28 @@ export class RagPipeline {
 		});
 
 		try {
-			const retrieval = await this.runRetrieval(request, trace);
+			// Retrieval can take >100s on the production server, longer than the
+			// Cloudflare Tunnel idle timeout. Interleave keepalive events every
+			// 10s so the route handler can flush an SSE comment and the proxy
+			// keeps the connection open.
+			const retrievalPromise = this.runRetrieval(request, trace);
+			let retrievalDone = false;
+			retrievalPromise.finally(() => {
+				retrievalDone = true;
+			});
+			while (!retrievalDone) {
+				const tick = new Promise<"tick">((r) =>
+					setTimeout(() => r("tick"), 10_000),
+				);
+				const winner = await Promise.race([
+					retrievalPromise.then(() => "done" as const),
+					tick,
+				]);
+				if (winner === "tick" && !retrievalDone) {
+					yield { type: "keepalive" };
+				}
+			}
+			const retrieval = await retrievalPromise;
 
 			if (retrieval.type === "early") {
 				yield { type: "chunk", text: retrieval.response.answer };


### PR DESCRIPTION
## Summary

Dos fixes pequeños pero necesarios tras el deploy del RAG a producción (#19).

### 1. FK constraint en citizen-summary insert

Cada `/v1/ask` dejaba en el log de prod:
```
Background summary generation failed for BOE-A-1994-26003: FOREIGN KEY constraint failed
```

Embeddings se almacenan al nivel de sub-chunk (`a10__1` = apartado 1 del artículo 10). La tabla `blocks` solo tiene IDs raíz (`a10`). El INSERT usaba el sub-chunk id directamente y fallaba la FK. Fix: extraer el block_id raíz con `parseSubchunkId()`.

### 2. SSE keepalive en /v1/ask/stream

`askStream` hace `await runRetrieval()` (90-130s en prod) antes del primer chunk. CF Tunnel idle timeout (~100s) corta la conexión → 502 en el navegador. Solución: emitir SSE comments (`: keepalive\n\n`) cada 10s durante el retrieval. Clientes los ignoran por spec, proxies los ven y mantienen la conexión.

Stopgap mientras se trabaja la fase 2 de #20 (paralelizar BM25 + vector). Cuando retrieval baje de 10s, los keepalives se vuelven inertes pero quedan de safety net.

## Test plan

- [x] Tests pasan (171 tests API, 389 tests global)
- [x] Lint limpio
- [ ] Tras deploy, verificar en prod: `curl -N /v1/ask/stream` debe devolver SSE comments durante los primeros ~130s, luego chunks
- [ ] Verificar que el log ya no muestra el FK error tras cada /v1/ask

## Follow-up (no incluido aquí)

Bug pre-existente identificado durante review: `generateMissingSummaries` busca el artículo con `articles.find((a) => a.normId === citation.normId)` y solo matchea normId, no normId+blockId. Para artículos con sub-chunks, el `article.text` resultante puede ser sólo un apartado, no el artículo completo. Issue separado a abrir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)