### PR TITLE
infra: ship leyes commits and rebuild web on every push

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,10 @@ on:
         required: false
         default: "all"
         type: string
+  # Fired by leyabierta/leyes on push to main (notify-leyabierta.yml)
+  # so the static site rebuilds whenever new laws are published.
+  repository_dispatch:
+    types: [leyes-updated]
 
 permissions:
   contents: read
@@ -39,7 +43,10 @@ jobs:
         id: api
         run: |
           TARGETS="${{ github.event.inputs.targets || '' }}"
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          if [ "${{ github.event_name }}" = "repository_dispatch" ]; then
+            # leyes-updated only changes content, never API code
+            echo "deploy=false" >> $GITHUB_OUTPUT
+          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             if [ "$TARGETS" = "all" ] || [ -z "$TARGETS" ] || echo "$TARGETS" | grep -q "api"; then
               echo "deploy=true" >> $GITHUB_OUTPUT
             else
@@ -62,7 +69,11 @@ jobs:
         id: web
         run: |
           TARGETS="${{ github.event.inputs.targets || '' }}"
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          if [ "${{ github.event_name }}" = "repository_dispatch" ]; then
+            # leyes-updated → always rebuild web to pick up new laws
+            echo "Web rebuild triggered by leyes update"
+            echo "deploy=true" >> $GITHUB_OUTPUT
+          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             if [ "$TARGETS" = "all" ] || [ -z "$TARGETS" ] || echo "$TARGETS" | grep -q "web"; then
               echo "deploy=true" >> $GITHUB_OUTPUT
             else

--- a/.github/workflows/leyes-rebuild-backstop.yml
+++ b/.github/workflows/leyes-rebuild-backstop.yml
@@ -1,0 +1,93 @@
+name: Leyes rebuild backstop
+
+# Safety net for the leyes → web pipeline.
+#
+# Primary path: when `leyabierta/leyes` is pushed, its `notify-leyabierta.yml`
+# workflow fires a `repository_dispatch` event that triggers `deploy.yml` to
+# rebuild the web. That covers the happy path with ~1-2 min latency.
+#
+# This workflow is the backstop in case the dispatch is dropped (GitHub Actions
+# degradation, expired PAT, workflow disabled, etc.). Every 30 minutes it:
+#   1. Reads the current HEAD SHA of `leyabierta/leyes` main.
+#   2. Compares it to the last-built SHA stored in actions/cache.
+#   3. If different → fires `repository_dispatch` to deploy.yml (same code path
+#      as the primary trigger) and refreshes the cache with the new SHA.
+#
+# Cache-based storage chosen because the default GITHUB_TOKEN cannot mutate
+# repo variables. Cache entries idle-evict after 7 days; we run every 30 min
+# so the entry stays warm indefinitely.
+
+on:
+  schedule:
+    - cron: "*/30 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: write   # to dispatch deploy.yml
+
+concurrency:
+  group: leyes-backstop
+  cancel-in-progress: false
+
+jobs:
+  check-and-trigger:
+    name: Check leyes SHA and trigger rebuild if drifted
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch remote leyes HEAD
+        id: remote
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          SHA=$(gh api repos/leyabierta/leyes/commits/main --jq '.sha')
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+          echo "Remote leyes HEAD: $SHA"
+
+      - name: Restore last built SHA
+        id: cache-restore
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: .last-leyes-sha
+          key: last-leyes-sha-${{ steps.remote.outputs.sha }}
+          restore-keys: |
+            last-leyes-sha-
+
+      - name: Compare and dispatch if drifted
+        id: decide
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REMOTE_SHA: ${{ steps.remote.outputs.sha }}
+        run: |
+          set -euo pipefail
+
+          LAST_SHA=""
+          if [ -f .last-leyes-sha ]; then
+            LAST_SHA=$(cat .last-leyes-sha)
+          fi
+          echo "Last built SHA: ${LAST_SHA:-<none>}"
+
+          if [ "$REMOTE_SHA" = "$LAST_SHA" ]; then
+            echo "✓ in sync — no rebuild needed"
+            echo "drifted=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "⚠ drift detected — firing repository_dispatch"
+          gh api -X POST "repos/${{ github.repository }}/dispatches" \
+            -f event_type=leyes-updated \
+            -f "client_payload[source]=backstop" \
+            -f "client_payload[remote_sha]=$REMOTE_SHA" \
+            -f "client_payload[previous_sha]=${LAST_SHA:-none}"
+
+          echo "$REMOTE_SHA" > .last-leyes-sha
+          echo "drifted=true" >> "$GITHUB_OUTPUT"
+          echo "✓ dispatch sent"
+
+      - name: Save updated SHA
+        if: steps.decide.outputs.drifted == 'true'
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: .last-leyes-sha
+          key: last-leyes-sha-${{ steps.remote.outputs.sha }}

