### PR TITLE
fix(docker): install ca-certificates so git push HTTPS works

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,10 @@ WORKDIR /app
 # Git is needed by GitService for diff operations.
 # adduser provides the addgroup/adduser commands used in the non-root step
 # below; with --no-install-recommends it isn't pulled transitively.
-RUN apt-get update && apt-get install -y --no-install-recommends git adduser \
+# ca-certificates is needed for `git push` over HTTPS in the daily pipeline
+# (Step 1.5 of daily-pipeline.sh) — without it git fails with "Problem with
+# the SSL CA cert".
+RUN apt-get update && apt-get install -y --no-install-recommends git adduser ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy workspace config + package files for dependency install


### PR DESCRIPTION
Caught while validating Step 1.5 of the new daily-pipeline.sh end-to-end. `git push` over HTTPS from inside the api container fails with "Problem with the SSL CA cert" because ca-certificates isn't in the image. ~370KB add to the image; cheap insurance.

Companion to #52.

🤖 Generated with [Claude Code](https://claude.com/claude-code)