### PR TITLE
Sprint 1: AND adaptive FTS5 + SIMD + worker pool — staging promotion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 # dependencies
 node_modules
 
+# native SIMD shared libs (built per-platform from vector-simd.c)
+packages/api/src/services/rag/vector-simd.*.so
+packages/api/src/services/rag/vector-simd.*.dylib
+
 # output
 out
 dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,11 @@ FROM oven/bun:1-slim
 
 WORKDIR /app
 
-# Git is needed by GitService for diff operations
-RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
+# Git is needed by GitService for diff operations.
+# gcc is needed to compile the SIMD shared library used by the RAG vector
+# search backend. We keep it after the build so on-host rebuilds (e.g.
+# during incident response) work without rebuilding the image.
+RUN apt-get update && apt-get install -y git gcc libc6-dev && rm -rf /var/lib/apt/lists/*
 
 # Copy workspace config + package files for dependency install
 COPY package.json bun.lock ./
@@ -19,6 +22,13 @@ COPY packages/api/ packages/api/
 COPY packages/pipeline/ packages/pipeline/
 COPY packages/shared/ packages/shared/
 COPY tsconfig.json ./
+
+# Build the SIMD shared lib for linux/amd64 (AVX2 + FMA).
+# The RAG vector search loads this via Bun.dlopen at runtime; if missing,
+# pipeline.ts falls back to the JS implementation transparently.
+RUN gcc -O3 -mavx2 -mfma -shared -fPIC \
+    -o packages/api/src/services/rag/vector-simd.linux-amd64.so \
+    packages/api/src/services/rag/vector-simd.c
 
 EXPOSE 3000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,22 @@
+# ── Build stage: compile the SIMD .so so gcc never reaches the runtime image ──
+FROM oven/bun:1-slim AS simd-builder
+
+WORKDIR /build
+
+RUN apt-get update && apt-get install -y --no-install-recommends gcc libc6-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY packages/api/src/services/rag/vector-simd.c .
+RUN gcc -O3 -mavx2 -mfma -shared -fPIC -o vector-simd.linux-amd64.so vector-simd.c
+
+# ── Runtime stage: slim, no compiler toolchain ──
 FROM oven/bun:1-slim
 
 WORKDIR /app
 
 # Git is needed by GitService for diff operations.
-# gcc is needed to compile the SIMD shared library used by the RAG vector
-# search backend. We keep it after the build so on-host rebuilds (e.g.
-# during incident response) work without rebuilding the image.
-RUN apt-get update && apt-get install -y git gcc libc6-dev && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends git \
+    && rm -rf /var/lib/apt/lists/*
 
 # Copy workspace config + package files for dependency install
 COPY package.json bun.lock ./
@@ -23,12 +33,9 @@ COPY packages/pipeline/ packages/pipeline/
 COPY packages/shared/ packages/shared/
 COPY tsconfig.json ./
 
-# Build the SIMD shared lib for linux/amd64 (AVX2 + FMA).
-# The RAG vector search loads this via Bun.dlopen at runtime; if missing,
-# pipeline.ts falls back to the JS implementation transparently.
-RUN gcc -O3 -mavx2 -mfma -shared -fPIC \
-    -o packages/api/src/services/rag/vector-simd.linux-amd64.so \
-    packages/api/src/services/rag/vector-simd.c
+# Pull in just the precompiled SIMD library from the builder stage.
+COPY --from=simd-builder /build/vector-simd.linux-amd64.so \
+     packages/api/src/services/rag/vector-simd.linux-amd64.so
 
 EXPOSE 3000
 

--- a/packages/api/src/__tests__/blocks-fts-adaptive.test.ts
+++ b/packages/api/src/__tests__/blocks-fts-adaptive.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Unit tests for the AND/OR adaptive matcher in bm25ArticleSearch.
+ *
+ * The function should:
+ *   a) Return AND results when they meet AND_FALLBACK_THRESHOLD (=20).
+ *   b) Fall back to OR when AND is too sparse, so recall isn't hurt by
+ *      a hyper-specific token combination.
+ *   c) Run a single match for 1-token queries (AND ≡ OR).
+ *
+ * We seed an in-memory FTS5 table with synthetic blocks so the test
+ * is hermetic.
+ */
+
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { bm25ArticleSearch } from "../services/rag/blocks-fts.ts";
+
+let db: Database;
+
+function seed(blocks: Array<{ id: string; norm: string; content: string }>) {
+	db.exec(`CREATE VIRTUAL TABLE blocks_fts USING fts5(
+		norm_id UNINDEXED,
+		block_id UNINDEXED,
+		title,
+		norm_title,
+		content,
+		tokenize='unicode61 remove_diacritics 2'
+	)`);
+	const stmt = db.prepare(
+		"INSERT INTO blocks_fts (norm_id, block_id, title, norm_title, content) VALUES (?, ?, ?, ?, ?)",
+	);
+	for (const b of blocks) {
+		stmt.run(b.norm, b.id, "", "", b.content);
+	}
+}
+
+beforeEach(() => {
+	db = new Database(":memory:");
+});
+
+afterEach(() => {
+	db.close();
+});
+
+describe("bm25ArticleSearch AND adaptive", () => {
+	test("uses AND when results meet threshold (≥20)", () => {
+		// 25 docs that all contain BOTH "vacaciones" and "trabajador".
+		const blocks = Array.from({ length: 25 }, (_, i) => ({
+			id: `b${i}`,
+			norm: `N${i}`,
+			content: "vacaciones del trabajador asalariado",
+		}));
+		// 30 noise docs that contain only "trabajador" (would inflate OR).
+		for (let i = 0; i < 30; i++) {
+			blocks.push({
+				id: `n${i}`,
+				norm: `M${i}`,
+				content: "trabajador autónomo",
+			});
+		}
+		seed(blocks);
+
+		const results = bm25ArticleSearch(db, "vacaciones trabajador", 50);
+		// AND match yields exactly 25 → should be returned (>=20).
+		expect(results.length).toBe(25);
+	});
+
+	test("falls back to OR when AND is sparse (<20)", () => {
+		// Only 3 docs match AND on both rare terms.
+		const blocks = [
+			{ id: "a1", norm: "N1", content: "criptomoneda blockchain regulada" },
+			{ id: "a2", norm: "N2", content: "criptomoneda blockchain emisor" },
+			{ id: "a3", norm: "N3", content: "criptomoneda blockchain custodia" },
+		];
+		// 50 noise docs with only "blockchain". OR should pick these up.
+		for (let i = 0; i < 50; i++) {
+			blocks.push({
+				id: `n${i}`,
+				norm: `M${i}`,
+				content: "blockchain redes distribuidas",
+			});
+		}
+		seed(blocks);
+
+		const results = bm25ArticleSearch(db, "criptomoneda blockchain", 50);
+		// AND alone would return 3 (<20) → fallback to OR → much more.
+		expect(results.length).toBeGreaterThan(20);
+		// The 3 AND-matching docs are still in there (OR is a superset).
+		const ids = new Set(results.map((r) => r.blockId));
+		expect(ids.has("a1")).toBe(true);
+		expect(ids.has("a2")).toBe(true);
+		expect(ids.has("a3")).toBe(true);
+	});
+
+	test("single-token query bypasses AND/OR branching", () => {
+		const blocks = [
+			{ id: "x1", norm: "N1", content: "salario mínimo interprofesional" },
+			{ id: "x2", norm: "N2", content: "salario base del convenio" },
+			{ id: "x3", norm: "N3", content: "ningún término relevante aquí" },
+		];
+		seed(blocks);
+
+		const results = bm25ArticleSearch(db, "salario", 50);
+		expect(results.length).toBe(2);
+	});
+
+	test("empty query returns []", () => {
+		seed([{ id: "a", norm: "N", content: "foo bar" }]);
+		expect(bm25ArticleSearch(db, "", 50)).toEqual([]);
+		// All tokens filtered out (length <= 2)
+		expect(bm25ArticleSearch(db, "el la de", 50)).toEqual([]);
+	});
+
+	test("respects normFilter on both AND and OR paths", () => {
+		const blocks = Array.from({ length: 30 }, (_, i) => ({
+			id: `b${i}`,
+			norm: i < 10 ? "TARGET" : "OTHER",
+			content: "vacaciones trabajador asalariado",
+		}));
+		seed(blocks);
+
+		const results = bm25ArticleSearch(db, "vacaciones trabajador", 50, [
+			"TARGET",
+		]);
+		expect(results.length).toBe(10);
+		expect(results.every((r) => r.normId === "TARGET")).toBe(true);
+	});
+});

--- a/packages/api/src/__tests__/vector-pool-smoke.test.ts
+++ b/packages/api/src/__tests__/vector-pool-smoke.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Smoke test for the vector worker pool.
+ *
+ * Spawns a small pool against a synthetic in-memory index and verifies:
+ *   - The pool initializes (workers respond ready).
+ *   - Queries dispatched in parallel resolve with correct top-K.
+ *   - Results match vectorSearchInMemory within score epsilon.
+ *
+ * Skipped if the native lib isn't available on the host (e.g. CI matrix
+ * without gcc + AVX2). Parity is the contract; throughput we measure
+ * separately on the production corpus.
+ */
+
+import { afterAll, describe, expect, test } from "bun:test";
+import {
+	type InMemoryVectorIndex,
+	vectorSearchInMemory,
+} from "../services/rag/embeddings.ts";
+import {
+	shutdownVectorPool,
+	vectorSearchPooled,
+} from "../services/rag/vector-pool.ts";
+import { simdAvailable } from "../services/rag/vector-simd.ts";
+
+const N = 512;
+const DIMS = 64;
+const TOP_K = 8;
+const SCORE_EPS = 1e-4;
+
+function makeIndex(seed: number): {
+	meta: Array<{ normId: string; blockId: string }>;
+	index: InMemoryVectorIndex;
+} {
+	let s = seed | 0 || 1;
+	const rnd = () => {
+		s ^= s << 13;
+		s ^= s >>> 17;
+		s ^= s << 5;
+		return ((s | 0) / 0x80000000) * 1.0;
+	};
+
+	const vectors = new Float32Array(N * DIMS);
+	for (let i = 0; i < vectors.length; i++) vectors[i] = rnd();
+
+	const norms = new Float32Array(N);
+	for (let i = 0; i < N; i++) {
+		let sum = 0;
+		const off = i * DIMS;
+		for (let j = 0; j < DIMS; j++) sum += vectors[off + j]! * vectors[off + j]!;
+		norms[i] = Math.sqrt(sum);
+	}
+
+	const meta = Array.from({ length: N }, (_, i) => ({
+		normId: `N${i}`,
+		blockId: `b${i}`,
+	}));
+
+	return {
+		meta,
+		index: {
+			chunks: [vectors],
+			vectorsPerChunk: [N],
+			normsPerChunk: [norms],
+			totalVectors: N,
+		},
+	};
+}
+
+function makeQuery(seed: number): Float32Array {
+	let s = seed | 0 || 7;
+	const q = new Float32Array(DIMS);
+	for (let i = 0; i < DIMS; i++) {
+		s ^= s << 13;
+		s ^= s >>> 17;
+		s ^= s << 5;
+		q[i] = ((s | 0) / 0x80000000) * 1.0;
+	}
+	return q;
+}
+
+afterAll(() => shutdownVectorPool());
+
+describe("vectorSearchPooled smoke", () => {
+	test.skipIf(!simdAvailable())(
+		"matches in-process top-K, supports concurrent queries",
+		async () => {
+			const { meta, index } = makeIndex(0xbeef);
+			const queries = Array.from({ length: 6 }, (_, i) => makeQuery(0x100 + i));
+
+			// Run all 6 in parallel — pool must serialize internally.
+			const pooledAll = await Promise.all(
+				queries.map((q) =>
+					vectorSearchPooled(q, meta, index, DIMS, TOP_K, {
+						workerCount: 2,
+					}),
+				),
+			);
+
+			for (let qi = 0; qi < queries.length; qi++) {
+				const ref = vectorSearchInMemory(
+					queries[qi]!,
+					meta,
+					index,
+					DIMS,
+					TOP_K,
+				);
+				const got = pooledAll[qi]!;
+				expect(got.length).toBe(ref.length);
+				const refKeys = ref.map((r) => `${r.normId}:${r.blockId}`).sort();
+				const gotKeys = got.map((r) => `${r.normId}:${r.blockId}`).sort();
+				expect(gotKeys).toEqual(refKeys);
+				const refScores = new Map(
+					ref.map((r) => [`${r.normId}:${r.blockId}`, r.score] as const),
+				);
+				for (const r of got) {
+					const expected = refScores.get(`${r.normId}:${r.blockId}`)!;
+					expect(Math.abs(r.score - expected)).toBeLessThan(SCORE_EPS);
+				}
+			}
+		},
+		20000,
+	);
+
+	test("simdAvailable() exposes a boolean", () => {
+		expect(typeof simdAvailable()).toBe("boolean");
+	});
+});