--- a/scripts/daily-pipeline.sh
+++ b/scripts/daily-pipeline.sh
@@ -4,54 +4,172 @@
 #
 # Usage: /opt/leyabierta/scripts/daily-pipeline.sh
 # Cron:  30 8 * * * /opt/leyabierta/scripts/daily-pipeline.sh
+
+# ── Single-instance lock ────────────────────────────────────────────────────
+# Prevents concurrent runs from racing on the leyes git working tree
+# (root cause of duplicate commits seen in production before 2026-04-27).
+LOCKFILE=/var/lock/leyabierta-pipeline.lock
+exec 9>"$LOCKFILE"
+if ! flock -n 9; then
+  echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] another pipeline run is in progress — skipping" >> /opt/leyabierta/logs/daily-pipeline.log
+  exit 0
+fi
+
 set -euo pipefail
 
 LOG=/opt/leyabierta/logs/daily-pipeline.log
 CONTAINER=code-api-1
+ENV_FILE=/opt/leyabierta/code/.env.prod
+LEYES_DIR_CONTAINER=/data/leyes
+DIVERGENCE_CEILING=200  # abort push if local is ahead by more than this; alert + investigate
 
 mkdir -p "$(dirname "$LOG")"
 log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $1" | tee -a "$LOG"; }
 
+# Load LEYES_PUSH_TOKEN from .env.prod for the push step. Sourcing the whole
+# file is safe (it only contains KEY=value lines) and lets us forward the
+# token to docker exec without baking it into the container image.
+if [ -r "$ENV_FILE" ]; then
+  # shellcheck disable=SC1090
+  set -a; source "$ENV_FILE"; set +a
+fi
+
 log "=== Daily pipeline started ==="
 
-# Step 1: Run pipeline (fetch new + reformed norms from BOE → JSON + git commits)
+# ── Step 1: Pipeline bootstrap (BOE → markdown + git commits) ──────────────
 log "→ Step 1: Pipeline bootstrap"
-docker exec $CONTAINER bun run pipeline bootstrap --country es --concurrency 2 >> "$LOG" 2>&1
+docker exec "$CONTAINER" bun run pipeline bootstrap --country es --concurrency 2 >> "$LOG" 2>&1
 log "  ✓ Pipeline done"
 
