### PR TITLE
feat(rag-ft): Fase 1b scaffolding — toolchain + data converter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,7 @@ og-images/
 
 # research / experiments
 packages/search-lab/
+
+# generated reranker training artifacts (regenerable from reranker-v1.jsonl)
+packages/api/research/training/triplets.jsonl
+packages/api/research/training/.venv/

--- a/packages/api/research/training/README.md
+++ b/packages/api/research/training/README.md
@@ -1,0 +1,124 @@
+# Reranker training (Fase 1b of RAG-FT)
+
+Workflow + tooling for training the cross-encoder reranker on the dataset assembled in Fase 1a (`packages/api/research/datasets/reranker-v1.jsonl`).
+
+> **Status:** scaffolding only. Pilot dataset is 136 pairs — too small for real training. This directory exists so that when the dataset is scaled to ~5K pairs, the training pipeline is already documented and the data converters are tested.
+
+## Toolchain decision (and why we deviated from the plan)
+
+The original `RAG-FT-PLAN.md` said "LoRA via mlx-lm" for the reranker. That was wrong: **mlx-lm is for autoregressive LLMs, not cross-encoders**. Cross-encoders (XLM-RoBERTa, BGE) need a different trainer.
+
+Realistic options surveyed:
+
+| Toolchain | Pros | Cons |
+|---|---|---|
+| **sentence-transformers + PEFT (PyTorch / MPS)** | Mature, well-documented for cross-encoder LoRA. Works on M4 Max via MPS backend. PEFT supports XLM-RoBERTa-LoRA out of the box. | Slower than MLX on Apple Silicon (~50-70% of CUDA-equivalent throughput). Requires Python env. |
+| mlx-embeddings | Native MLX speed. Supports XLM-RoBERTa loading. | Cross-encoder training (vs bi-encoder) is not first-class yet. Would need custom training loop. |
+| mlx-lm | — | Wrong abstraction; doesn't apply. |
+
+**Decision: sentence-transformers + PEFT.** Maturity wins at this scale. We can revisit mlx-embeddings if/when training becomes a bottleneck.
+
+## Prerequisites
+
+```bash
+# Python 3.11+ recommended.
+python3 -m venv .venv
+source .venv/bin/activate
+pip install \
+  'sentence-transformers>=3.0' \
+  'transformers>=4.40' \
+  'peft>=0.11' \
+  'torch>=2.3' \
+  'accelerate>=0.30' \
+  'datasets>=2.18'
+```
+
+On Apple Silicon, PyTorch will use the **MPS backend** automatically when `torch.backends.mps.is_available()` is `True`. Verify:
+
+```python
+import torch
+print(torch.backends.mps.is_available())  # should be True
+print(torch.backends.mps.is_built())      # should be True
+```
+
+## Pipeline
+
+```
+reranker-v1.jsonl    →    convert-reranker-data.ts    →    triplets.jsonl
+   (Fase 1a)             (this directory)                    (training input)
+
+triplets.jsonl       →    train.py                    →    LoRA adapter (safetensors)
+                          (sentence-transformers
+                          + PEFT, MPS backend)
+
+LoRA adapter         →    eval.py                     →    R@10 / R@5 deltas
+                          (against eval-v2 holdout)
+```
+
+### 1. Convert dataset to triplet format
+
+```bash
+bun run packages/api/research/training/convert-reranker-data.ts \
+  --in packages/api/research/datasets/reranker-v1.jsonl \
+  --out packages/api/research/training/triplets.jsonl \
+  --format triplet
+```
+
+Each input pair (query + positive + N hard negatives) expands to N triplets:
+
+```jsonl
+{"query": "...", "positive": "<positive article text>", "negative": "<hard neg 1>"}
+{"query": "...", "positive": "<positive article text>", "negative": "<hard neg 2>"}
+...
+```
+
+This is the exact format `sentence_transformers.losses.MultipleNegativesRankingLoss` expects.
+
+### 2. Train (not yet implemented; spec only)
+
+`train.py` will be a thin wrapper around `sentence_transformers.CrossEncoder` with PEFT LoRA. Target candidate base models (per the plan):
+
+- `BAAI/bge-reranker-v2-m3` — 568M params, multilingual, strong baseline.
+- `IIC/MEL` — XLM-RoBERTa-large continual-pretrained on BOE/Congreso (arXiv:2501.16011). Spanish-legal-specific.
+
+LoRA hyperparameters as a starting point (revise after first runs):
+
+```python
+LoraConfig(
+    r=16, lora_alpha=32, lora_dropout=0.05,
+    bias="none", task_type=TaskType.FEATURE_EXTRACTION,
+    target_modules=["query", "value"],  # XLM-RoBERTa attention
+)
+```
+
+Training config:
+- batch size: 16 (MPS memory permitting; halve if OOM)
+- epochs: 3-5 (early-stop on validation R@10)
+- lr: 2e-5
+- warmup: 10% of total steps
+
+### 3. Evaluate
+
+`eval.py` runs the trained reranker on the eval-v2 holdout (50 untouchable questions) and reports:
+
+- R@10, R@5, R@1 vs the Cohere baseline
+- **R@10 broken down per register** (informal / formal / procedural) — this is the per-register decision we made in Fase 1a to catch register-shift regressions early.
+- Inference latency per query (P50, P95).
+- $ per query (always 0 for self-hosted; included for the comparison table).
+
+Ship criteria from the plan: variant beats Cohere on factual correctness without R@10 regression and reduces cost by >50%. The cost gate is automatic ($0 vs $0.0025); the R@10 gate is the real bar.
+
+## What's in this directory
+
+- `README.md` (this file)
+- `convert-reranker-data.ts` — JSONL pair → triplet converter (committed, tested)
+- `train.py` — placeholder, to be added when dataset scales
+- `eval.py` — placeholder, to be added when adapter exists
+- `triplets.jsonl` — generated artifact, gitignored
+
+## Open questions (to resolve before scaling training)
+
+1. **Loss function**: `MultipleNegativesRankingLoss` (in-batch) vs `MarginMSELoss` (with teacher scores) — the second needs a teacher, the first doesn't. Default: in-batch MNR.
+2. **Sequence length**: BGE-reranker-v2-m3 supports 8192 tokens but we'll cap at 512 to fit longer Spanish articles in batch. Articles >512 chars get truncated to first 512.
+3. **Trap pairs**: should `is_trap: true` examples get higher loss weight? Probably yes (they're the adversarial cases the system fails on today). Hyperparameter tbd.
+4. **Validation split**: we'll hold out 10% of `reranker-v1.jsonl` as a training-time validation set, separate from the eval-v2 holdout. Keeps the eval-v2 holdout truly unseen.

--- a/packages/api/research/training/convert-reranker-data.ts
+++ b/packages/api/research/training/convert-reranker-data.ts
@@ -1,0 +1,160 @@
+#!/usr/bin/env bun
+/**
+ * Convert the assembled reranker dataset (`reranker-v1.jsonl`) into the
+ * triplet format expected by sentence-transformers cross-encoder training.
+ *
+ * Each input pair has 1 query, 1 positive, and N hard negatives. The
+ * converter expands this to N triplets per pair (one per negative), so
+ * the training run sees each (query, positive) compared against every
+ * hard negative.
+ *
+ * Input row (reranker-v1.jsonl):
+ *   { id, query, register, is_trap, positive: {text, ...},
+ *     hard_negatives: [{text, source, ...}, ...], meta: {...} }
+ *
+ * Output row (triplets.jsonl):
+ *   { query, positive, negative, source, register, is_trap, pair_id }
+ *
+ * The `source`, `register`, `is_trap`, and `pair_id` fields are kept so
+ * the trainer can apply per-stratum loss weighting if we decide to.
+ */
+
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+export type RerankerPair = {
+	id: string;
+	query: string;
+	register: string;
+	is_trap: boolean;
+	positive: { text: string };
+	hard_negatives: Array<{
+		text: string;
+		source: "semantic-topk" | "materia-sibling";
+	}>;
+};
+
+export type Triplet = {
+	query: string;
+	positive: string;
+	negative: string;
+	source: "semantic-topk" | "materia-sibling";
+	register: string;
+	is_trap: boolean;
+	pair_id: string;
+};
+
+/**
+ * Expand one (query, positive, N negatives) pair into N (query, positive,
+ * negative) triplets. Skips pairs with no negatives (shouldn't happen at
+ * pilot scale — the assembler enforces ≥1 of each type — but we don't
+ * trust input invariants on a converter).
+ */
+export function pairToTriplets(pair: RerankerPair): Triplet[] {
+	if (!pair.positive?.text || pair.hard_negatives.length === 0) return [];
+	return pair.hard_negatives.map((neg) => ({
+		query: pair.query,
+		positive: pair.positive.text,
+		negative: neg.text,
+		source: neg.source,
+		register: pair.register,
+		is_trap: pair.is_trap,
+		pair_id: pair.id,
+	}));
+}
+
+/**
+ * Truncate a passage (positive or negative) to a max char length. Cross-
+ * encoders cap at ~512 tokens; we approximate with characters here so the
+ * converter doesn't need a tokenizer dependency. The trainer can re-truncate
+ * with the actual tokenizer; this just keeps the JSONL manageable.
+ */
+export function truncatePassage(text: string, maxChars = 2000): string {
+	if (text.length <= maxChars) return text;
+	return `${text.slice(0, maxChars)}…`;
+}
+
+export function applyTruncation(
+	triplets: readonly Triplet[],
+	maxChars: number,
+): Triplet[] {
+	return triplets.map((t) => ({
+		...t,
+		positive: truncatePassage(t.positive, maxChars),
+		negative: truncatePassage(t.negative, maxChars),
+	}));
+}
+
+type ConvertArgs = {
+	inPath: string;
+	outPath: string;
+	maxChars: number;
+	dropTraps: boolean;
+};
+
+function loadJsonl(path: string): RerankerPair[] {
+	return readFileSync(path, "utf8")
+		.trim()
+		.split("\n")
+		.map((line) => JSON.parse(line) as RerankerPair);
+}
+
+function writeJsonl(path: string, rows: readonly Triplet[]): void {
+	mkdirSync(dirname(path), { recursive: true });
+	const body = rows.map((r) => JSON.stringify(r)).join("\n");
+	writeFileSync(path, rows.length === 0 ? "" : `${body}\n`, "utf8");
+}
+
+function main(args: ConvertArgs): void {
+	const pairs = loadJsonl(args.inPath);
+	const filtered = args.dropTraps ? pairs.filter((p) => !p.is_trap) : pairs;
+	const triplets = filtered.flatMap(pairToTriplets);
+	const truncated = applyTruncation(triplets, args.maxChars);
+	writeJsonl(args.outPath, truncated);
+
+	const bySource = new Map<string, number>();
+	const byRegister = new Map<string, number>();
+	for (const t of truncated) {
+		bySource.set(t.source, (bySource.get(t.source) ?? 0) + 1);
+		byRegister.set(t.register, (byRegister.get(t.register) ?? 0) + 1);
+	}
+	console.log(`Read ${pairs.length} pairs from ${args.inPath}`);
+	if (args.dropTraps) {
+		console.log(`  dropped ${pairs.length - filtered.length} trap pairs`);
+	}
+	console.log(`Wrote ${truncated.length} triplets to ${args.outPath}`);
+	console.log(
+		`  by negative source: ${JSON.stringify(Object.fromEntries(bySource))}`,
+	);
+	console.log(
+		`  by register: ${JSON.stringify(Object.fromEntries(byRegister))}`,
+	);
+}
+
+function parseArgs(argv: readonly string[]): ConvertArgs {
+	const opts: Record<string, string> = {};
+	for (let i = 0; i < argv.length; i++) {
+		const a = argv[i];
+		if (!a.startsWith("--")) continue;
+		const eq = a.indexOf("=");
+		if (eq > 0) {
+			opts[a.slice(2, eq)] = a.slice(eq + 1);
+		} else {
+			opts[a.slice(2)] = argv[++i] ?? "";
+		}
+	}
+	return {
+		inPath: resolve(
+			opts.in ?? "packages/api/research/datasets/reranker-v1.jsonl",
+		),
+		outPath: resolve(
+			opts.out ?? "packages/api/research/training/triplets.jsonl",
+		),
+		maxChars: Number.parseInt(opts["max-chars"] ?? "2000", 10),
+		dropTraps: opts["drop-traps"] === "true",
+	};
+}
+
+if (import.meta.main) {
+	main(parseArgs(process.argv.slice(2)));
+}

--- a/packages/api/src/__tests__/convert-reranker-data.test.ts
+++ b/packages/api/src/__tests__/convert-reranker-data.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Unit tests for the reranker dataset → triplet converter (Fase 1b).
+ *
+ * The converter is pure (input pair → output triplets), so all tests run
+ * against fixtures rather than the real dataset on disk.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+	applyTruncation,
+	pairToTriplets,
+	type RerankerPair,
+	truncatePassage,
+} from "../../research/training/convert-reranker-data.ts";
+
+function pair(over: Partial<RerankerPair> = {}): RerankerPair {
+	return {
+		id: "rkr-000001",
+		query: "¿cuántos días libres me dan si me caso?",
+		register: "informal",
+		is_trap: false,
+		positive: { text: "Quince días naturales en caso de matrimonio." },
+		hard_negatives: [
+			{ text: "Cinco días por nacimiento.", source: "semantic-topk" },
+			{ text: "Permiso por mudanza.", source: "materia-sibling" },
+		],
+		...over,
+	};
+}
+
+describe("pairToTriplets", () => {
+	test("expands one pair into N triplets, one per negative", () => {
+		const triplets = pairToTriplets(pair());
+		expect(triplets.length).toBe(2);
+		expect(triplets[0].query).toBe(pair().query);
+		expect(triplets[0].positive).toBe(
+			"Quince días naturales en caso de matrimonio.",
+		);
+		expect(triplets[0].negative).toBe("Cinco días por nacimiento.");
+		expect(triplets[0].source).toBe("semantic-topk");
+		expect(triplets[1].source).toBe("materia-sibling");
+	});
+
+	test("preserves register, is_trap, and pair_id on every triplet", () => {
+		const triplets = pairToTriplets(
+			pair({ register: "procedural", is_trap: true }),
+		);
+		for (const t of triplets) {
+			expect(t.register).toBe("procedural");
+			expect(t.is_trap).toBe(true);
+			expect(t.pair_id).toBe("rkr-000001");
+		}
+	});
+
+	test("returns empty for pair with no negatives", () => {
+		expect(pairToTriplets(pair({ hard_negatives: [] }))).toEqual([]);
+	});
+
+	test("returns empty for pair with empty positive text", () => {
+		const p: RerankerPair = pair();
+		(p as { positive: { text: string } }).positive = { text: "" };
+		expect(pairToTriplets(p)).toEqual([]);
+	});
+});
+
+describe("truncatePassage", () => {
+	test("returns text unchanged when shorter than max", () => {
+		expect(truncatePassage("hola", 100)).toBe("hola");
+	});
+
+	test("truncates and adds ellipsis when over max", () => {
+		const t = truncatePassage("x".repeat(200), 50);
+		expect(t.length).toBe(51); // 50 chars + 1 ellipsis
+		expect(t.endsWith("…")).toBe(true);
+	});
+
+	test("handles exact-length input", () => {
+		expect(truncatePassage("abc", 3)).toBe("abc");
+	});
+
+	test("handles empty input", () => {
+		expect(truncatePassage("", 100)).toBe("");
+	});
+});
+
+describe("applyTruncation", () => {
+	test("truncates positive and negative independently", () => {
+		const triplets = pairToTriplets(
+			pair({
+				positive: { text: "x".repeat(500) },
+				hard_negatives: [{ text: "y".repeat(500), source: "semantic-topk" }],
+			}),
+		);
+		const out = applyTruncation(triplets, 100);
+		expect(out[0].positive.length).toBe(101); // 100 + …
+		expect(out[0].negative.length).toBe(101);
+	});
+
+	test("does not truncate already-short passages", () => {
+		const triplets = pairToTriplets(pair());
+		const out = applyTruncation(triplets, 1000);
+		expect(out[0].positive).toBe(triplets[0].positive);
+		expect(out[0].negative).toBe(triplets[0].negative);
+	});
+
+	test("does not mutate input triplets", () => {
+		const triplets = pairToTriplets(
+			pair({ positive: { text: "x".repeat(500) } }),
+		);
+		const before = triplets[0].positive;
+		applyTruncation(triplets, 50);
+		expect(triplets[0].positive).toBe(before);
+	});
+});


