### PR TITLE
Sprint 1 cleanup: drop simd/js fallbacks, pool-only

### DIFF
--- a/packages/api/src/services/rag/embeddings.ts
+++ b/packages/api/src/services/rag/embeddings.ts
@@ -517,13 +517,9 @@ async function loadVectorsToMemory(
 	totalVectors: number,
 	dims: number,
 ): Promise<InMemoryVectorIndex> {
-	// When the worker pool is enabled, allocate chunks as SharedArrayBuffer
-	// directly so they can be referenced by workers without a 5.6 GB copy
-	// at boot. The pool checks the chunk's underlying buffer type and skips
-	// the toShared() copy path when the buffer is already a SAB.
-	const useShared =
-		(process.env.RAG_VECTOR_BACKEND ?? "").toLowerCase() === "pool";
-
+	// Vector chunks are always SAB-backed so the worker pool can reference
+	// them without a 5.6 GB copy at boot. The pool detects the underlying
+	// buffer type and reuses SABs directly in toShared().
 	const vecFile = Bun.file(vecPath);
 	const totalBytes = vecFile.size;
 	const bytesPerVec = dims * 4;
@@ -543,36 +539,24 @@ async function loadVectorsToMemory(
 		const endByte = endVec * bytesPerVec;
 		const wanted = endByte - startByte;
 
-		// Read into an ArrayBuffer first (Bun has a fast path for this) and
-		// then, when the pool needs SAB-backed chunks, memcpy across. Per-
-		// chunk peak is 2× chunk size during the copy, but each ArrayBuffer
-		// becomes garbage immediately and is reclaimed before the next
-		// chunk allocates. Streaming via for-await proved CPU-bound at
-		// ~80x slower in practice — see bench-pool history.
+		// Read into an ArrayBuffer first (Bun's fast path) and then memcpy
+		// into a SAB. Per-chunk peak is 2× chunk size during the copy, but
+		// each ArrayBuffer is reclaimed before the next chunk allocates.
+		// Streaming via for-await proved CPU-bound at ~80x slower in
+		// practice — see bench-pool history.
 		const buf = await vecFile.slice(startByte, endByte).arrayBuffer();
 		if (buf.byteLength < wanted) {
 			throw new Error(
 				`vectors.bin chunk short: expected ${wanted} got ${buf.byteLength}`,
 			);
 		}
-		let vectors: Float32Array;
-		if (useShared) {
-			const sab = new SharedArrayBuffer(wanted);
-			new Uint8Array(sab).set(new Uint8Array(buf, 0, wanted));
-			vectors = new Float32Array(sab);
-		} else {
-			// Bun.file().slice() may return slightly more than requested; trim.
-			const trimmed = buf.byteLength === wanted ? buf : buf.slice(0, wanted);
-			vectors = new Float32Array(trimmed);
-		}
+		const sab = new SharedArrayBuffer(wanted);
+		new Uint8Array(sab).set(new Uint8Array(buf, 0, wanted));
+		const vectors = new Float32Array(sab);
 
-		// Precompute L2 norm per vector — paid once at load, reused per query.
-		// Norms are cheap (~2 MB total) — use SAB-backed too when shared so
-		// workers get them in the init message without a copy step.
-		const normsBytes = numVecs * 4;
-		const norms = useShared
-			? new Float32Array(new SharedArrayBuffer(normsBytes))
-			: new Float32Array(numVecs);
+		// Norms are cheap (~2 MB total) but live in a SAB too so workers
+		// receive them via the init message without a copy step.
+		const norms = new Float32Array(new SharedArrayBuffer(numVecs * 4));
 		for (let i = 0; i < numVecs; i++) {
 			const offset = i * dims;
 			let sum = 0;

--- a/packages/api/src/services/rag/pipeline.ts
+++ b/packages/api/src/services/rag/pipeline.ts
@@ -13,7 +13,6 @@ import {
 	ensureVectorIndex,
 	getEmbeddedNormIds,
 	getEmbeddingCount,
-	vectorSearchInMemory,
 } from "./embeddings.ts";
 import { JURISDICTION_NAMES, resolveJurisdiction } from "./jurisdiction.ts";
 import { type RerankerCandidate, rerank } from "./reranker.ts";
@@ -30,58 +29,17 @@ import {
 } from "./temporal.ts";
 import { type RagTrace, startTrace } from "./tracing.ts";
 import { vectorSearchPooled } from "./vector-pool.ts";
-// Native SIMD backend (gated by RAG_VECTOR_BACKEND, falls back when unavailable).
-import { simdAvailable, vectorSearchSIMD } from "./vector-simd.ts";
 
 /**
- * RAG_VECTOR_BACKEND selects how the vector top-K is computed:
- *   - "pool"  → SharedArrayBuffer pool of N workers (best for concurrency)
- *   - "simd"  → in-process bun:ffi (single-thread, blocks event loop)
- *   - "js"    → pure JS fallback (safety valve, slow)
- *   - unset   → "simd" by default (Day 2 baseline; Day 3 opts in via env)
+ * Vector pool sizing — env-tunable but the defaults match the prod
+ * KonarServer layout (8 vCPU, 4 workers leave 4 cores for the rest).
+ * If the .so or worker spawn fail, the API will not boot — the orchestrator
+ * (watchtower / docker restart) keeps the previous container running.
  */
-const VECTOR_BACKEND = (process.env.RAG_VECTOR_BACKEND ?? "simd").toLowerCase();
 const VECTOR_POOL_WORKERS = Number(process.env.RAG_VECTOR_POOL_WORKERS ?? "4");
 const VECTOR_POOL_MAX_PENDING = Number(
 	process.env.RAG_VECTOR_POOL_MAX_PENDING ?? "20",
 );
-
-/**
- * Dispatch a vector top-K search to the configured backend, falling back
- * cleanly when a backend can't run (missing native lib, pool busy, etc.).
- * Returns the raw VectorSearchResult[]; the caller still applies
- * MIN_SIMILARITY filtering to keep the existing semantics.
- */
-async function selectVectorBackend(
-	embedding: Float32Array,
-	meta: Array<{ normId: string; blockId: string }>,
-	index: Parameters<typeof vectorSearchSIMD>[2],
-	dims: number,
-	topK: number,
-) {
-	if (VECTOR_BACKEND === "pool") {
-		try {
-			return await vectorSearchPooled(embedding, meta, index, dims, topK, {
-				workerCount: VECTOR_POOL_WORKERS,
-				maxPending: VECTOR_POOL_MAX_PENDING,
-			});
-		} catch (err) {
-			const e = err as Error;
-			if (e.message === "VECTOR_POOL_BUSY") {
-				console.warn("[vector-pool] busy — falling back to in-process SIMD");
-			} else {
-				console.warn(
-					`[vector-pool] unavailable (${e.message}) — falling back to SIMD`,
-				);
-			}
-			// fall through to SIMD/JS below
-		}
-	}
-	if (VECTOR_BACKEND !== "js" && simdAvailable()) {
-		return vectorSearchSIMD(embedding, meta, index, dims, topK);
-	}
-	return vectorSearchInMemory(embedding, meta, index, dims, topK);
-}
 
 // ── Config ──
 
@@ -901,12 +859,16 @@ export class RagPipeline {
 		const vidx = await this.getVectorIndex();
 		const vectorResults = vidx
 			? (
-					await selectVectorBackend(
+					await vectorSearchPooled(
 						queryResult.embedding,
 						vidx.meta,
 						vidx.vectors,
 						vidx.dims,
 						RERANK_POOL_SIZE,
+						{
+							workerCount: VECTOR_POOL_WORKERS,
+							maxPending: VECTOR_POOL_MAX_PENDING,
+						},
 					)
 				).filter((r) => r.score >= MIN_SIMILARITY)
 			: [];
@@ -1948,12 +1910,16 @@ export class RagPipeline {
 		const vidx = await this.getVectorIndex();
 		const vectorResults = vidx
 			? (
-					await selectVectorBackend(
+					await vectorSearchPooled(
 						queryResult.embedding,
 						vidx.meta,
 						vidx.vectors,
 						vidx.dims,
 						RERANK_POOL_SIZE,
+						{
+							workerCount: VECTOR_POOL_WORKERS,
+							maxPending: VECTOR_POOL_MAX_PENDING,
+						},
 					)
 				).filter((r) => r.score >= MIN_SIMILARITY)
 			: [];


### PR DESCRIPTION
Follow-up to #31. After validating the worker pool end-to-end (R@5=96.5%, R@10=100%, p50 25s, 2.9× concurrency), the in-process SIMD and JS fallbacks add maintenance cost without operational value:

- in-process SIMD blocks the event loop ~870 ms per query — functionally a pool with N=1
- pure JS at ~50 s per query is a footgun — better to fail boot than serve queries that slow

If pool init fails (missing `.so`, ABI break, OOM), the API does not start and watchtower keeps the previous container running.

`vectorSearchInMemory` and `vectorSearchSIMD` remain exported as parity-test fixtures only — they're no longer on the production code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)