--- a/packages/api/src/__tests__/vector-simd-parity.test.ts
+++ b/packages/api/src/__tests__/vector-simd-parity.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Parity test: native SIMD cosine_topk vs JS vectorSearchInMemory.
+ *
+ * Builds a synthetic corpus (small N, modest dim) and asserts that for
+ * a battery of random queries, the native top-K is the same set as the
+ * JS top-K and the scores agree within a tight epsilon (FMA + reduction
+ * order differ from scalar accumulation, so exact equality is too strict).
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+	type InMemoryVectorIndex,
+	vectorSearchInMemory,
+} from "../services/rag/embeddings.ts";
+import {
+	simdAvailable,
+	vectorSearchSIMD,
+} from "../services/rag/vector-simd.ts";
+
+const N = 1024;
+const DIMS = 128;
+const TOP_K = 10;
+const SCORE_EPS = 1e-4;
+
+function makeIndex(seed: number): {
+	meta: Array<{ normId: string; blockId: string }>;
+	index: InMemoryVectorIndex;
+} {
+	// Deterministic PRNG (xorshift32) so failures reproduce.
+	let s = seed | 0 || 1;
+	const rnd = () => {
+		s ^= s << 13;
+		s ^= s >>> 17;
+		s ^= s << 5;
+		// Map to roughly [-1, 1)
+		return ((s | 0) / 0x80000000) * 1.0;
+	};
+
+	const vectors = new Float32Array(N * DIMS);
+	for (let i = 0; i < vectors.length; i++) vectors[i] = rnd();
+
+	const norms = new Float32Array(N);
+	for (let i = 0; i < N; i++) {
+		let sum = 0;
+		const off = i * DIMS;
+		for (let j = 0; j < DIMS; j++) sum += vectors[off + j]! * vectors[off + j]!;
+		norms[i] = Math.sqrt(sum);
+	}
+
+	const meta = Array.from({ length: N }, (_, i) => ({
+		normId: `N${i}`,
+		blockId: `b${i}`,
+	}));
+
+	const index: InMemoryVectorIndex = {
+		chunks: [vectors],
+		vectorsPerChunk: [N],
+		normsPerChunk: [norms],
+		totalVectors: N,
+	};
+	return { meta, index };
+}
+
+function makeQuery(seed: number): Float32Array {
+	let s = seed | 0 || 7;
+	const q = new Float32Array(DIMS);
+	for (let i = 0; i < DIMS; i++) {
+		s ^= s << 13;
+		s ^= s >>> 17;
+		s ^= s << 5;
+		q[i] = ((s | 0) / 0x80000000) * 1.0;
+	}
+	return q;
+}
+
+describe("vectorSearchSIMD parity", () => {
+	test.skipIf(!simdAvailable())(
+		"matches JS top-K set and scores within epsilon",
+		() => {
+			const { meta, index } = makeIndex(0xc0ffee);
+
+			for (let trial = 0; trial < 20; trial++) {
+				const q = makeQuery(0xa11ce + trial);
+				const jsRes = vectorSearchInMemory(q, meta, index, DIMS, TOP_K);
+				const simdRes = vectorSearchSIMD(q, meta, index, DIMS, TOP_K);
+
+				expect(simdRes.length).toBe(jsRes.length);
+
+				const jsKeys = jsRes.map((r) => `${r.normId}:${r.blockId}`).sort();
+				const simdKeys = simdRes.map((r) => `${r.normId}:${r.blockId}`).sort();
+				expect(simdKeys).toEqual(jsKeys);
+
+				// Score-by-key parity within epsilon
+				const jsScores = new Map(
+					jsRes.map((r) => [`${r.normId}:${r.blockId}`, r.score]),
+				);
+				for (const r of simdRes) {
+					const expected = jsScores.get(`${r.normId}:${r.blockId}`)!;
+					expect(Math.abs(r.score - expected)).toBeLessThan(SCORE_EPS);
+				}
+			}
+		},
+	);
+
+	test("simdAvailable() returns boolean", () => {
+		expect(typeof simdAvailable()).toBe("boolean");
+	});
+});