### PR DESCRIPTION
Scaffolding de Fase 1b (#44) de la línea de trabajo RAG-FT (#42). **Depende de #50** para el dataset de entrada; los tests son self-contained.

## Decisión de toolchain (importante)

El plan original decía \"LoRA via mlx-lm\". **Estaba mal**: mlx-lm es para LLMs autoregresivos, no cross-encoders. Esta PR documenta el cambio:

| Toolchain | Veredicto |
|---|---|
| sentence-transformers + PEFT (PyTorch / MPS) | **Elegido**. Maduro, LoRA cross-encoder out-of-the-box, MPS backend funciona bien en M4 Max. |
| mlx-embeddings | Cross-encoder training no es first-class todavía. Reevaluar si la velocidad se vuelve crítica. |
| mlx-lm | Abstracción incorrecta. Descartado. |

## Qué incluye

- `training/README.md` — toolchain decision + comandos exactos de setup (Python venv, deps, MPS check).
- `training/convert-reranker-data.ts` — pair → triplet converter para formato \`MultipleNegativesRankingLoss\`. Mantiene metadata de \`source\`/\`register\`/\`is_trap\`/\`pair_id\` para per-stratum loss weighting opcional.
- 11 unit tests (pure functions, fixtures). 0 DB / fs deps.
- \`.gitignore\` para artefactos generables.

## Qué NO incluye (intencionalmente)

- \`train.py\` — wrapper sobre \`sentence_transformers.CrossEncoder\` + PEFT.
- \`eval.py\` — corre adapter contra eval-v2 holdout, reporta **R@10 per register** (la decisión que tomamos en #50 para detectar regresiones de informal antes del A/B).

Ambos llegan cuando el dataset escale a ~5K pares (entrenar con 136 no es serio). Esto es plumbing.

## Test plan

- [x] \`bun run check\` — sin errores nuevos.
- [x] \`bun test\` — 422/422 pasan (11 nuevos para el converter; los demás vienen de staging).
- [ ] E2E del converter sobre \`reranker-v1.jsonl\` real — bloqueado en merge de #50.

Refs: #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)