### PR TITLE
fix(rag): force CF to start streaming immediately

### DIFF
--- a/packages/api/src/routes/ask.ts
+++ b/packages/api/src/routes/ask.ts
@@ -98,6 +98,11 @@ export function askRoutes(pipeline: RagPipeline | null) {
 					})) {
 						if (event.type === "chunk") {
 							yield `event: chunk\ndata: ${JSON.stringify(event.text)}\n\n`;
+						} else if (event.type === "keepalive") {
+							// SSE comment — clients ignore it, but proxies (Cloudflare
+							// Tunnel) see the bytes and keep the connection open during
+							// the long retrieval phase.
+							yield `: keepalive\n\n`;
 						} else {
 							yield `event: done\ndata: ${JSON.stringify({ citations: event.citations, meta: event.meta, declined: event.declined })}\n\n`;
 						}

--- a/packages/api/src/routes/ask.ts
+++ b/packages/api/src/routes/ask.ts
@@ -74,6 +74,16 @@ export function askRoutes(pipeline: RagPipeline | null) {
 		.post(
 			"/ask/stream",
 			async function* ({ body, set }) {
+				// Set SSE headers up front so error yields below also carry the
+				// correct Content-Type and no-buffering hints.
+				set.headers["Content-Type"] = "text/event-stream";
+				set.headers["Cache-Control"] = "no-cache, no-transform";
+				set.headers.Connection = "keep-alive";
+				// Hint to nginx-style proxies to disable response buffering. Cloudflare
+				// reads this and (mostly) flushes immediately. Without it CF Tunnel
+				// can hold the response until Content-Length / certain buffer fills.
+				set.headers["X-Accel-Buffering"] = "no";
+
 				if (!pipeline) {
 					set.status = 503;
 					yield `event: error\ndata: ${JSON.stringify({ error: "El servicio de preguntas no está disponible." })}\n\n`;
@@ -87,20 +97,12 @@ export function askRoutes(pipeline: RagPipeline | null) {
 					return;
 				}
 
-				set.headers["Content-Type"] = "text/event-stream";
-				set.headers["Cache-Control"] = "no-cache, no-transform";
-				set.headers.Connection = "keep-alive";
-				// Hint to nginx-style proxies to disable response buffering. Cloudflare
-				// reads this and (mostly) flushes immediately. Without it CF Tunnel
-				// can hold the response until Content-Length / certain buffer fills.
-				set.headers["X-Accel-Buffering"] = "no";
-
 				try {
 					// Emit an immediate stage event so the response status + first byte
 					// reach Cloudflare well within its 100s origin-timeout window.
 					// Without this, CF returns 524 even though the server is still
 					// working on retrieval.
-					yield `event: stage\ndata: "retrieval_started"\n\n`;
+					yield `event: stage\ndata: ${JSON.stringify({ stage: "retrieval_started" })}\n\n`;
 					for await (const event of pipeline.askStream({
 						question: validated,
 						jurisdiction: body.jurisdiction,
@@ -111,7 +113,7 @@ export function askRoutes(pipeline: RagPipeline | null) {
 							// Real event (not SSE comment) so proxies that filter
 							// comments still see byte traffic. Clients ignore unknown
 							// event types per the SSE spec.
-							yield `event: keepalive\ndata: {}\n\n`;
+							yield `event: keepalive\ndata: ${JSON.stringify({})}\n\n`;
 						} else {
 							yield `event: done\ndata: ${JSON.stringify({ citations: event.citations, meta: event.meta, declined: event.declined })}\n\n`;
 						}

--- a/packages/api/src/routes/ask.ts
+++ b/packages/api/src/routes/ask.ts
@@ -88,10 +88,19 @@ export function askRoutes(pipeline: RagPipeline | null) {
 				}
 
 				set.headers["Content-Type"] = "text/event-stream";
-				set.headers["Cache-Control"] = "no-store";
+				set.headers["Cache-Control"] = "no-cache, no-transform";
 				set.headers.Connection = "keep-alive";
+				// Hint to nginx-style proxies to disable response buffering. Cloudflare
+				// reads this and (mostly) flushes immediately. Without it CF Tunnel
+				// can hold the response until Content-Length / certain buffer fills.
+				set.headers["X-Accel-Buffering"] = "no";
 
 				try {
+					// Emit an immediate stage event so the response status + first byte
+					// reach Cloudflare well within its 100s origin-timeout window.
+					// Without this, CF returns 524 even though the server is still
+					// working on retrieval.
+					yield `event: stage\ndata: "retrieval_started"\n\n`;
 					for await (const event of pipeline.askStream({
 						question: validated,
 						jurisdiction: body.jurisdiction,
@@ -99,10 +108,10 @@ export function askRoutes(pipeline: RagPipeline | null) {
 						if (event.type === "chunk") {
 							yield `event: chunk\ndata: ${JSON.stringify(event.text)}\n\n`;
 						} else if (event.type === "keepalive") {
-							// SSE comment — clients ignore it, but proxies (Cloudflare
-							// Tunnel) see the bytes and keep the connection open during
-							// the long retrieval phase.
-							yield `: keepalive\n\n`;
+							// Real event (not SSE comment) so proxies that filter
+							// comments still see byte traffic. Clients ignore unknown
+							// event types per the SSE spec.
+							yield `event: keepalive\ndata: {}\n\n`;
 						} else {
 							yield `event: done\ndata: ${JSON.stringify({ citations: event.citations, meta: event.meta, declined: event.declined })}\n\n`;
 						}

--- a/packages/api/src/services/rag/pipeline.ts
+++ b/packages/api/src/services/rag/pipeline.ts
@@ -3024,11 +3024,12 @@ Responde SOLO con JSON.`,
 						.replace(/[\x00-\x1f]/g, "")
 						.trim();
 					if (sanitized) {
-						this.insertSummaryStmt.run(
-							article.normId,
-							article.blockId,
-							sanitized,
-						);
+						// blocks.block_id is the article-level id (e.g. "a10"); embeddings
+						// may carry sub-chunk ids (e.g. "a10__1") which would fail the FK.
+						const rootBlockId =
+							parseSubchunkId(article.blockId)?.parentBlockId ??
+							article.blockId;
+						this.insertSummaryStmt.run(article.normId, rootBlockId, sanitized);
 					}
 				})
 				.catch((err) => {

--- a/packages/api/src/services/rag/pipeline.ts
+++ b/packages/api/src/services/rag/pipeline.ts
@@ -1388,6 +1388,7 @@ export class RagPipeline {
 	 */
 	async *askStream(request: AskRequest): AsyncGenerator<
 		| { type: "chunk"; text: string }
+		| { type: "keepalive" }
 		| {
 				type: "done";
 				citations: Citation[];
@@ -1403,7 +1404,28 @@ export class RagPipeline {
 		});
 
 		try {
-			const retrieval = await this.runRetrieval(request, trace);
+			// Retrieval can take >100s on the production server, longer than the
+			// Cloudflare Tunnel idle timeout. Interleave keepalive events every
+			// 10s so the route handler can flush an SSE comment and the proxy
+			// keeps the connection open.
+			const retrievalPromise = this.runRetrieval(request, trace);
+			let retrievalDone = false;
+			retrievalPromise.finally(() => {
+				retrievalDone = true;
+			});
+			while (!retrievalDone) {
+				const tick = new Promise<"tick">((r) =>
+					setTimeout(() => r("tick"), 10_000),
+				);
+				const winner = await Promise.race([
+					retrievalPromise.then(() => "done" as const),
+					tick,
+				]);
+				if (winner === "tick" && !retrievalDone) {
+					yield { type: "keepalive" };
+				}
+			}
+			const retrieval = await retrievalPromise;
 
 			if (retrieval.type === "early") {
 				yield { type: "chunk", text: retrieval.response.answer };


### PR DESCRIPTION
## Summary

Tras el merge del PR #27, probé \`/v1/ask/stream\` desde fuera (vía CF Tunnel) y obtuve **524 (origin timeout)** a los 100s a pesar de los SSE keepalives cada 10s. Cloudflare ignoraba los keepalives porque (a) eran SSE comments que algunos proxies filtran, y (b) estaba esperando el primer byte para evaluar timeout, no bytes intermedios.

## Cambios

1. **Yield inmediato de un \`event: stage\`** antes de \`runRetrieval()\`. CF mide su timeout 100s desde apertura de conexión a primer byte; con el stage event los headers + primer byte llegan a t=0.
2. **Keepalive como evento real** (\`event: keepalive\`) en lugar de SSE comment. Algunos proxies filtran comments del response buffered; los eventos reales se reenvían.
3. **Header \`X-Accel-Buffering: no\`** + \`Cache-Control: no-cache, no-transform\` para que CF (y proxies estilo nginx) flusheen el response en vez de bufferar hasta Content-Length.

Los clientes ignoran tipos de eventos SSE desconocidos por spec, así que \`AskChat.tsx\` sigue funcionando sin cambios (lee \`event: chunk\` y \`event: done\` como antes).

## Test plan

- [x] Tests pasan (171 tests)
- [x] Lint limpio
- [ ] Tras deploy: \`curl -N https://api.leyabierta.es/v1/ask/stream\` debe devolver \`event: stage\` inmediatamente, luego keepalives cada 10s, y completarse sin 524

🤖 Generated with [Claude Code](https://claude.com/claude-code)