--- a/packages/api/src/services/rag/blocks-fts.ts
+++ b/packages/api/src/services/rag/blocks-fts.ts
@@ -72,7 +72,25 @@ export interface BM25ArticleResult {
 }
 
 /**
+ * Threshold below which an AND-matched query is considered too sparse and
+ * we re-run as OR. Tuned empirically: with K=20 the eval gold set keeps
+ * R@1 ≥ baseline while killing the OR-explosion on generic-token queries
+ * ("días tengo caso") where OR alone took 49s in prod.
+ */
+const AND_FALLBACK_THRESHOLD = 20;
+
+/**
  * Search articles using BM25 via FTS5.
+ *
+ * Adaptive AND/OR: when a query has 2+ tokens we first run a strict AND
+ * match (every token must appear). If that returns ≥ AND_FALLBACK_THRESHOLD
+ * results we keep them — AND is dramatically cheaper for high-frequency
+ * tokens because FTS5 can intersect short postings lists early. If it
+ * returns less, we fall back to OR so that recall is preserved on
+ * questions phrased with rare or domain-specific words.
+ *
+ * The decision is made by the cardinality of the result set, not by
+ * a hardcoded stop-word list — so it adapts to the corpus.
  *
  * @param db - SQLite database
  * @param query - Search query (plain text, will be tokenized)
@@ -85,45 +103,54 @@ export function bm25ArticleSearch(
 	topK: number = 50,
 	normFilter?: string[],
 ): BM25ArticleResult[] {
-	// Sanitize query for FTS5: remove punctuation, wrap tokens in quotes
-	const safeQuery = query
+	// Sanitize query for FTS5: remove punctuation, wrap tokens in quotes.
+	const tokens = query
 		.replace(/[¿?¡!"'()[\]{},.:;]/g, "")
 		.split(/\s+/)
 		.filter((t) => t.length > 2)
 		.slice(0, 12)
-		.map((t) => `"${t}"`)
-		.join(" OR ");
+		.map((t) => `"${t}"`);
 
-	if (!safeQuery) return [];
+	if (tokens.length === 0) return [];
 
 	const normPlaceholders = normFilter?.length
 		? `AND norm_id IN (${normFilter.map(() => "?").join(",")})`
 		: "";
 
-	try {
-		const params: (string | number)[] = [safeQuery];
-		if (normFilter?.length) params.push(...normFilter);
-		params.push(Math.floor(topK));
+	const runMatch = (matchExpr: string): BM25ArticleResult[] => {
+		try {
+			const params: (string | number)[] = [matchExpr];
+			if (normFilter?.length) params.push(...normFilter);
+			params.push(Math.floor(topK));
 
-		const results = db
-			.query<{ norm_id: string; block_id: string }, (string | number)[]>(
-				`SELECT norm_id, block_id
-         FROM blocks_fts
-         WHERE blocks_fts MATCH ?
-           ${normPlaceholders}
-         ORDER BY bm25(blocks_fts, 0, 0, 5.0, 8.0, 1.0)
-         LIMIT ?`,
-			)
-			.all(...params);
+			const results = db
+				.query<{ norm_id: string; block_id: string }, (string | number)[]>(
+					`SELECT norm_id, block_id
+           FROM blocks_fts
+           WHERE blocks_fts MATCH ?
+             ${normPlaceholders}
+           ORDER BY bm25(blocks_fts, 0, 0, 5.0, 8.0, 1.0)
+           LIMIT ?`,
+				)
+				.all(...params);
 
-		return results.map((r, i) => ({
-			normId: r.norm_id,
-			blockId: r.block_id,
-			rank: i + 1,
-		}));
-	} catch {
-		return [];
-	}
+			return results.map((r, i) => ({
+				normId: r.norm_id,
+				blockId: r.block_id,
+				rank: i + 1,
+			}));
+		} catch {
+			return [];
+		}
+	};
+
+	// Single-token: AND ≡ OR, just run it once.
+	if (tokens.length === 1) return runMatch(tokens[0]!);
+
+	// Multi-token: try AND first, fall back to OR if too sparse.
+	const andResults = runMatch(tokens.join(" AND "));
+	if (andResults.length >= AND_FALLBACK_THRESHOLD) return andResults;
+	return runMatch(tokens.join(" OR "));
 }
 
 /**

--- a/packages/api/src/services/rag/blocks-fts.ts
+++ b/packages/api/src/services/rag/blocks-fts.ts
@@ -139,7 +139,17 @@ export function bm25ArticleSearch(
 				blockId: r.block_id,
 				rank: i + 1,
 			}));
-		} catch {
+		} catch (err) {
+			// FTS5 parse errors, schema mismatches and lock contention all
+			// surface here. Returning [] is the right behaviour (the AND
+			// path triggers OR fallback by length<threshold; the OR path
+			// just yields zero candidates and the rest of the RRF systems
+			// carry the load), but a silent swallow makes prod failures
+			// invisible. Log so diagnostics show up in container logs and
+			// Opik traces without breaking retrieval.
+			console.warn(
+				`[bm25] FTS5 query failed for "${matchExpr.slice(0, 80)}": ${(err as Error).message}`,
+			);
 			return [];
 		}
 	};

--- a/packages/api/src/services/rag/embeddings.ts
+++ b/packages/api/src/services/rag/embeddings.ts
@@ -517,13 +517,9 @@ async function loadVectorsToMemory(
 	totalVectors: number,
 	dims: number,
 ): Promise<InMemoryVectorIndex> {
-	// When the worker pool is enabled, allocate chunks as SharedArrayBuffer
-	// directly so they can be referenced by workers without a 5.6 GB copy
-	// at boot. The pool checks the chunk's underlying buffer type and skips
-	// the toShared() copy path when the buffer is already a SAB.
-	const useShared =
-		(process.env.RAG_VECTOR_BACKEND ?? "").toLowerCase() === "pool";
-
+	// Vector chunks are always SAB-backed so the worker pool can reference
+	// them without a 5.6 GB copy at boot. The pool detects the underlying
+	// buffer type and reuses SABs directly in toShared().
 	const vecFile = Bun.file(vecPath);
 	const totalBytes = vecFile.size;
 	const bytesPerVec = dims * 4;
@@ -543,36 +539,24 @@ async function loadVectorsToMemory(
 		const endByte = endVec * bytesPerVec;
 		const wanted = endByte - startByte;
 
-		// Read into an ArrayBuffer first (Bun has a fast path for this) and
-		// then, when the pool needs SAB-backed chunks, memcpy across. Per-
-		// chunk peak is 2× chunk size during the copy, but each ArrayBuffer
-		// becomes garbage immediately and is reclaimed before the next
-		// chunk allocates. Streaming via for-await proved CPU-bound at
-		// ~80x slower in practice — see bench-pool history.
+		// Read into an ArrayBuffer first (Bun's fast path) and then memcpy
+		// into a SAB. Per-chunk peak is 2× chunk size during the copy, but
+		// each ArrayBuffer is reclaimed before the next chunk allocates.
+		// Streaming via for-await proved CPU-bound at ~80x slower in
+		// practice — see bench-pool history.
 		const buf = await vecFile.slice(startByte, endByte).arrayBuffer();
 		if (buf.byteLength < wanted) {
 			throw new Error(
 				`vectors.bin chunk short: expected ${wanted} got ${buf.byteLength}`,
 			);
 		}
-		let vectors: Float32Array;
-		if (useShared) {
-			const sab = new SharedArrayBuffer(wanted);
-			new Uint8Array(sab).set(new Uint8Array(buf, 0, wanted));
-			vectors = new Float32Array(sab);
-		} else {
-			// Bun.file().slice() may return slightly more than requested; trim.
-			const trimmed = buf.byteLength === wanted ? buf : buf.slice(0, wanted);
-			vectors = new Float32Array(trimmed);
-		}
+		const sab = new SharedArrayBuffer(wanted);
+		new Uint8Array(sab).set(new Uint8Array(buf, 0, wanted));
+		const vectors = new Float32Array(sab);
 
-		// Precompute L2 norm per vector — paid once at load, reused per query.
-		// Norms are cheap (~2 MB total) — use SAB-backed too when shared so
-		// workers get them in the init message without a copy step.
-		const normsBytes = numVecs * 4;
-		const norms = useShared
-			? new Float32Array(new SharedArrayBuffer(normsBytes))
-			: new Float32Array(numVecs);
+		// Norms are cheap (~2 MB total) but live in a SAB too so workers
+		// receive them via the init message without a copy step.
+		const norms = new Float32Array(new SharedArrayBuffer(numVecs * 4));
 		for (let i = 0; i < numVecs; i++) {
 			const offset = i * dims;
 			let sum = 0;

--- a/packages/api/src/services/rag/embeddings.ts
+++ b/packages/api/src/services/rag/embeddings.ts
@@ -543,35 +543,24 @@ async function loadVectorsToMemory(
 		const endByte = endVec * bytesPerVec;
 		const wanted = endByte - startByte;
 
+		// Read into an ArrayBuffer first (Bun has a fast path for this) and
+		// then, when the pool needs SAB-backed chunks, memcpy across. Per-
+		// chunk peak is 2× chunk size during the copy, but each ArrayBuffer
+		// becomes garbage immediately and is reclaimed before the next
+		// chunk allocates. Streaming via for-await proved CPU-bound at
+		// ~80x slower in practice — see bench-pool history.
+		const buf = await vecFile.slice(startByte, endByte).arrayBuffer();
+		if (buf.byteLength < wanted) {
+			throw new Error(
+				`vectors.bin chunk short: expected ${wanted} got ${buf.byteLength}`,
+			);
+		}
 		let vectors: Float32Array;
 		if (useShared) {
-			// Stream into a SAB directly to avoid a transient 2nd copy.
 			const sab = new SharedArrayBuffer(wanted);
+			new Uint8Array(sab).set(new Uint8Array(buf, 0, wanted));
 			vectors = new Float32Array(sab);
-			const stream = vecFile.slice(startByte, endByte).stream();
-			let offset = 0;
-			for await (const part of stream) {
-				const u8 = part as Uint8Array;
-				new Uint8Array(sab, offset, u8.byteLength).set(u8);
-				offset += u8.byteLength;
-				if (offset > wanted) {
-					throw new Error(
-						`vectors.bin chunk too long: expected ${wanted} got ${offset}`,
-					);
-				}
-			}
-			if (offset < wanted) {
-				throw new Error(
-					`vectors.bin chunk short: expected ${wanted} got ${offset}`,
-				);
-			}
 		} else {
-			const buf = await vecFile.slice(startByte, endByte).arrayBuffer();
-			if (buf.byteLength < wanted) {
-				throw new Error(
-					`vectors.bin chunk short: expected ${wanted} got ${buf.byteLength}`,
-				);
-			}
 			// Bun.file().slice() may return slightly more than requested; trim.
 			const trimmed = buf.byteLength === wanted ? buf : buf.slice(0, wanted);
 			vectors = new Float32Array(trimmed);

--- a/packages/api/src/services/rag/embeddings.ts
+++ b/packages/api/src/services/rag/embeddings.ts
@@ -517,6 +517,13 @@ async function loadVectorsToMemory(
 	totalVectors: number,
 	dims: number,
 ): Promise<InMemoryVectorIndex> {
+	// When the worker pool is enabled, allocate chunks as SharedArrayBuffer
+	// directly so they can be referenced by workers without a 5.6 GB copy
+	// at boot. The pool checks the chunk's underlying buffer type and skips
+	// the toShared() copy path when the buffer is already a SAB.
+	const useShared =
+		(process.env.RAG_VECTOR_BACKEND ?? "").toLowerCase() === "pool";
+
 	const vecFile = Bun.file(vecPath);
 	const totalBytes = vecFile.size;
 	const bytesPerVec = dims * 4;
@@ -534,18 +541,49 @@ async function loadVectorsToMemory(
 		const numVecs = endVec - startVec;
 		const startByte = startVec * bytesPerVec;
 		const endByte = endVec * bytesPerVec;
-		const buf = await vecFile.slice(startByte, endByte).arrayBuffer();
 		const wanted = endByte - startByte;
-		if (buf.byteLength < wanted) {
-			throw new Error(
-				`vectors.bin chunk short: expected ${wanted} got ${buf.byteLength}`,
-			);
+
+		let vectors: Float32Array;
+		if (useShared) {
+			// Stream into a SAB directly to avoid a transient 2nd copy.
+			const sab = new SharedArrayBuffer(wanted);
+			vectors = new Float32Array(sab);
+			const stream = vecFile.slice(startByte, endByte).stream();
+			let offset = 0;
+			for await (const part of stream) {
+				const u8 = part as Uint8Array;
+				new Uint8Array(sab, offset, u8.byteLength).set(u8);
+				offset += u8.byteLength;
+				if (offset > wanted) {
+					throw new Error(
+						`vectors.bin chunk too long: expected ${wanted} got ${offset}`,
+					);
+				}
+			}
+			if (offset < wanted) {
+				throw new Error(
+					`vectors.bin chunk short: expected ${wanted} got ${offset}`,
+				);
+			}
+		} else {
+			const buf = await vecFile.slice(startByte, endByte).arrayBuffer();
+			if (buf.byteLength < wanted) {
+				throw new Error(
+					`vectors.bin chunk short: expected ${wanted} got ${buf.byteLength}`,
+				);
+			}
+			// Bun.file().slice() may return slightly more than requested; trim.
+			const trimmed = buf.byteLength === wanted ? buf : buf.slice(0, wanted);
+			vectors = new Float32Array(trimmed);
 		}
-		// Bun.file().slice() may return slightly more than requested; trim.
-		const trimmed = buf.byteLength === wanted ? buf : buf.slice(0, wanted);
-		const vectors = new Float32Array(trimmed);
+
 		// Precompute L2 norm per vector — paid once at load, reused per query.
-		const norms = new Float32Array(numVecs);
+		// Norms are cheap (~2 MB total) — use SAB-backed too when shared so
+		// workers get them in the init message without a copy step.
+		const normsBytes = numVecs * 4;
+		const norms = useShared
+			? new Float32Array(new SharedArrayBuffer(normsBytes))
+			: new Float32Array(numVecs);
 		for (let i = 0; i < numVecs; i++) {
 			const offset = i * dims;
 			let sum = 0;

--- a/packages/api/src/services/rag/pipeline.ts
+++ b/packages/api/src/services/rag/pipeline.ts
@@ -13,7 +13,6 @@ import {
 	ensureVectorIndex,
 	getEmbeddedNormIds,
 	getEmbeddingCount,
-	vectorSearchInMemory,
 } from "./embeddings.ts";
 import { JURISDICTION_NAMES, resolveJurisdiction } from "./jurisdiction.ts";
 import { type RerankerCandidate, rerank } from "./reranker.ts";
@@ -30,58 +29,17 @@ import {
 } from "./temporal.ts";
 import { type RagTrace, startTrace } from "./tracing.ts";
 import { vectorSearchPooled } from "./vector-pool.ts";
-// Native SIMD backend (gated by RAG_VECTOR_BACKEND, falls back when unavailable).
-import { simdAvailable, vectorSearchSIMD } from "./vector-simd.ts";
 
 /**
- * RAG_VECTOR_BACKEND selects how the vector top-K is computed:
- *   - "pool"  → SharedArrayBuffer pool of N workers (best for concurrency)
- *   - "simd"  → in-process bun:ffi (single-thread, blocks event loop)
- *   - "js"    → pure JS fallback (safety valve, slow)
- *   - unset   → "simd" by default (Day 2 baseline; Day 3 opts in via env)
+ * Vector pool sizing — env-tunable but the defaults match the prod
+ * KonarServer layout (8 vCPU, 4 workers leave 4 cores for the rest).
+ * If the .so or worker spawn fail, the API will not boot — the orchestrator
+ * (watchtower / docker restart) keeps the previous container running.
  */
-const VECTOR_BACKEND = (process.env.RAG_VECTOR_BACKEND ?? "simd").toLowerCase();
 const VECTOR_POOL_WORKERS = Number(process.env.RAG_VECTOR_POOL_WORKERS ?? "4");
 const VECTOR_POOL_MAX_PENDING = Number(
 	process.env.RAG_VECTOR_POOL_MAX_PENDING ?? "20",
 );
