### PR TITLE
fix(pipeline): expose missing dates and dedup discovered norms

### DIFF
--- a/packages/pipeline/src/cli.ts
+++ b/packages/pipeline/src/cli.ts
@@ -112,6 +112,31 @@ async function bootstrap() {
 		}
 	}
 
+	// Deduplicate `discovered` by id. The BOE catalog API has been observed to
+	// return the same id in different pages near pagination boundaries, and
+	// duplicates would otherwise be fetched twice and (in concurrent runs) end
+	// up as duplicate commits. The flock in daily-pipeline.sh prevents
+	// concurrent runs; this guard prevents single-run duplicates regardless.
+	const seenIds = new Set<string>();
+	const dedupedDiscovered: DiscoveredNorm[] = [];
+	let droppedDuplicates = 0;
+	for (const item of discovered) {
+		if (seenIds.has(item.id)) {
+			droppedDuplicates++;
+			continue;
+		}
+		seenIds.add(item.id);
+		dedupedDiscovered.push(item);
+	}
+	if (droppedDuplicates > 0) {
+		console.warn(
+			`[discover] Dropped ${droppedDuplicates} duplicate ids from ` +
+				`discovered set (likely BOE pagination boundary).`,
+		);
+	}
+	discovered.length = 0;
+	discovered.push(...dedupedDiscovered);
+
 	// Everything from discoverUpdated is either new or updated — process all.
 	// In --force mode, discoverAll returns everything — also process all.
 	const errorIds = new Set(errorRetries);

--- a/packages/pipeline/src/git/repo.ts
+++ b/packages/pipeline/src/git/repo.ts
@@ -176,11 +176,37 @@ export class GitRepo {
 
 		const message = formatCommitMessage(info);
 
-		// Clamp dates to valid git range
+		// Validate the date BEFORE clamping. Empty/malformed dates are an
+		// upstream bug and silently clamping them to 1970-01-02 buries the
+		// problem — we end up with junk commit dates that look intentional.
+		// Refuse to commit with no date; the caller must supply something.
+		const sourceId = info.trailers["Source-Id"] ?? "<no-source-id>";
+		const normId = info.trailers["Norm-Id"] ?? "<no-norm-id>";
+		if (!info.authorDate || !/^\d{4}-\d{2}-\d{2}$/.test(info.authorDate)) {
+			throw new Error(
+				`Refusing to commit with invalid date "${info.authorDate}" ` +
+					`(Source-Id=${sourceId}, Norm-Id=${normId}). ` +
+					`Fix the upstream parser instead of clamping silently.`,
+			);
+		}
+
+		// Clamp to git's safe range. Some downstream tools (web build, GitHub
+		// UI) behave poorly on pre-1970 timestamps. Anything we clamp gets
+		// logged so we can audit which commits had real ancient dates vs which
+		// had a fallback like "1900-01-01" (the BOE metadata sentinel for
+		// missing data).
 		let gitDate = info.authorDate;
 		if (gitDate < "1970-01-02") {
+			console.warn(
+				`[git.commit] Clamping pre-1970 date ${gitDate} → 1970-01-02 ` +
+					`(Source-Id=${sourceId}, Norm-Id=${normId})`,
+			);
 			gitDate = "1970-01-02";
 		} else if (gitDate > "2099-12-31") {
+			console.warn(
+				`[git.commit] Clamping post-2099 date ${gitDate} → 2099-12-31 ` +
+					`(Source-Id=${sourceId}, Norm-Id=${normId})`,
+			);
 			gitDate = "2099-12-31";
 		}
 		const authorDate = `${gitDate}T00:00:00`;

--- a/packages/pipeline/src/pipeline.ts
+++ b/packages/pipeline/src/pipeline.ts
@@ -250,8 +250,19 @@ export async function fetchNorm(
 	}
 
 	// Norms with blocks but no version history (e.g. missing fecha_publicacion
-	// in XML) get a synthetic bootstrap reform from the metadata publication date
+	// in XML) get a synthetic bootstrap reform from the metadata publication
+	// date. If the metadata itself fell back to the BOE sentinel (1900-01-01),
+	// flag it loudly — we have no real date for this norm and the commit will
+	// end up clamped to 1970-01-02, which is wrong but at least auditable
+	// from the warning.
 	if (reforms.length === 0) {
+		if (!metadata.publishedAt || metadata.publishedAt === "1900-01-01") {
+			console.warn(
+				`[pipeline] ${metadata.id} has no version history AND no real ` +
+					`publishedAt — falling back to "${metadata.publishedAt}". ` +
+					`Commit date will be clamped/wrong; investigate BOE metadata.`,
+			);
+		}
 		reforms = [
 			{
 				date: metadata.publishedAt,

--- a/packages/pipeline/src/spain/boe-metadata.ts
+++ b/packages/pipeline/src/spain/boe-metadata.ts
@@ -98,6 +98,16 @@ export class BoeMetadataParser implements MetadataParser {
 		const vigencia = parseBoeDate(item.fecha_vigencia as string);
 		const eli = item.url_eli as string | undefined;
 
+		// "1900-01-01" is the sentinel for "BOE returned no usable
+		// fecha_publicacion". Log it so the per-norm commit later (which will
+		// clamp to 1970-01-02) is traceable to the real cause: missing source
+		// data, not a pipeline bug.
+		if (!published) {
+			console.warn(
+				`[boe-metadata] ${normId} has no fecha_publicacion (raw=${JSON.stringify(item.fecha_publicacion)}) — falling back to 1900-01-01`,
+			);
+		}
+
 		return {
 			title,
 			shortTitle: extractShortTitle(title),


### PR DESCRIPTION
Two bugs surfaced while reconciling the leyes repo divergence today.

## Bug 1 — silent epoch+1 commits
`packages/pipeline/src/git/repo.ts:181` used a string-comparison clamp that turned any pre-1970 date into `1970-01-02` with no warning. Empty strings clamped to the same value, so a missing date looked indistinguishable from a real ancient law. ~12 commits in production hit this with date 1970-01-02.

**Fix:** refuse empty/malformed dates (caller must supply); log all clamped dates with Source-Id + Norm-Id; add upstream warnings when the BOE metadata falls back to `1900-01-01` and when synthetic bootstrap reforms inherit that sentinel.

These don't change the clamp behavior (still 1970-01-02 floor — load-bearing for git compat) but make every clamped commit traceable to the upstream parsing failure.

## Bug 2 — duplicate commits for the same reform
Concurrent pipeline runs were the primary cause (now blocked by `flock` in daily-pipeline.sh). Secondary vector: BOE catalog API can return the same id in different pages near pagination boundaries.

**Fix:** dedup `discovered` array by id in cli.ts, with a warning so duplicates from BOE are visible.

## Tests

- `bun test packages/pipeline`: 204/204 pass
- The new `[boe-metadata] BOE-A-2024-1234 has no fecha_publicacion` warning fires correctly in the existing tests for missing-date inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)