-# Step 2: Ingest JSON → SQLite
+# ── Step 1.5: Push leyes repo to GitHub ─────────────────────────────────────
+# Decoupled from AI/email steps: the law text is the product, AI enrichment is
+# additive. Pushing here triggers the web rebuild ASAP. Push failure does NOT
+# block the rest of the pipeline (DB ingest still runs, API stays current).
+# Run a git command inside the container. Network-touching ops (fetch/push/pull)
+# get LEYES_PUSH_TOKEN forwarded + an inline credential helper that supplies it
+# to the HTTPS remote. The token never lands on disk and never appears in
+# `ps`/`docker inspect` (it's piped via -e env var, not a CLI argument).
+git_in_container() {
+  docker exec -e LEYES_PUSH_TOKEN="${LEYES_PUSH_TOKEN:-}" "$CONTAINER" \
+    git -c "credential.helper=!f() { echo username=x-access-token; echo password=\$LEYES_PUSH_TOKEN; }; f" \
+        -C "$LEYES_DIR_CONTAINER" "$@"
+}
+
+push_leyes() {
+  local ahead behind sha_before sha_after
+
+  if [ -z "${LEYES_PUSH_TOKEN:-}" ]; then
+    log "  ✗ LEYES_PUSH_TOKEN not set in $ENV_FILE — cannot push"
+    return 1
+  fi
+
+  # Ensure git identity exists inside the container so any rebase that needs
+  # to create commits (merge resolution, signoff, etc.) doesn't fail.
+  # `pipeline bootstrap` sets author via GIT_AUTHOR_* env vars at commit time
+  # so this only kicks in for our own git operations.
+  git_in_container config user.name  "Ley Abierta Bot" >> "$LOG" 2>&1 || true
+  git_in_container config user.email "bot@leyabierta.es" >> "$LOG" 2>&1 || true
+
+  sha_before=$(git_in_container rev-parse HEAD 2>&1)
+  log "  HEAD before push: $sha_before"
+
+  # Fetch first to know how far we've drifted from origin
+  if ! git_in_container fetch origin main >> "$LOG" 2>&1; then
+    log "  ✗ git fetch failed — aborting push attempt"
+    return 1
+  fi
+
+  ahead=$(git_in_container rev-list --count origin/main..HEAD)
+  behind=$(git_in_container rev-list --count HEAD..origin/main)
+  log "  divergence: ahead=$ahead behind=$behind (ceiling=$DIVERGENCE_CEILING)"
+
+  if [ "$ahead" -gt "$DIVERGENCE_CEILING" ]; then
+    log "  ✗ ABORT: local is ahead by $ahead (ceiling $DIVERGENCE_CEILING). Manual intervention required."
+    log "    Investigate /opt/leyabierta/data/leyes before next run."
+    return 1
+  fi
+
+  if [ "$ahead" = "0" ] && [ "$behind" = "0" ]; then
+    log "  nothing to push (already in sync)"
+    return 0
+  fi
+
+  if [ "$behind" -gt "0" ]; then
+    log "  remote has $behind unseen commits — rebasing"
+    if ! git_in_container pull --rebase origin main >> "$LOG" 2>&1; then
+      log "  ✗ rebase failed — manual intervention required"
+      git_in_container rebase --abort >> "$LOG" 2>&1 || true
+      return 1
+    fi
+  fi
+
+  if ! git_in_container push origin main >> "$LOG" 2>&1; then
+    log "  ✗ push failed — will retry on next pipeline run"
+    return 1
+  fi
+
+  sha_after=$(git_in_container rev-parse HEAD 2>&1)
+  log "  ✓ push OK ($ahead commits published, HEAD=$sha_after)"
+  return 0
+}
+
+log "→ Step 1.5: Push leyes to GitHub"
+# Run without set -e so push failure doesn't kill the rest of the pipeline
+set +e
+push_leyes
+push_status=$?
+set -e
+if [ "$push_status" -ne 0 ]; then
+  log "  ⚠ push failed (status $push_status). DB ingest + AI steps will continue."
+fi
+
+# ── Step 2: Ingest JSON → SQLite ────────────────────────────────────────────
 log "→ Step 2: Ingest"
-docker exec $CONTAINER bun run ingest >> "$LOG" 2>&1
+docker exec "$CONTAINER" bun run ingest >> "$LOG" 2>&1
 log "  ✓ Ingest done"
 
-# Step 3: Ingest analisis (materias, notas, refs from BOE)
+# ── Step 3: Ingest analisis (materias, notas, refs from BOE) ────────────────
 log "→ Step 3: Ingest analisis"
-docker exec $CONTAINER bun run ingest-analisis >> "$LOG" 2>&1
+docker exec "$CONTAINER" bun run ingest-analisis >> "$LOG" 2>&1
 log "  ✓ Ingest-analisis done"
 
-# Step 4: AI — reform summaries
+# ── Step 4: AI — reform summaries ───────────────────────────────────────────
 log "→ Step 4: Reform summaries"
-docker exec $CONTAINER bun run packages/api/src/scripts/generate-reform-summaries.ts >> "$LOG" 2>&1
+docker exec "$CONTAINER" bun run packages/api/src/scripts/generate-reform-summaries.ts >> "$LOG" 2>&1
 log "  ✓ Reform summaries done"
 
-# Step 5: AI — citizen tags & summaries
+# ── Step 5: AI — citizen tags & summaries ───────────────────────────────────
 log "→ Step 5: Citizen tags"
-docker exec $CONTAINER bun run packages/pipeline/src/scripts/generate-citizen-tags.ts >> "$LOG" 2>&1
+docker exec "$CONTAINER" bun run packages/pipeline/src/scripts/generate-citizen-tags.ts >> "$LOG" 2>&1
 log "  ✓ Citizen tags done"
 