-
-/**
- * Dispatch a vector top-K search to the configured backend, falling back
- * cleanly when a backend can't run (missing native lib, pool busy, etc.).
- * Returns the raw VectorSearchResult[]; the caller still applies
- * MIN_SIMILARITY filtering to keep the existing semantics.
- */
-async function selectVectorBackend(
-	embedding: Float32Array,
-	meta: Array<{ normId: string; blockId: string }>,
-	index: Parameters<typeof vectorSearchSIMD>[2],
-	dims: number,
-	topK: number,
-) {
-	if (VECTOR_BACKEND === "pool") {
-		try {
-			return await vectorSearchPooled(embedding, meta, index, dims, topK, {
-				workerCount: VECTOR_POOL_WORKERS,
-				maxPending: VECTOR_POOL_MAX_PENDING,
-			});
-		} catch (err) {
-			const e = err as Error;
-			if (e.message === "VECTOR_POOL_BUSY") {
-				console.warn("[vector-pool] busy — falling back to in-process SIMD");
-			} else {
-				console.warn(
-					`[vector-pool] unavailable (${e.message}) — falling back to SIMD`,
-				);
-			}
-			// fall through to SIMD/JS below
-		}
-	}
-	if (VECTOR_BACKEND !== "js" && simdAvailable()) {
-		return vectorSearchSIMD(embedding, meta, index, dims, topK);
-	}
-	return vectorSearchInMemory(embedding, meta, index, dims, topK);
-}
 
 // ── Config ──
 
