### PR TITLE
fix: auto-fixable lint errors blocking Deploy on main

### DIFF
--- a/packages/api/research/eval-gate.ts
+++ b/packages/api/research/eval-gate.ts
@@ -197,7 +197,9 @@ async function main() {
 		} catch (err) {
 			const msg = err instanceof Error ? err.message : String(err);
 			const stack = err instanceof Error ? err.stack : "";
-			console.error(`\nQ${q.id} failed: ${msg}\n${stack?.split("\n").slice(0, 4).join("\n") ?? ""}`);
+			console.error(
+				`\nQ${q.id} failed: ${msg}\n${stack?.split("\n").slice(0, 4).join("\n") ?? ""}`,
+			);
 		}
 	}
 	process.stdout.write("\n");

--- a/packages/api/src/services/rag/pipeline.ts
+++ b/packages/api/src/services/rag/pipeline.ts
@@ -43,11 +43,11 @@ import {
 } from "./synthesis.ts";
 import { type RagTrace, startTrace } from "./tracing.ts";
 
+export { normalizePeriodicTitle } from "./analyzer.ts";
 // Re-exports kept for backwards compatibility with existing tests + external
 // imports. Tests import { articleTypePenalty, normalizePeriodicTitle } from
 // this module; keep that surface stable.
 export { articleTypePenalty } from "./retrieval.ts";
-export { normalizePeriodicTitle } from "./analyzer.ts";
 export type { Citation } from "./synthesis.ts";
 
 // Suppress unused-import warning: bm25HybridSearch is imported only so the


### PR DESCRIPTION
Pre-existing biome violations from #37 que bloquean el Deploy de #48. Ambos son auto-fixes seguros (imports + formato). Mergear inmediatamente para desbloquear el deploy.