-# Step 6: AI — omnibus topic detection
+# ── Step 6: AI — omnibus topic detection ────────────────────────────────────
 log "→ Step 6: Omnibus topics"
-docker exec $CONTAINER bun run packages/api/src/scripts/generate-omnibus-topics.ts >> "$LOG" 2>&1
+docker exec "$CONTAINER" bun run packages/api/src/scripts/generate-omnibus-topics.ts >> "$LOG" 2>&1
 log "  ✓ Omnibus topics done"
 
-# Step 7: OG images (only generates missing ones)
+# ── Step 7: OG images (only generates missing ones) ─────────────────────────
 log "→ Step 7: OG images"
-docker exec $CONTAINER bun run packages/api/src/scripts/generate-og-images.ts >> "$LOG" 2>&1
+docker exec "$CONTAINER" bun run packages/api/src/scripts/generate-og-images.ts >> "$LOG" 2>&1
 log "  ✓ OG images done"
 
-# Step 8: Email notifications
+# ── Step 8: Email notifications ─────────────────────────────────────────────
 log "→ Step 8: Send notifications"
-docker exec $CONTAINER bun run packages/api/src/scripts/send-notifications.ts >> "$LOG" 2>&1
+docker exec "$CONTAINER" bun run packages/api/src/scripts/send-notifications.ts >> "$LOG" 2>&1
 log "  ✓ Notifications sent"
+
+# ── Step 9: Retry push if step 1.5 failed (AI may have generated new commits) ──
+# Reform summaries / citizen tags don't write to leyes markdown — they write to
+# DB only. So a retry only matters if step 1.5 push genuinely failed.
+if [ "$push_status" -ne 0 ]; then
+  log "→ Step 9: Retry push (step 1.5 failed earlier)"
+  set +e
+  push_leyes
+  retry_status=$?
+  set -e
+  if [ "$retry_status" -ne 0 ]; then
+    log "  ⚠ retry also failed. Will retry on next daily run. Investigate logs."
+  fi
+fi
 
 log "=== Daily pipeline completed ==="


### PR DESCRIPTION
## Summary

Closes the gap between the daily pipeline and the public site.

The daily pipeline on KonarServer used to write commits to the local `leyes` repo but never pushed them. The public mirror was 4+ days stale (869 commits behind), the static site never picked up new laws, and freshly-ingested BOE entries returned 404 on leyabierta.es even though the API had them.

This change wires the loop end-to-end:

- **`scripts/daily-pipeline.sh`** — `flock` wrapper (prevents concurrent runs that produced duplicate commits), `git push` immediately after `pipeline bootstrap` (web rebuild starts before AI/email steps), divergence ceiling of 200 commits (catches silent backlog growth early), retry at end if first push failed. Push uses an in-container HTTPS credential helper sourcing `LEYES_PUSH_TOKEN` from `.env.prod`.
- **`.github/workflows/deploy.yml`** — adds `repository_dispatch: types: [leyes-updated]` trigger; on dispatch events, forces `web=true api=false`.
- **`.github/workflows/leyes-rebuild-backstop.yml`** — polls leyes HEAD every 30 min and fires the same dispatch if SHA drifts from the last built one (cached in `actions/cache`). Belt-and-suspenders for dropped dispatch events.

## Companion changes outside this repo

- `leyabierta/leyes` gets `.github/workflows/notify-leyabierta.yml` (separately committed)
- KonarServer `/opt/leyabierta/code/.env.prod` gets `LEYES_PUSH_TOKEN`
- `leyabierta/leyes` repo gets `LEYABIERTA_DISPATCH_TOKEN` secret

## Test plan

- [x] Local web build with 12,247 laws completes in 57s (well under CF Pages 20-min limit)
- [ ] After merge: server git push of accumulated 869 commits succeeds
- [ ] notify-leyabierta.yml fires on the push
- [ ] deploy.yml runs with event_name=repository_dispatch, web=true api=false
- [ ] /laws/BOE-A-2026-9157/ returns 200 instead of 404
- [ ] Backstop workflow runs successfully on next 30-min tick

🤖 Generated with [Claude Code](https://claude.com/claude-code)