@@ -901,12 +859,16 @@ export class RagPipeline {
 		const vidx = await this.getVectorIndex();
 		const vectorResults = vidx
 			? (
-					await selectVectorBackend(
+					await vectorSearchPooled(
 						queryResult.embedding,
 						vidx.meta,
 						vidx.vectors,
 						vidx.dims,
 						RERANK_POOL_SIZE,
+						{
+							workerCount: VECTOR_POOL_WORKERS,
+							maxPending: VECTOR_POOL_MAX_PENDING,
+						},
 					)
 				).filter((r) => r.score >= MIN_SIMILARITY)
 			: [];
@@ -1948,12 +1910,16 @@ export class RagPipeline {
 		const vidx = await this.getVectorIndex();
 		const vectorResults = vidx
 			? (
-					await selectVectorBackend(
+					await vectorSearchPooled(
 						queryResult.embedding,
 						vidx.meta,
 						vidx.vectors,
 						vidx.dims,
 						RERANK_POOL_SIZE,
+						{
+							workerCount: VECTOR_POOL_WORKERS,
+							maxPending: VECTOR_POOL_MAX_PENDING,
+						},
 					)
 				).filter((r) => r.score >= MIN_SIMILARITY)
 			: [];

--- a/packages/api/src/services/rag/pipeline.ts
+++ b/packages/api/src/services/rag/pipeline.ts
@@ -29,6 +29,8 @@ import {
 	enrichWithTemporalContext,
 } from "./temporal.ts";
 import { type RagTrace, startTrace } from "./tracing.ts";
+// Native SIMD backend (gated by RAG_VECTOR_BACKEND, falls back when unavailable).
+import { simdAvailable, vectorSearchSIMD } from "./vector-simd.ts";
 
 // ── Config ──
 
@@ -846,13 +848,23 @@ export class RagPipeline {
 		// and cached on the instance, so subsequent requests have no disk I/O.
 		const t0 = Date.now();
 		const vidx = await this.getVectorIndex();
+		const useSimd = simdAvailable();
 		const vectorResults = vidx
-			? vectorSearchInMemory(
-					queryResult.embedding,
-					vidx.meta,
-					vidx.vectors,
-					vidx.dims,
-					RERANK_POOL_SIZE,
+			? (useSimd
+					? vectorSearchSIMD(
+							queryResult.embedding,
+							vidx.meta,
+							vidx.vectors,
+							vidx.dims,
+							RERANK_POOL_SIZE,
+						)
+					: vectorSearchInMemory(
+							queryResult.embedding,
+							vidx.meta,
+							vidx.vectors,
+							vidx.dims,
+							RERANK_POOL_SIZE,
+						)
 				).filter((r) => r.score >= MIN_SIMILARITY)
 			: [];
 		const tVector = Date.now() - t0;
@@ -1891,13 +1903,23 @@ export class RagPipeline {
 		});
 		const vectorStart = Date.now();
 		const vidx = await this.getVectorIndex();
+		const useSimd = simdAvailable();
 		const vectorResults = vidx
-			? vectorSearchInMemory(
-					queryResult.embedding,
-					vidx.meta,
-					vidx.vectors,
-					vidx.dims,
-					RERANK_POOL_SIZE,
+			? (useSimd
+					? vectorSearchSIMD(
+							queryResult.embedding,
+							vidx.meta,
+							vidx.vectors,
+							vidx.dims,
+							RERANK_POOL_SIZE,
+						)
+					: vectorSearchInMemory(
+							queryResult.embedding,
+							vidx.meta,
+							vidx.vectors,
+							vidx.dims,
+							RERANK_POOL_SIZE,
+						)
 				).filter((r) => r.score >= MIN_SIMILARITY)
 			: [];
 		const vectorRanked: RankedItem[] = vectorResults.map((r) => ({

--- a/packages/api/src/services/rag/pipeline.ts
+++ b/packages/api/src/services/rag/pipeline.ts
@@ -29,8 +29,59 @@ import {
 	enrichWithTemporalContext,
 } from "./temporal.ts";
 import { type RagTrace, startTrace } from "./tracing.ts";
+import { vectorSearchPooled } from "./vector-pool.ts";
 // Native SIMD backend (gated by RAG_VECTOR_BACKEND, falls back when unavailable).
 import { simdAvailable, vectorSearchSIMD } from "./vector-simd.ts";
+
+/**
+ * RAG_VECTOR_BACKEND selects how the vector top-K is computed:
+ *   - "pool"  → SharedArrayBuffer pool of N workers (best for concurrency)
+ *   - "simd"  → in-process bun:ffi (single-thread, blocks event loop)
+ *   - "js"    → pure JS fallback (safety valve, slow)
+ *   - unset   → "simd" by default (Day 2 baseline; Day 3 opts in via env)
+ */
+const VECTOR_BACKEND = (process.env.RAG_VECTOR_BACKEND ?? "simd").toLowerCase();
+const VECTOR_POOL_WORKERS = Number(process.env.RAG_VECTOR_POOL_WORKERS ?? "4");
+const VECTOR_POOL_MAX_PENDING = Number(
+	process.env.RAG_VECTOR_POOL_MAX_PENDING ?? "20",
+);
+
+/**
+ * Dispatch a vector top-K search to the configured backend, falling back
+ * cleanly when a backend can't run (missing native lib, pool busy, etc.).
+ * Returns the raw VectorSearchResult[]; the caller still applies
+ * MIN_SIMILARITY filtering to keep the existing semantics.
+ */
+async function selectVectorBackend(
+	embedding: Float32Array,
+	meta: Array<{ normId: string; blockId: string }>,
+	index: Parameters<typeof vectorSearchSIMD>[2],
+	dims: number,
+	topK: number,
+) {
+	if (VECTOR_BACKEND === "pool") {
+		try {
+			return await vectorSearchPooled(embedding, meta, index, dims, topK, {
+				workerCount: VECTOR_POOL_WORKERS,
+				maxPending: VECTOR_POOL_MAX_PENDING,
+			});
+		} catch (err) {
+			const e = err as Error;
+			if (e.message === "VECTOR_POOL_BUSY") {
+				console.warn("[vector-pool] busy — falling back to in-process SIMD");
+			} else {
+				console.warn(
+					`[vector-pool] unavailable (${e.message}) — falling back to SIMD`,
+				);
+			}
+			// fall through to SIMD/JS below
+		}
+	}
+	if (VECTOR_BACKEND !== "js" && simdAvailable()) {
+		return vectorSearchSIMD(embedding, meta, index, dims, topK);
+	}
+	return vectorSearchInMemory(embedding, meta, index, dims, topK);
+}
 
 // ── Config ──
 
@@ -848,23 +899,15 @@ export class RagPipeline {
 		// and cached on the instance, so subsequent requests have no disk I/O.
 		const t0 = Date.now();
 		const vidx = await this.getVectorIndex();
-		const useSimd = simdAvailable();
 		const vectorResults = vidx
-			? (useSimd
-					? vectorSearchSIMD(
-							queryResult.embedding,
-							vidx.meta,
-							vidx.vectors,
-							vidx.dims,
-							RERANK_POOL_SIZE,
-						)
-					: vectorSearchInMemory(
-							queryResult.embedding,
-							vidx.meta,
-							vidx.vectors,
-							vidx.dims,
-							RERANK_POOL_SIZE,
-						)
+			? (
+					await selectVectorBackend(
+						queryResult.embedding,
+						vidx.meta,
+						vidx.vectors,
+						vidx.dims,
+						RERANK_POOL_SIZE,
+					)
 				).filter((r) => r.score >= MIN_SIMILARITY)
 			: [];
 		const tVector = Date.now() - t0;
@@ -1903,23 +1946,15 @@ export class RagPipeline {
 		});
 		const vectorStart = Date.now();
 		const vidx = await this.getVectorIndex();
-		const useSimd = simdAvailable();
 		const vectorResults = vidx
-			? (useSimd
-					? vectorSearchSIMD(
-							queryResult.embedding,
-							vidx.meta,
-							vidx.vectors,
-							vidx.dims,
-							RERANK_POOL_SIZE,
-						)
-					: vectorSearchInMemory(
-							queryResult.embedding,
-							vidx.meta,
-							vidx.vectors,
-							vidx.dims,
-							RERANK_POOL_SIZE,
-						)
+			? (
+					await selectVectorBackend(
+						queryResult.embedding,
+						vidx.meta,
+						vidx.vectors,
+						vidx.dims,
+						RERANK_POOL_SIZE,
+					)
 				).filter((r) => r.score >= MIN_SIMILARITY)
 			: [];
 		const vectorRanked: RankedItem[] = vectorResults.map((r) => ({

--- a/packages/api/src/services/rag/vector-pool.ts
+++ b/packages/api/src/services/rag/vector-pool.ts
@@ -44,7 +44,14 @@ interface SharedIndex {
 	totalVectors: number;
 }
 
+/**
+ * Singleton state. We track the in-flight init promise separately so two
+ * concurrent callers race to neither create two pools nor see a half-built
+ * one. If init rejects we clear `initPromise` so the next caller retries
+ * (vs. permanently caching the failed instance).
+ */
 let pool: VectorPool | null = null;
+let initPromise: Promise<VectorPool | null> | null = null;
 
 class VectorPool {
 	private workers: Worker[] = [];
@@ -236,28 +243,55 @@ function defaultLibPath(): string | null {
  * Lazily build the singleton pool. Returns null if pool cannot be
  * created (unsupported platform, missing .so) — callers should fall
  * back to the synchronous in-process path.
+ *
+ * Concurrent callers share the same `initPromise` (no double-init,
+ * no leaked workers). If the first init rejects, `initPromise` is
+ * cleared so a later call gets to try again.
+ *
+ * NOTE: `options` is only honoured on the first call that triggers
+ * init. Later calls receive the existing singleton regardless of the
+ * options they pass — the pool is not reconfigurable at runtime.
  */
 export async function getVectorPool(
 	index: InMemoryVectorIndex,
 	options: { workerCount?: number; maxPending?: number } = {},
 ): Promise<VectorPool | null> {
 	if (pool) return pool;
-	const libPath = defaultLibPath();
-	if (!libPath) return null;
+	if (initPromise) return initPromise;
 
-	const dim = index.chunks[0]
-		? index.chunks[0].length / index.vectorsPerChunk[0]!
-		: 0;
-	if (!dim) return null;
+	initPromise = (async () => {
+		const libPath = defaultLibPath();
+		if (!libPath) return null;
 
-	const shared = toShared(index);
-	pool = new VectorPool(shared, {
-		workerCount: options.workerCount ?? 4,
-		libPath,
-		maxPending: options.maxPending ?? 20,
-	});
-	await pool.ready();
-	return pool;
+		const dim = index.chunks[0]
+			? index.chunks[0].length / index.vectorsPerChunk[0]!
+			: 0;
+		if (!dim) return null;
+
+		const shared = toShared(index);
+		const candidate = new VectorPool(shared, {
+			workerCount: options.workerCount ?? 4,
+			libPath,
+			maxPending: options.maxPending ?? 20,
+		});
+		try {
+			await candidate.ready();
+		} catch (err) {
+			candidate.terminate();
+			throw err;
+		}
+		pool = candidate;
+		return pool;
+	})();
+
+	try {
+		return await initPromise;
+	} catch (err) {
+		// Clear so the next caller can retry (e.g. .so was missing at boot
+		// but now exists after a reload).
+		initPromise = null;
+		throw err;
+	}
 }
 
 export async function vectorSearchPooled(
@@ -291,6 +325,7 @@ export async function vectorSearchPooled(
 export function shutdownVectorPool() {
 	pool?.terminate();
 	pool = null;
+	initPromise = null;
 }
 
 export type { VectorPool };

--- a/packages/api/src/services/rag/vector-pool.ts
+++ b/packages/api/src/services/rag/vector-pool.ts
@@ -183,14 +183,25 @@ function toShared(index: InMemoryVectorIndex): SharedIndex {
 	const sharedNorms: SharedArrayBuffer[] = [];
 	for (let c = 0; c < index.chunks.length; c++) {
 		const v = index.chunks[c]!;
-		const sab = new SharedArrayBuffer(v.byteLength);
-		new Float32Array(sab).set(v);
-		sharedChunks.push(sab);
+		// If embeddings.ts allocated the chunk on a SharedArrayBuffer
+		// (RAG_VECTOR_BACKEND=pool path), reuse it. Otherwise copy once —
+		// peak memory during init temporarily doubles, ~5.6 GB extra on prod.
+		if (v.buffer instanceof SharedArrayBuffer) {
+			sharedChunks.push(v.buffer);
+		} else {
+			const sab = new SharedArrayBuffer(v.byteLength);
+			new Float32Array(sab).set(v);
+			sharedChunks.push(sab);
+		}
 
 		const n = index.normsPerChunk[c]!;
-		const sabN = new SharedArrayBuffer(n.byteLength);
-		new Float32Array(sabN).set(n);
-		sharedNorms.push(sabN);
+		if (n.buffer instanceof SharedArrayBuffer) {
+			sharedNorms.push(n.buffer);
+		} else {
+			const sabN = new SharedArrayBuffer(n.byteLength);
+			new Float32Array(sabN).set(n);
+			sharedNorms.push(sabN);
+		}
 	}
 	return {
 		sharedChunks,

--- a/packages/api/src/services/rag/vector-pool.ts
+++ b/packages/api/src/services/rag/vector-pool.ts
@@ -1,0 +1,285 @@
+/**
+ * Vector worker pool — owns N Bun Workers that share a single in-memory
+ * vector index via SharedArrayBuffer.
+ *
+ *   main thread                          workers
+ *   ┌────────────┐    init (SAB refs)    ┌──────────────┐
+ *   │ pool       │ ────────────────────▶ │ vector-worker│  N copies
+ *   │  queue     │                       │  + simd.so   │
+ *   │  promises  │ ◀─── result(id, k) ── │              │
+ *   └────────────┘    query(id, q, K)    └──────────────┘
+ *
+ * Each query is dispatched round-robin to an idle worker; if all are
+ * busy, the request is queued (FIFO) up to MAX_PENDING. Beyond that we
+ * reject so the API layer can return 503 Busy instead of memory-bombing
+ * under sustained load.
+ *
+ * Memory: vectors.bin (~5.6 GB) lives once in SABs allocated by the
+ * pool's create() and viewed read-only by every worker. Per-worker
+ * heap is small (the .so handle, the message buffers, no JS-side
+ * vector storage).
+ */
+
+import { join } from "node:path";
+import type { InMemoryVectorIndex, VectorSearchResult } from "./embeddings.ts";
+
+interface PoolConfig {
+	workerCount: number;
+	libPath: string;
+	maxPending: number;
+}
+
+interface Pending {
+	resolve: (r: Array<{ globalIdx: number; score: number }>) => void;
+	reject: (e: Error) => void;
+	query: Float32Array;
+	topK: number;
+}
+
+interface SharedIndex {
+	sharedChunks: SharedArrayBuffer[];
+	sharedNorms: SharedArrayBuffer[];
+	vectorsPerChunk: number[];
+	dim: number;
+	totalVectors: number;
+}
+
+let pool: VectorPool | null = null;
+
+class VectorPool {
+	private workers: Worker[] = [];
+	private idle: Worker[] = [];
+	private workerReady = new Set<Worker>();
+	private pending = new Map<number, Pending>();
+	private queue: number[] = [];
+	private nextId = 1;
+	private readonly maxPending: number;
+	private initPromise: Promise<void>;
+
+	constructor(
+		private readonly shared: SharedIndex,
+		config: PoolConfig,
+	) {
+		this.maxPending = config.maxPending;
+		const workerUrl = new URL("./vector-worker.ts", import.meta.url);
+
+		const readyPromises: Promise<void>[] = [];
+		for (let i = 0; i < config.workerCount; i++) {
+			const w = new Worker(workerUrl);
+			this.workers.push(w);
+
+			const ready = new Promise<void>((resolve, reject) => {
+				const onMsg = (e: MessageEvent) => {
+					const msg = e.data;
+					if (msg?.type === "ready") {
+						this.workerReady.add(w);
+						this.idle.push(w);
+						w.removeEventListener("message", onMsg);
+						w.addEventListener("message", (ev) => this.onWorkerMessage(w, ev));
+						resolve();
+					} else if (msg?.type === "error") {
+						reject(new Error(msg.message));
+					}
+				};
+				w.addEventListener("message", onMsg);
+				w.addEventListener("error", (e) => reject(new Error(String(e))));
+			});
+			readyPromises.push(ready);
+
+			w.postMessage({
+				type: "init",
+				sharedChunks: this.shared.sharedChunks,
+				sharedNorms: this.shared.sharedNorms,
+				vectorsPerChunk: this.shared.vectorsPerChunk,
+				dim: this.shared.dim,
+				libPath: config.libPath,
+			});
+		}
+
+		this.initPromise = Promise.all(readyPromises).then(() => {
+			console.log(
+				`[vector-pool] ${this.workers.length} workers ready (shared index: ${this.shared.totalVectors} vectors, ${this.shared.sharedChunks.length} chunks)`,
+			);
+		});
+	}
+
+	async ready(): Promise<void> {
+		await this.initPromise;
+	}
+
+	private onWorkerMessage(worker: Worker, event: MessageEvent) {
+		const msg = event.data;
+		if (msg?.type === "result") {
+			const p = this.pending.get(msg.id);
+			if (p) {
+				this.pending.delete(msg.id);
+				p.resolve(msg.results);
+			}
+		} else if (msg?.type === "error") {
+			const p = this.pending.get(msg.id);
+			if (p) {
+				this.pending.delete(msg.id);
+				p.reject(new Error(msg.message ?? "worker error"));
+			}
+		}
+		// Worker is now idle; pick up the next queued job if any.
+		this.idle.push(worker);
+		this.drain();
+	}
+
+	private drain() {
+		while (this.idle.length > 0 && this.queue.length > 0) {
+			const id = this.queue.shift()!;
+			const p = this.pending.get(id);
+			if (!p) continue;
+			const w = this.idle.shift()!;
+			w.postMessage({
+				type: "query",
+				id,
+				query: p.query,
+				topK: p.topK,
+			});
+		}
+	}
+
+	search(
+		query: Float32Array,
+		topK: number,
+	): Promise<Array<{ globalIdx: number; score: number }>> {
+		if (this.pending.size >= this.maxPending) {
+			return Promise.reject(new Error("VECTOR_POOL_BUSY"));
+		}
+		const id = this.nextId++;
+		return new Promise((resolve, reject) => {
+			this.pending.set(id, { resolve, reject, query, topK });
+			this.queue.push(id);
+			this.drain();
+		});
+	}
+
+	terminate() {
+		for (const w of this.workers) w.terminate();
+		this.workers = [];
+		this.idle = [];
+		this.workerReady.clear();
+		for (const p of this.pending.values())
+			p.reject(new Error("pool terminated"));
+		this.pending.clear();
+		this.queue = [];
+	}
+}
+
+/**
+ * Build a SharedArrayBuffer-backed view of an existing in-memory vector
+ * index by *copying* each chunk into a SAB. We accept the one-time copy
+ * cost (~5.6 GB) at boot; afterwards the SAB is the source of truth and
+ * the original ArrayBuffer is dropped.
+ *
+ * If we ever rebuild loadVectorsToMemory() to allocate SABs directly,
+ * this copy disappears.
+ */
+function toShared(index: InMemoryVectorIndex): SharedIndex {
+	const sharedChunks: SharedArrayBuffer[] = [];
+	const sharedNorms: SharedArrayBuffer[] = [];
+	for (let c = 0; c < index.chunks.length; c++) {
+		const v = index.chunks[c]!;
+		const sab = new SharedArrayBuffer(v.byteLength);
+		new Float32Array(sab).set(v);
+		sharedChunks.push(sab);
+
+		const n = index.normsPerChunk[c]!;
+		const sabN = new SharedArrayBuffer(n.byteLength);
+		new Float32Array(sabN).set(n);
+		sharedNorms.push(sabN);
+	}
+	return {
+		sharedChunks,
+		sharedNorms,
+		vectorsPerChunk: [...index.vectorsPerChunk],
+		dim: index.chunks[0]
+			? index.chunks[0].length / index.vectorsPerChunk[0]!
+			: 0,
+		totalVectors: index.totalVectors,
+	};
+}
+
+/**
+ * Look up the platform-specific shared library path next to this file.
+ */
+function defaultLibPath(): string | null {
+	const platform = process.platform;
+	const arch = process.arch;
+	if (platform === "linux" && arch === "x64") {
+		return join(import.meta.dir, "vector-simd.linux-amd64.so");
+	}
+	if (platform === "darwin" && arch === "arm64") {
+		return join(import.meta.dir, "vector-simd.darwin-arm64.dylib");
+	}
+	if (platform === "darwin" && arch === "x64") {
+		return join(import.meta.dir, "vector-simd.darwin-amd64.dylib");
+	}
+	return null;
+}
+
+/**
+ * Lazily build the singleton pool. Returns null if pool cannot be
+ * created (unsupported platform, missing .so) — callers should fall
+ * back to the synchronous in-process path.
+ */
+export async function getVectorPool(
+	index: InMemoryVectorIndex,
+	options: { workerCount?: number; maxPending?: number } = {},
+): Promise<VectorPool | null> {
+	if (pool) return pool;
+	const libPath = defaultLibPath();
+	if (!libPath) return null;
+
+	const dim = index.chunks[0]
+		? index.chunks[0].length / index.vectorsPerChunk[0]!
+		: 0;
+	if (!dim) return null;
+
+	const shared = toShared(index);
+	pool = new VectorPool(shared, {
+		workerCount: options.workerCount ?? 4,
+		libPath,
+		maxPending: options.maxPending ?? 20,
+	});
+	await pool.ready();
+	return pool;
+}
+
+export async function vectorSearchPooled(
+	queryEmbedding: Float32Array,
+	meta: Array<{ normId: string; blockId: string }>,
+	index: InMemoryVectorIndex,
+	dims: number,
+	topK: number = 10,
+	options: { workerCount?: number; maxPending?: number } = {},
+): Promise<VectorSearchResult[]> {
+	const p = await getVectorPool(index, options);
+	if (!p) {
+		throw new Error("vector pool unavailable on this platform");
+	}
+	const t0 = performance.now();
+	const raw = await p.search(queryEmbedding, topK);
+	const totalMs = performance.now() - t0;
+	console.log(
+		`[vector-search-pool] ${index.totalVectors} vectors → top-${raw.length} in ${totalMs.toFixed(0)}ms`,
+	);
+	return raw.slice(0, topK).map((r) => {
+		const article = meta[r.globalIdx]!;
+		return {
+			normId: article.normId,
+			blockId: article.blockId,
+			score: r.score,
+		};
+	});
+}
+
+export function shutdownVectorPool() {
+	pool?.terminate();
+	pool = null;
+}
+
+export type { VectorPool };

--- a/packages/api/src/services/rag/vector-simd.c
+++ b/packages/api/src/services/rag/vector-simd.c
@@ -1,0 +1,182 @@
+/*
+ * SIMD brute-force cosine top-K for the RAG vector index.
+ *
+ * One exported function:
+ *   cosine_topk(query, query_norm, vectors, doc_norms, n_docs, dim,
+ *               top_k, out_indices, out_scores)
+ *
+ * - `query`          : float32[dim]
+ * - `query_norm`     : precomputed L2 norm of the query (host computes once)
+ * - `vectors`        : float32[n_docs * dim]  flat row-major
+ * - `doc_norms`      : float32[n_docs] precomputed L2 norms
+ * - `n_docs`, `dim`  : sizes
+ * - `top_k`          : how many to return (out arrays must be sized for top_k)
+ * - `out_indices`    : int32[top_k]   filled with selected document indices
+ * - `out_scores`     : float32[top_k] filled with cosine scores
+ *
+ * Returns the actual number of results written (= min(top_k, n_docs)).
+ *
+ * The implementation:
+ *   - Computes dot products with AVX2 (`__m256` + `_mm256_fmadd_ps`).
+ *     `dim` is 3072 in production = 384 lanes of 8 floats, no tail.
+ *     We still write the tail loop to be safe for other dims (e.g. tests).
+ *   - Maintains a min-heap of (score, index) of size `top_k`. The heap
+ *     is keyed on score; the smallest score sits at slot 0 so we can
+ *     reject without doing the full FMA chain when a document can't
+ *     beat the current floor.
+ *   - The per-vector floor check happens AFTER computing the dot
+ *     product (since we don't have an upper bound for cosine without
+ *     extra info). It still saves the heap update on most documents.
+ *
+ * Build:
+ *   linux/amd64:  gcc -O3 -mavx2 -mfma -shared -fPIC -o vector-simd.linux-amd64.so vector-simd.c
+ *   darwin/arm64: clang -O3 -shared -fPIC -arch arm64 -o vector-simd.darwin-arm64.dylib vector-simd.c
+ *
+ * On arm64 we fall back to a plain scalar loop for now. AVX2 isn't
+ * available; NEON could be added later but dev correctness is what
+ * darwin builds need, and dev corpora are small.
+ */
+
+#include <stdint.h>
+#include <stddef.h>
+#include <math.h>
+
+#if defined(__AVX2__) && defined(__FMA__)
+#include <immintrin.h>
+#define HAVE_AVX2_FMA 1
+#else
+#define HAVE_AVX2_FMA 0
+#endif
+
+/* ---------- dot product ---------- */
+
+static inline float dot_product(const float* a, const float* b, size_t dim) {
+#if HAVE_AVX2_FMA
+    __m256 acc0 = _mm256_setzero_ps();
+    __m256 acc1 = _mm256_setzero_ps();
+    size_t i = 0;
+    /* Two-way unrolled accumulator helps hide FMA latency. */
+    for (; i + 16 <= dim; i += 16) {
+        __m256 va0 = _mm256_loadu_ps(a + i);
+        __m256 vb0 = _mm256_loadu_ps(b + i);
+        acc0 = _mm256_fmadd_ps(va0, vb0, acc0);
+        __m256 va1 = _mm256_loadu_ps(a + i + 8);
+        __m256 vb1 = _mm256_loadu_ps(b + i + 8);
+        acc1 = _mm256_fmadd_ps(va1, vb1, acc1);
+    }
+    for (; i + 8 <= dim; i += 8) {
+        __m256 va = _mm256_loadu_ps(a + i);
+        __m256 vb = _mm256_loadu_ps(b + i);
+        acc0 = _mm256_fmadd_ps(va, vb, acc0);
+    }
+    __m256 acc = _mm256_add_ps(acc0, acc1);
+    /* Horizontal sum of the 8 lanes. */
+    __m128 lo = _mm256_castps256_ps128(acc);
+    __m128 hi = _mm256_extractf128_ps(acc, 1);
+    __m128 s = _mm_add_ps(lo, hi);
+    s = _mm_hadd_ps(s, s);
+    s = _mm_hadd_ps(s, s);
+    float total = _mm_cvtss_f32(s);
+    /* Tail (dims not divisible by 8). */
+    for (; i < dim; i++) total += a[i] * b[i];
+    return total;
+#else
+    float total = 0.0f;
+    for (size_t i = 0; i < dim; i++) total += a[i] * b[i];
+    return total;
+#endif
+}
+
+/* ---------- min-heap of size top_k ---------- *
+ *
+ * Slot 0 holds the *smallest* score so far. When we have a new candidate
+ * with score > heap[0].score, we replace slot 0 and sift-down.
+ */
+
+typedef struct { float score; int32_t index; } HeapItem;
+
+static inline void heap_sift_down(HeapItem* h, int32_t n, int32_t start) {
+    int32_t i = start;
+    for (;;) {
+        int32_t l = 2 * i + 1;
+        int32_t r = 2 * i + 2;
+        int32_t smallest = i;
+        if (l < n && h[l].score < h[smallest].score) smallest = l;
+        if (r < n && h[r].score < h[smallest].score) smallest = r;
+        if (smallest == i) break;
+        HeapItem tmp = h[i]; h[i] = h[smallest]; h[smallest] = tmp;
+        i = smallest;
+    }
+}
+
+static inline void heap_sift_up(HeapItem* h, int32_t start) {
+    int32_t i = start;
+    while (i > 0) {
+        int32_t parent = (i - 1) / 2;
+        if (h[parent].score <= h[i].score) break;
+        HeapItem tmp = h[i]; h[i] = h[parent]; h[parent] = tmp;
+        i = parent;
+    }
+}
+
+/* ---------- exported function ---------- */
+
+int32_t cosine_topk(
+    const float* query,
+    float        query_norm,
+    const float* vectors,
+    const float* doc_norms,
+    int32_t      n_docs,
+    int32_t      dim,
+    int32_t      top_k,
+    int32_t*     out_indices,
+    float*       out_scores
+) {
+    if (n_docs <= 0 || top_k <= 0 || query_norm == 0.0f) return 0;
+    if (top_k > n_docs) top_k = n_docs;
+
+    /* Use a static-sized stack heap up to 4096; for larger top_k, host
+     * is expected to keep top_k modest (rerank pool ~80). */
+    HeapItem heap[4096];
+    if (top_k > (int32_t)(sizeof(heap)/sizeof(heap[0]))) {
+        top_k = (int32_t)(sizeof(heap)/sizeof(heap[0]));
+    }
+    int32_t heap_size = 0;
+    float floor_score = -INFINITY;
+
+    for (int32_t i = 0; i < n_docs; i++) {
+        const float* doc = vectors + (size_t)i * (size_t)dim;
+        float dn = doc_norms[i];
+        if (dn == 0.0f) continue;
+
+        float dot = dot_product(query, doc, dim);
+        float score = dot / (query_norm * dn);
+
+        if (heap_size < top_k) {
+            heap[heap_size].score = score;
+            heap[heap_size].index = i;
+            heap_size++;
+            heap_sift_up(heap, heap_size - 1);
+            if (heap_size == top_k) floor_score = heap[0].score;
+        } else if (score > floor_score) {
+            heap[0].score = score;
+            heap[0].index = i;
+            heap_sift_down(heap, top_k, 0);
+            floor_score = heap[0].score;
+        }
+    }
+
+    /* Heap-sort: extract min repeatedly into the *end* of the array,
+     * then reverse — output is descending by score. */
+    int32_t n = heap_size;
+    for (int32_t end = n - 1; end > 0; end--) {
+        HeapItem tmp = heap[0]; heap[0] = heap[end]; heap[end] = tmp;
+        heap_sift_down(heap, end, 0);
+    }
+    /* Now heap[0..n-1] is ascending by score; copy reversed. */
+    for (int32_t i = 0; i < n; i++) {
+        out_scores[i]  = heap[n - 1 - i].score;
+        out_indices[i] = heap[n - 1 - i].index;
+    }
+    return n;
+}

--- a/packages/api/src/services/rag/vector-simd.c
+++ b/packages/api/src/services/rag/vector-simd.c
@@ -166,14 +166,20 @@ int32_t cosine_topk(
         }
     }
 
-    /* Heap-sort: extract min repeatedly into the *end* of the array,
-     * then reverse — output is descending by score. */
+    /* Heap-sort using a min-heap: repeatedly swap heap[0] (the smallest
+     * remaining score) into the *end* of the live region, then sift
+     * down. After the loop heap[0..n-1] is *descending* by score
+     * (largest at index 0, smallest at index n-1). The copy below
+     * reverses that, so the output arrays end up *ascending*. JS callers
+     * re-sort descending themselves; we don't rely on either ordering
+     * downstream, but the comments here matter for anyone adding a new
+     * caller that skips the re-sort. */
     int32_t n = heap_size;
     for (int32_t end = n - 1; end > 0; end--) {
         HeapItem tmp = heap[0]; heap[0] = heap[end]; heap[end] = tmp;
         heap_sift_down(heap, end, 0);
     }
-    /* Now heap[0..n-1] is ascending by score; copy reversed. */
+    /* heap[0..n-1] is descending; copying via heap[n-1-i] yields ascending. */
     for (int32_t i = 0; i < n; i++) {
         out_scores[i]  = heap[n - 1 - i].score;
         out_indices[i] = heap[n - 1 - i].index;

--- a/packages/api/src/services/rag/vector-simd.ts
+++ b/packages/api/src/services/rag/vector-simd.ts
@@ -1,0 +1,208 @@
+/**
+ * Native SIMD brute-force cosine top-K search via Bun.dlopen.
+ *
+ * Loads the platform-appropriate shared library compiled from
+ * `vector-simd.c` and exposes a single function `vectorSearchSIMD`
+ * that mirrors the contract of `vectorSearchInMemory` (in
+ * embeddings.ts) but pushes the inner loops to AVX2+FMA on Linux/x86_64.
+ *
+ * Behavior contract — for the same inputs, the top-K returned by
+ * `vectorSearchSIMD` is the same set as `vectorSearchInMemory` up to
+ * ties broken by index order. Scores match within ~1e-5 absolute
+ * (different reduction order between scalar JS and FMA).
+ *
+ * Selection of backend at runtime:
+ *   - process.env.RAG_VECTOR_BACKEND === "js"   → never load native
+ *   - "simd" or unset → try native; fall back to JS if dylib missing
+ */
+
+import { dlopen, FFIType, ptr, suffix } from "bun:ffi";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import type { InMemoryVectorIndex, VectorSearchResult } from "./embeddings.ts";
+
+const BACKEND_ENV = (process.env.RAG_VECTOR_BACKEND ?? "simd").toLowerCase();
+
+interface NativeBindings {
+	cosine_topk: (
+		query: Uint8Array | NodeJS.TypedArray,
+		queryNorm: number,
+		vectors: Uint8Array | NodeJS.TypedArray,
+		docNorms: Uint8Array | NodeJS.TypedArray,
+		nDocs: number,
+		dim: number,
+		topK: number,
+		outIndices: Uint8Array | NodeJS.TypedArray,
+		outScores: Uint8Array | NodeJS.TypedArray,
+	) => number;
+}
+
+let cached: NativeBindings | null | undefined;
+
+function platformLibName(): string | null {
+	const platform = process.platform;
+	const arch = process.arch;
+	if (platform === "linux" && arch === "x64") {
+		return `vector-simd.linux-amd64.${suffix}`;
+	}
+	if (platform === "darwin" && arch === "arm64") {
+		return `vector-simd.darwin-arm64.${suffix}`;
+	}
+	if (platform === "darwin" && arch === "x64") {
+		return `vector-simd.darwin-amd64.${suffix}`;
+	}
+	return null;
+}
+
+function loadNative(): NativeBindings | null {
+	if (cached !== undefined) return cached;
+	if (BACKEND_ENV === "js") {
+		cached = null;
+		return null;
+	}
+	const libName = platformLibName();
+	if (!libName) {
+		cached = null;
+		return null;
+	}
+	const libPath = join(import.meta.dir, libName);
+	if (!existsSync(libPath)) {
+		console.warn(
+			`[vector-simd] native lib missing at ${libPath} — falling back to JS`,
+		);
+		cached = null;
+		return null;
+	}
+	try {
+		const { symbols } = dlopen(libPath, {
+			cosine_topk: {
+				args: [
+					FFIType.ptr, // const float* query
+					FFIType.f32, // float query_norm
+					FFIType.ptr, // const float* vectors
+					FFIType.ptr, // const float* doc_norms
+					FFIType.i32, // int32 n_docs
+					FFIType.i32, // int32 dim
+					FFIType.i32, // int32 top_k
+					FFIType.ptr, // int32* out_indices
+					FFIType.ptr, // float* out_scores
+				],
+				returns: FFIType.i32,
+			},
+		});
+		cached = {
+			cosine_topk: (q, qn, v, dn, n, d, k, oi, os) =>
+				symbols.cosine_topk(
+					ptr(q as NodeJS.TypedArray),
+					qn,
+					ptr(v as NodeJS.TypedArray),
+					ptr(dn as NodeJS.TypedArray),
+					n,
+					d,
+					k,
+					ptr(oi as NodeJS.TypedArray),
+					ptr(os as NodeJS.TypedArray),
+				),
+		};
+		return cached;
+	} catch (err) {
+		console.warn(
+			`[vector-simd] dlopen failed (${(err as Error).message}) — JS fallback`,
+		);
+		cached = null;
+		return null;
+	}
+}
+
+/**
+ * Returns true iff the native backend is available and selected.
+ * Handlers can use this to decide whether to call vectorSearchSIMD()
+ * or stay on vectorSearchInMemory().
+ */
+export function simdAvailable(): boolean {
+	return loadNative() !== null;
+}
+
+/**
+ * Native SIMD vector search.
+ *
+ * The vector index is split into chunks (Float32Array up to ~2.5GB each)
+ * because Bun's ArrayBuffer cap is ~4GB and our prod corpus is ~6GB. We
+ * call the native function once per chunk and merge top-K across chunks
+ * with a tiny final selection in JS — cost is negligible for K≤200.
+ */
+export function vectorSearchSIMD(
+	queryEmbedding: Float32Array,
+	meta: Array<{ normId: string; blockId: string }>,
+	index: InMemoryVectorIndex,
+	dims: number,
+	topK: number = 10,
+): VectorSearchResult[] {
+	const native = loadNative();
+	if (!native) {
+		throw new Error(
+			"vectorSearchSIMD called but native backend is unavailable",
+		);
+	}
+
+	// Precompute query norm.
+	let queryNorm = 0;
+	for (let i = 0; i < dims; i++) {
+		const v = queryEmbedding[i] ?? 0;
+		queryNorm += v * v;
+	}
+	queryNorm = Math.sqrt(queryNorm);
+	if (queryNorm === 0) return [];
+
+	const t0 = performance.now();
+	const merged: Array<{ globalIdx: number; score: number }> = [];
+	let globalOffset = 0;
+
+	for (let c = 0; c < index.chunks.length; c++) {
+		const vectors = index.chunks[c]!;
+		const norms = index.normsPerChunk[c]!;
+		const numVecs = index.vectorsPerChunk[c]!;
+		if (numVecs === 0) continue;
+
+		const k = Math.min(topK, numVecs);
+		const outIndices = new Int32Array(k);
+		const outScores = new Float32Array(k);
+
+		const written = native.cosine_topk(
+			queryEmbedding,
+			queryNorm,
+			vectors,
+			norms,
+			numVecs,
+			dims,
+			k,
+			outIndices,
+			outScores,
+		);
+
+		for (let i = 0; i < written; i++) {
+			merged.push({
+				globalIdx: globalOffset + outIndices[i]!,
+				score: outScores[i]!,
+			});
+		}
+		globalOffset += numVecs;
+	}
+
+	// Final selection across chunks.
+	merged.sort((a, b) => b.score - a.score);
+	const results = merged.slice(0, topK).map((m) => {
+		const article = meta[m.globalIdx]!;
+		return {
+			normId: article.normId,
+			blockId: article.blockId,
+			score: m.score,
+		} satisfies VectorSearchResult;
+	});
+
+	const totalMs = performance.now() - t0;
+	console.log(
+		`[vector-search-simd] ${index.totalVectors} vectors, ${index.chunks.length} chunks, ${totalMs.toFixed(0)}ms`,
+	);
+	return results;
+}

--- a/packages/api/src/services/rag/vector-worker.ts
+++ b/packages/api/src/services/rag/vector-worker.ts
@@ -64,32 +64,42 @@ self.onmessage = (event: MessageEvent) => {
 	const msg = event.data as InMessage;
 
 	if (msg.type === "init") {
-		const chunks = msg.sharedChunks.map((sab) => new Float32Array(sab));
-		const norms = msg.sharedNorms.map((sab) => new Float32Array(sab));
-		const lib = dlopen(msg.libPath, {
-			cosine_topk: {
-				args: [
-					FFIType.ptr,
-					FFIType.f32,
-					FFIType.ptr,
-					FFIType.ptr,
-					FFIType.i32,
-					FFIType.i32,
-					FFIType.i32,
-					FFIType.ptr,
-					FFIType.ptr,
-				],
-				returns: FFIType.i32,
-			},
-		});
-		state = {
-			chunks,
-			norms,
-			vpc: msg.vectorsPerChunk,
-			dim: msg.dim,
-			cosine_topk: lib.symbols.cosine_topk as unknown as CosineTopk,
-		};
-		self.postMessage({ type: "ready" });
+		// Init failures (missing .so, wrong ABI, SAB constructor surprises)
+		// must reach the pool as an `error` message — otherwise the pool's
+		// `ready` promise would never settle and the worker slot would leak.
+		try {
+			const chunks = msg.sharedChunks.map((sab) => new Float32Array(sab));
+			const norms = msg.sharedNorms.map((sab) => new Float32Array(sab));
+			const lib = dlopen(msg.libPath, {
+				cosine_topk: {
+					args: [
+						FFIType.ptr,
+						FFIType.f32,
+						FFIType.ptr,
+						FFIType.ptr,
+						FFIType.i32,
+						FFIType.i32,
+						FFIType.i32,
+						FFIType.ptr,
+						FFIType.ptr,
+					],
+					returns: FFIType.i32,
+				},
+			});
+			state = {
+				chunks,
+				norms,
+				vpc: msg.vectorsPerChunk,
+				dim: msg.dim,
+				cosine_topk: lib.symbols.cosine_topk as unknown as CosineTopk,
+			};
+			self.postMessage({ type: "ready" });
+		} catch (err) {
+			self.postMessage({
+				type: "error",
+				message: `worker init failed: ${(err as Error).message}`,
+			});
+		}
 		return;
 	}
 
@@ -103,48 +113,60 @@ self.onmessage = (event: MessageEvent) => {
 			return;
 		}
 
-		// Precompute query norm.
-		let qNorm = 0;
-		const q = msg.query;
-		for (let i = 0; i < state.dim; i++) qNorm += q[i]! * q[i]!;
-		qNorm = Math.sqrt(qNorm);
+		// Any throw inside the SIMD path or its prologue must come back as
+		// an `error` reply tagged with the request id. Otherwise the
+		// pending Promise on the main thread hangs forever and the pool
+		// permanently loses one worker slot.
+		try {
+			// Precompute query norm.
+			let qNorm = 0;
+			const q = msg.query;
+			for (let i = 0; i < state.dim; i++) qNorm += q[i]! * q[i]!;
+			qNorm = Math.sqrt(qNorm);
 
-		const merged: Array<{ globalIdx: number; score: number }> = [];
-		let globalOffset = 0;
+			const merged: Array<{ globalIdx: number; score: number }> = [];
+			let globalOffset = 0;
 
-		for (let c = 0; c < state.chunks.length; c++) {
-			const vectors = state.chunks[c]!;
-			const norms = state.norms[c]!;
-			const numVecs = state.vpc[c]!;
-			if (numVecs === 0) continue;
+			for (let c = 0; c < state.chunks.length; c++) {
+				const vectors = state.chunks[c]!;
+				const norms = state.norms[c]!;
+				const numVecs = state.vpc[c]!;
+				if (numVecs === 0) continue;
 
-			const k = Math.min(msg.topK, numVecs);
-			const outIndices = new Int32Array(k);
-			const outScores = new Float32Array(k);
+				const k = Math.min(msg.topK, numVecs);
+				const outIndices = new Int32Array(k);
+				const outScores = new Float32Array(k);
 
-			const written = state.cosine_topk(
-				ptr(q),
-				qNorm,
-				ptr(vectors),
-				ptr(norms),
-				numVecs,
-				state.dim,
-				k,
-				ptr(outIndices),
-				ptr(outScores),
-			);
+				const written = state.cosine_topk(
+					ptr(q),
+					qNorm,
+					ptr(vectors),
+					ptr(norms),
+					numVecs,
+					state.dim,
+					k,
+					ptr(outIndices),
+					ptr(outScores),
+				);
 
-			for (let i = 0; i < written; i++) {
-				merged.push({
-					globalIdx: globalOffset + outIndices[i]!,
-					score: outScores[i]!,
-				});
+				for (let i = 0; i < written; i++) {
+					merged.push({
+						globalIdx: globalOffset + outIndices[i]!,
+						score: outScores[i]!,
+					});
+				}
+				globalOffset += numVecs;
 			}
-			globalOffset += numVecs;
-		}
 
-		merged.sort((a, b) => b.score - a.score);
-		const top = merged.slice(0, msg.topK);
-		self.postMessage({ type: "result", id: msg.id, results: top });
+			merged.sort((a, b) => b.score - a.score);
+			const top = merged.slice(0, msg.topK);
+			self.postMessage({ type: "result", id: msg.id, results: top });
+		} catch (err) {
+			self.postMessage({
+				type: "error",
+				id: msg.id,
+				message: `query failed: ${(err as Error).message}`,
+			});
+		}
 	}
 };

--- a/packages/api/src/services/rag/vector-worker.ts
+++ b/packages/api/src/services/rag/vector-worker.ts
@@ -1,0 +1,150 @@
+/**
+ * Vector worker — runs SIMD cosine top-K on the shared vector index.
+ *
+ * Spawned by `vector-pool.ts` via `new Worker(new URL("./vector-worker.ts",
+ * import.meta.url))`. Receives one `init` message at boot with:
+ *   - sharedChunks: SharedArrayBuffer[] — vectors per chunk (read-only).
+ *   - sharedNorms:  SharedArrayBuffer[] — precomputed L2 norms per chunk.
+ *   - vectorsPerChunk: number[]
+ *   - dim: number
+ *   - libPath: string — path to vector-simd.{so,dylib}
+ *
+ * Then any number of `query` messages with `{ id, query: Float32Array,
+ * topK: number }`. The worker replies with `{ id, results: { idx, score }[] }`.
+ *
+ * Memory: the SharedArrayBuffer is referenced (not copied) into the
+ * worker's address space. With N workers all viewing the same SABs, the
+ * physical RAM cost stays at the single 5.6 GB index.
+ *
+ * The worker does not load SQLite or BM25 here — those stay in the main
+ * thread for now (BM25 is synchronous + already cheap with AND adaptive,
+ * and adding a second worker concern multiplies the surface). When BM25
+ * becomes a bottleneck under sustained concurrency we can revisit.
+ */
+
+import { dlopen, FFIType, ptr } from "bun:ffi";
+
+declare const self: {
+	postMessage: (message: unknown) => void;
+	onmessage: ((event: MessageEvent) => void) | null;
+};
+
+interface InitMessage {
+	type: "init";
+	sharedChunks: SharedArrayBuffer[];
+	sharedNorms: SharedArrayBuffer[];
+	vectorsPerChunk: number[];
+	dim: number;
+	libPath: string;
+}
+
+interface QueryMessage {
+	type: "query";
+	id: number;
+	query: Float32Array;
+	topK: number;
+}
+
+type InMessage = InitMessage | QueryMessage;
+
+// biome-ignore lint/suspicious/noExplicitAny: bun:ffi symbol types are dynamic.
+type CosineTopk = (...args: any[]) => number;
+
+interface State {
+	chunks: Float32Array[];
+	norms: Float32Array[];
+	vpc: number[];
+	dim: number;
+	cosine_topk: CosineTopk;
+}
+
+let state: State | null = null;
+
+self.onmessage = (event: MessageEvent) => {
+	const msg = event.data as InMessage;
+
+	if (msg.type === "init") {
+		const chunks = msg.sharedChunks.map((sab) => new Float32Array(sab));
+		const norms = msg.sharedNorms.map((sab) => new Float32Array(sab));
+		const lib = dlopen(msg.libPath, {
+			cosine_topk: {
+				args: [
+					FFIType.ptr,
+					FFIType.f32,
+					FFIType.ptr,
+					FFIType.ptr,
+					FFIType.i32,
+					FFIType.i32,
+					FFIType.i32,
+					FFIType.ptr,
+					FFIType.ptr,
+				],
+				returns: FFIType.i32,
+			},
+		});
+		state = {
+			chunks,
+			norms,
+			vpc: msg.vectorsPerChunk,
+			dim: msg.dim,
+			cosine_topk: lib.symbols.cosine_topk as unknown as CosineTopk,
+		};
+		self.postMessage({ type: "ready" });
+		return;
+	}
+
+	if (msg.type === "query") {
+		if (!state) {
+			self.postMessage({
+				type: "error",
+				id: msg.id,
+				message: "not initialized",
+			});
+			return;
+		}
+
+		// Precompute query norm.
+		let qNorm = 0;
+		const q = msg.query;
+		for (let i = 0; i < state.dim; i++) qNorm += q[i]! * q[i]!;
+		qNorm = Math.sqrt(qNorm);
+
+		const merged: Array<{ globalIdx: number; score: number }> = [];
+		let globalOffset = 0;
+
+		for (let c = 0; c < state.chunks.length; c++) {
+			const vectors = state.chunks[c]!;
+			const norms = state.norms[c]!;
+			const numVecs = state.vpc[c]!;
+			if (numVecs === 0) continue;
+
+			const k = Math.min(msg.topK, numVecs);
+			const outIndices = new Int32Array(k);
+			const outScores = new Float32Array(k);
+
+			const written = state.cosine_topk(
+				ptr(q),
+				qNorm,
+				ptr(vectors),
+				ptr(norms),
+				numVecs,
+				state.dim,
+				k,
+				ptr(outIndices),
+				ptr(outScores),
+			);
+
+			for (let i = 0; i < written; i++) {
+				merged.push({
+					globalIdx: globalOffset + outIndices[i]!,
+					score: outScores[i]!,
+				});
+			}
+			globalOffset += numVecs;
+		}
+
+		merged.sort((a, b) => b.score - a.score);
+		const top = merged.slice(0, msg.topK);
+		self.postMessage({ type: "result", id: msg.id, results: top });
+	}
+};

--- a/scripts/build-vector-simd.sh
+++ b/scripts/build-vector-simd.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Build vector-simd shared library for the current platform.
+#
+# Targets:
+#   - linux/amd64 (production KonarServer): AVX2 + FMA via gcc
+#   - darwin/arm64 (dev macOS Apple Silicon): scalar fallback via clang
+#
+# The output filename includes os+arch so both binaries can coexist
+# in the repo and we pick the right one at runtime.
+#
+# Usage:
+#   ./scripts/build-vector-simd.sh              # auto-detect host
+#   ./scripts/build-vector-simd.sh linux-amd64  # cross-compile-ish
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SRC="${SCRIPT_DIR}/../packages/api/src/services/rag/vector-simd.c"
+OUT_DIR="${SCRIPT_DIR}/../packages/api/src/services/rag"
+
+TARGET="${1:-auto}"
+
+if [ "$TARGET" = "auto" ]; then
+  case "$(uname -s)/$(uname -m)" in
+    Linux/x86_64)   TARGET=linux-amd64 ;;
+    Darwin/arm64)   TARGET=darwin-arm64 ;;
+    Darwin/x86_64)  TARGET=darwin-amd64 ;;
+    *)              echo "unsupported host: $(uname -s)/$(uname -m)" >&2; exit 1 ;;
+  esac
+fi
+
+echo "Building vector-simd for $TARGET"
+
+case "$TARGET" in
+  linux-amd64)
+    OUT="${OUT_DIR}/vector-simd.linux-amd64.so"
+    gcc -O3 -mavx2 -mfma -shared -fPIC -o "$OUT" "$SRC"
+    ;;
+  darwin-arm64)
+    OUT="${OUT_DIR}/vector-simd.darwin-arm64.dylib"
+    clang -O3 -shared -fPIC -arch arm64 -o "$OUT" "$SRC"
+    ;;
+  darwin-amd64)
+    OUT="${OUT_DIR}/vector-simd.darwin-amd64.dylib"
+    clang -O3 -mavx2 -mfma -shared -fPIC -arch x86_64 -o "$OUT" "$SRC"
+    ;;
+  *)
+    echo "unknown target: $TARGET" >&2
+    exit 1
+    ;;
+esac
+
+echo "Built: $OUT ($(du -h "$OUT" | cut -f1))"


### PR DESCRIPTION
Promotes the Sprint 1 RAG performance work from \`staging\` to \`main\`. Watchtower picks up the new image and rolls the prod container.

## What ships

Single production code path: vector top-K via a SharedArrayBuffer-backed pool of 4 Bun Workers, each calling the AVX2+FMA SIMD kernel via \`Bun.dlopen\`. BM25 uses an adaptive AND/OR FTS5 matcher to short-circuit the OR-explosion on generic-token queries.

## Validated

- Per-query SIMD vs JS on prod corpus (484k × 3072): ~870 ms vs ~62.6 s median — **~72× faster**.
- Pool concurrency: 5 queries in parallel finish in 1.7 s wall vs 4.8 s sequential SIMD — **2.9× concurrency speedup**.
- End-to-end on the 57 omnibus gold-set questions (sidecar A/B): R@5 = 96.5% (matches the previous baseline at the equivalent unit), R@10 = 100%, MRR 0.848, p50 25 s, p95 37 s, 0 errors.
- Code review: claude[bot] reviewer approved twice (initial + after fixes + final cleanup).

## Failure mode

If the worker pool can't init (missing \`.so\`, ABI break, OOM), the API does not start. Watchtower keeps the previous container running.

## Tunables

- \`RAG_VECTOR_POOL_WORKERS\` (default 4)
- \`RAG_VECTOR_POOL_MAX_PENDING\` (default 20, returns 503 above this)

## Test plan

- [x] CI: lint + 398 unit tests pass.
- [x] Sidecar end-to-end on prod corpus.
- [ ] Smoke /v1/ask once watchtower deploys.
- [ ] 48h monitoring window: \`docker stats\`, Opik traces, container memory peaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)