### PR TITLE
feat: progress stepper + markdown rendering on /pregunta

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ og-images/
 
 # research / experiments
 packages/search-lab/
+packages/api/research/training/

--- a/bun.lock
+++ b/bun.lock
@@ -49,11 +49,13 @@
         "astro": "6.1.9",
         "diff2html": "3.4.56",
         "js-yaml": "4.1.1",
+        "markdown-it": "^14.1.1",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
         "sanitize-html": "^2.17.2",
       },
       "devDependencies": {
+        "@types/markdown-it": "^14.1.2",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@types/sanitize-html": "^2.16.1",

--- a/packages/api/src/routes/ask.ts
+++ b/packages/api/src/routes/ask.ts
@@ -115,7 +115,7 @@ export function askRoutes(pipeline: RagPipeline | null) {
 							// event types per the SSE spec.
 							yield `event: keepalive\ndata: ${JSON.stringify({})}\n\n`;
 						} else if (event.type === "progress") {
-							yield `event: progress\ndata: ${JSON.stringify({ step: event.step, label: event.label })}\n\n`;
+							yield `event: progress\ndata: ${JSON.stringify({ step: event.step })}\n\n`;
 						} else {
 							yield `event: done\ndata: ${JSON.stringify({ citations: event.citations, meta: event.meta, declined: event.declined })}\n\n`;
 						}

--- a/packages/api/src/routes/ask.ts
+++ b/packages/api/src/routes/ask.ts
@@ -114,6 +114,8 @@ export function askRoutes(pipeline: RagPipeline | null) {
 							// comments still see byte traffic. Clients ignore unknown
 							// event types per the SSE spec.
 							yield `event: keepalive\ndata: ${JSON.stringify({})}\n\n`;
+						} else if (event.type === "progress") {
+							yield `event: progress\ndata: ${JSON.stringify({ step: event.step, label: event.label })}\n\n`;
 						} else {
 							yield `event: done\ndata: ${JSON.stringify({ citations: event.citations, meta: event.meta, declined: event.declined })}\n\n`;
 						}

--- a/packages/api/src/services/hybrid-search.ts
+++ b/packages/api/src/services/hybrid-search.ts
@@ -32,12 +32,11 @@ import {
 	EMBEDDING_MODELS,
 	type EmbeddingModel,
 	embedQuery,
-	ensureVectorIndex,
-	type InMemoryVectorIndex,
 	type VectorSearchResult,
 } from "./rag/embeddings.ts";
 import { type RankedItem, reciprocalRankFusion } from "./rag/rrf.ts";
 import { startHybridTrace } from "./rag/tracing.ts";
+import { getSharedVectorIndex } from "./rag/vector-index-singleton.ts";
 import { vectorSearchPooled } from "./rag/vector-pool.ts";
 
 export const HYBRID_EMBEDDING_MODEL_KEY = "gemini-embedding-2";
@@ -161,12 +160,6 @@ export interface HybridSearcher {
  * in-memory `vectors.bin` index used by the RAG pipeline.
  */
 export class HybridSearcherImpl implements HybridSearcher {
-	private vectorIndex: {
-		meta: Array<{ normId: string; blockId: string }>;
-		vectors: InMemoryVectorIndex;
-		dims: number;
-	} | null = null;
-	private vectorIndexPromise: Promise<void> | null = null;
 	private cache = new QueryEmbeddingCache(1000);
 
 	constructor(
@@ -187,29 +180,17 @@ export class HybridSearcherImpl implements HybridSearcher {
 	}
 
 	private async getVectorIndex() {
-		if (this.vectorIndex) return this.vectorIndex;
-		if (!this.vectorIndexPromise) {
-			this.vectorIndexPromise = ensureVectorIndex(
-				this.db,
-				this.modelKey,
-				this.dataDir,
-			)
-				.then((idx) => {
-					if (!idx) {
-						throw new Error(
-							`No vector index available for model ${this.modelKey}. Run sync-embeddings.ts first.`,
-						);
-					}
-					this.vectorIndex = idx;
-				})
-				.catch((err) => {
-					this.vectorIndexPromise = null;
-					throw err;
-				});
+		const idx = await getSharedVectorIndex(
+			this.db,
+			this.modelKey,
+			this.dataDir,
+		);
+		if (!idx) {
+			throw new Error(
+				`No vector index available for model ${this.modelKey}. Run sync-embeddings.ts first.`,
+			);
 		}
-		await this.vectorIndexPromise;
-		if (!this.vectorIndex) throw new Error("Vector index failed to load");
-		return this.vectorIndex;
+		return idx;
 	}
 
 	async rankNorms(

--- a/packages/api/src/services/rag/pipeline.ts
+++ b/packages/api/src/services/rag/pipeline.ts
@@ -396,7 +396,7 @@ export class RagPipeline {
 	async *askStream(request: AskRequest): AsyncGenerator<
 		| { type: "chunk"; text: string }
 		| { type: "keepalive" }
-		| { type: "progress"; step: ProgressStep; label: string }
+		| { type: "progress"; step: ProgressStep }
 		| {
 				type: "done";
 				citations: Citation[];
@@ -415,16 +415,12 @@ export class RagPipeline {
 			// Emit the first progress event before any awaits — the client
 			// gets a label as soon as the SSE stream opens, killing the
 			// "30s of mute spinner" perception.
-			yield {
-				type: "progress",
-				step: "analyzing",
-				label: "Entendiendo tu pregunta…",
-			};
+			yield { type: "progress", step: "analyzing" };
 
 			// Buffer for `progress` events emitted from inside runRetrievalCore.
 			// The callback fires synchronously from a worker awaiting context;
 			// we drain the buffer between awaits in the keepalive loop.
-			const progressBuffer: Array<{ step: ProgressStep; label: string }> = [];
+			const progressBuffer: Array<{ step: ProgressStep }> = [];
 
 			// Retrieval can take >100s on the production server, longer than the
 			// Cloudflare Tunnel idle timeout. Interleave keepalive events every
@@ -439,8 +435,8 @@ export class RagPipeline {
 				embeddedNormIds: this.getEmbeddedNormIdsCached(),
 				vectorIndex: await this.getVectorIndex(),
 				trace,
-				onProgress: (step, label) => {
-					progressBuffer.push({ step, label });
+				onProgress: (step) => {
+					progressBuffer.push({ step });
 				},
 			});
 			let retrievalDone = false;
@@ -458,7 +454,7 @@ export class RagPipeline {
 				// Drain buffered progress events before yielding keepalive/done.
 				while (progressBuffer.length > 0) {
 					const p = progressBuffer.shift()!;
-					yield { type: "progress", step: p.step, label: p.label };
+					yield { type: "progress", step: p.step };
 				}
 				if (winner === "tick" && !retrievalDone) {
 					yield { type: "keepalive" };
@@ -525,11 +521,7 @@ export class RagPipeline {
 
 			const { articles, useTemporal, bestScore } = retrieval;
 
-			yield {
-				type: "progress",
-				step: "writing",
-				label: "Redactando la respuesta con citas…",
-			};
+			yield { type: "progress", step: "writing" };
 
 			const { evidenceText, systemPrompt } = buildEvidence({
 				db: this.db,

--- a/packages/api/src/services/rag/pipeline.ts
+++ b/packages/api/src/services/rag/pipeline.ts
@@ -464,7 +464,7 @@ export class RagPipeline {
 			// tick race resolved but before the loop re-checked the buffer.
 			while (progressBuffer.length > 0) {
 				const p = progressBuffer.shift()!;
-				yield { type: "progress", step: p.step, label: p.label };
+				yield { type: "progress", step: p.step };
 			}
 			const retrieval = await retrievalPromise;
 

--- a/packages/api/src/services/rag/pipeline.ts
+++ b/packages/api/src/services/rag/pipeline.ts
@@ -19,14 +19,11 @@ import {
 	ensureBlocksFts,
 	ensureBlocksFtsVocab,
 } from "./blocks-fts.ts";
-import {
-	ensureVectorIndex,
-	getEmbeddedNormIds,
-	getEmbeddingCount,
-} from "./embeddings.ts";
+import { getEmbeddedNormIds, getEmbeddingCount } from "./embeddings.ts";
 import {
 	EMBEDDING_MODEL_KEY,
 	LOW_CONFIDENCE_THRESHOLD,
+	type ProgressStep,
 	type RetrievedArticle,
 	runRetrievalCore,
 	TOP_K,
@@ -42,6 +39,7 @@ import {
 	verifyCitations,
 } from "./synthesis.ts";
 import { type RagTrace, startTrace } from "./tracing.ts";
+import { getSharedVectorIndex } from "./vector-index-singleton.ts";
 
 export { normalizePeriodicTitle } from "./analyzer.ts";
 // Re-exports kept for backwards compatibility with existing tests + external
@@ -88,8 +86,6 @@ const DECLINE_LOW_CONFIDENCE =
 export class RagPipeline {
 	private cohereApiKey: string | null;
 	private embeddedNormIds: string[] | null = null;
-	private vectorIndex: Awaited<ReturnType<typeof ensureVectorIndex>> = null;
-	private vectorIndexPromise: Promise<void> | null = null;
 
 	private insertSummaryStmt: ReturnType<Database["prepare"]>;
 	private insertAskLogStmt: ReturnType<Database["prepare"]>;
@@ -400,6 +396,7 @@ export class RagPipeline {
 	async *askStream(request: AskRequest): AsyncGenerator<
 		| { type: "chunk"; text: string }
 		| { type: "keepalive" }
+		| { type: "progress"; step: ProgressStep; label: string }
 		| {
 				type: "done";
 				citations: Citation[];
@@ -415,6 +412,20 @@ export class RagPipeline {
 		});
 
 		try {
+			// Emit the first progress event before any awaits — the client
+			// gets a label as soon as the SSE stream opens, killing the
+			// "30s of mute spinner" perception.
+			yield {
+				type: "progress",
+				step: "analyzing",
+				label: "Entendiendo tu pregunta…",
+			};
+
+			// Buffer for `progress` events emitted from inside runRetrievalCore.
+			// The callback fires synchronously from a worker awaiting context;
+			// we drain the buffer between awaits in the keepalive loop.
+			const progressBuffer: Array<{ step: ProgressStep; label: string }> = [];
+
 			// Retrieval can take >100s on the production server, longer than the
 			// Cloudflare Tunnel idle timeout. Interleave keepalive events every
 			// 10s so the route handler can flush an SSE comment and the proxy
@@ -428,6 +439,9 @@ export class RagPipeline {
 				embeddedNormIds: this.getEmbeddedNormIdsCached(),
 				vectorIndex: await this.getVectorIndex(),
 				trace,
+				onProgress: (step, label) => {
+					progressBuffer.push({ step, label });
+				},
 			});
 			let retrievalDone = false;
 			retrievalPromise.finally(() => {
@@ -441,9 +455,20 @@ export class RagPipeline {
 					retrievalPromise.then(() => "done" as const),
 					tick,
 				]);
+				// Drain buffered progress events before yielding keepalive/done.
+				while (progressBuffer.length > 0) {
+					const p = progressBuffer.shift()!;
+					yield { type: "progress", step: p.step, label: p.label };
+				}
 				if (winner === "tick" && !retrievalDone) {
 					yield { type: "keepalive" };
 				}
+			}
+			// Final drain in case the last progress event landed after the
+			// tick race resolved but before the loop re-checked the buffer.
+			while (progressBuffer.length > 0) {
+				const p = progressBuffer.shift()!;
+				yield { type: "progress", step: p.step, label: p.label };
 			}
 			const retrieval = await retrievalPromise;
 
@@ -499,6 +524,13 @@ export class RagPipeline {
 			}
 
 			const { articles, useTemporal, bestScore } = retrieval;
+
+			yield {
+				type: "progress",
+				step: "writing",
+				label: "Redactando la respuesta con citas…",
+			};
+
 			const { evidenceText, systemPrompt } = buildEvidence({
 				db: this.db,
 				articles,
@@ -674,26 +706,12 @@ export class RagPipeline {
 
 	/**
 	 * Ensure the flat binary vector index exists and is up to date.
-	 * Built once from SQLite on first request (~30s), then cached.
+	 * Built once from SQLite on first request (~30s) and shared
+	 * process-wide via `getSharedVectorIndex` so `/v1/laws` (hybrid search)
+	 * and `/v1/ask` (RAG) don't load `vectors-int8.bin` twice.
 	 */
 	private async getVectorIndex() {
-		if (this.vectorIndex) return this.vectorIndex;
-		if (!this.vectorIndexPromise) {
-			this.vectorIndexPromise = ensureVectorIndex(
-				this.db,
-				EMBEDDING_MODEL_KEY,
-				this.dataDir,
-			)
-				.then((idx) => {
-					this.vectorIndex = idx;
-				})
-				.catch((err) => {
-					this.vectorIndexPromise = null;
-					throw err;
-				});
-		}
-		await this.vectorIndexPromise;
-		return this.vectorIndex;
+		return getSharedVectorIndex(this.db, EMBEDDING_MODEL_KEY, this.dataDir);
 	}
 
 	/**

--- a/packages/api/src/services/rag/retrieval.ts
+++ b/packages/api/src/services/rag/retrieval.ts
@@ -491,6 +491,8 @@ const ANCHOR_RANKS = new Set([
 	"constitucion",
 ]);
 
+export type ProgressStep = "analyzing" | "retrieving" | "ranking" | "writing";
+
 export type RunRetrievalCoreOpts = {
 	db: Database;
 	apiKey: string;
@@ -504,6 +506,13 @@ export type RunRetrievalCoreOpts = {
 		dims: number;
 	} | null;
 	trace?: RagTrace;
+	/**
+	 * Optional progress callback. Fired at phase boundaries inside the
+	 * retrieval pipeline (`retrieving` before vector/BM25 fan-out, `ranking`
+	 * before the Cohere/LLM rerank). The streaming route consumes these to
+	 * surface SSE `progress` events; non-streaming callers can omit.
+	 */
+	onProgress?: (step: ProgressStep, label: string) => void;
 };
 
 /**
@@ -527,6 +536,7 @@ export async function runRetrievalCore(
 		embeddedNormIds,
 		vectorIndex,
 		trace,
+		onProgress,
 	} = opts;
 
 	// 1. Analyze + embed query in parallel.
@@ -595,6 +605,8 @@ export async function runRetrievalCore(
 		minSimilarity: MIN_SIMILARITY,
 		embeddingDims: queryResult.embedding.length,
 	});
+
+	onProgress?.("retrieving", "Buscando entre 12.000 leyes…");
 
 	const parallelStart = Date.now();
 	const bm25BreakT = performance.now();
@@ -830,6 +842,7 @@ export async function runRetrievalCore(
 	let rerankerBackend = "none";
 
 	if (allFusedArticles.length > TOP_K) {
+		onProgress?.("ranking", "Seleccionando los artículos más relevantes…");
 		const candidates: RerankerCandidate[] = allFusedArticles.map((a) => ({
 			key: `${a.normId}:${a.blockId}`,
 			title: `${a.blockTitle} — ${describeNormScope(a.rank, resolveJurisdiction(a.sourceUrl, a.normId))}: ${a.normTitle}`,

--- a/packages/api/src/services/rag/retrieval.ts
+++ b/packages/api/src/services/rag/retrieval.ts
@@ -512,7 +512,7 @@ export type RunRetrievalCoreOpts = {
 	 * before the Cohere/LLM rerank). The streaming route consumes these to
 	 * surface SSE `progress` events; non-streaming callers can omit.
 	 */
-	onProgress?: (step: ProgressStep, label: string) => void;
+	onProgress?: (step: ProgressStep) => void;
 };
 
 /**
@@ -606,7 +606,7 @@ export async function runRetrievalCore(
 		embeddingDims: queryResult.embedding.length,
 	});
 
-	onProgress?.("retrieving", "Buscando entre 12.000 leyes…");
+	onProgress?.("retrieving");
 
 	const parallelStart = Date.now();
 	const bm25BreakT = performance.now();
@@ -842,7 +842,7 @@ export async function runRetrievalCore(
 	let rerankerBackend = "none";
 
 	if (allFusedArticles.length > TOP_K) {
-		onProgress?.("ranking", "Seleccionando los artículos más relevantes…");
+		onProgress?.("ranking");
 		const candidates: RerankerCandidate[] = allFusedArticles.map((a) => ({
 			key: `${a.normId}:${a.blockId}`,
 			title: `${a.blockTitle} — ${describeNormScope(a.rank, resolveJurisdiction(a.sourceUrl, a.normId))}: ${a.normTitle}`,

--- a/packages/api/src/services/rag/vector-index-singleton.ts
+++ b/packages/api/src/services/rag/vector-index-singleton.ts
@@ -17,17 +17,34 @@ type VectorIndex = Awaited<ReturnType<typeof ensureVectorIndex>>;
 
 let cached: VectorIndex = null;
 let inflight: Promise<VectorIndex> | null = null;
+let loadedModelKey: string | null = null;
+let loadedDataDir: string | null = null;
 
 export async function getSharedVectorIndex(
 	db: Database,
 	modelKey: string,
 	dataDir: string,
 ): Promise<VectorIndex> {
-	if (cached) return cached;
+	if (cached) {
+		if (
+			process.env.NODE_ENV !== "production" &&
+			(modelKey !== loadedModelKey || dataDir !== loadedDataDir)
+		) {
+			console.warn(
+				`[vector-index-singleton] cache hit ignores divergent params: ` +
+					`requested modelKey="${modelKey}" dataDir="${dataDir}", ` +
+					`cached modelKey="${loadedModelKey}" dataDir="${loadedDataDir}". ` +
+					`Returning cached index regardless.`,
+			);
+		}
+		return cached;
+	}
 	if (!inflight) {
 		inflight = ensureVectorIndex(db, modelKey, dataDir)
 			.then((idx) => {
 				cached = idx;
+				loadedModelKey = modelKey;
+				loadedDataDir = dataDir;
 				return idx;
 			})
 			.catch((err) => {
@@ -42,4 +59,6 @@ export async function getSharedVectorIndex(
 export function _resetSharedVectorIndexForTests(): void {
 	cached = null;
 	inflight = null;
+	loadedModelKey = null;
+	loadedDataDir = null;
 }

--- a/packages/api/src/services/rag/vector-index-singleton.ts
+++ b/packages/api/src/services/rag/vector-index-singleton.ts
@@ -1,0 +1,45 @@
+/**
+ * Process-wide singleton for the flat binary vector index.
+ *
+ * Both `RagPipeline` (used by `/v1/ask`) and `HybridSearcherImpl` (used by
+ * `/v1/laws` hybrid mode) need the same `vectors-int8.bin` mapped into RAM.
+ * Before this singleton each owned its own private cache and the file got
+ * loaded twice on the first request that hit a path the other had not warmed
+ * up yet — adding ~5s to the first `/v1/ask` after a `/v1/laws` call.
+ *
+ * The single in-flight promise also dedupes concurrent first-callers so
+ * parallel cold requests can't trigger two parallel loads.
+ */
+import type { Database } from "bun:sqlite";
+import { ensureVectorIndex } from "./embeddings.ts";
+
+type VectorIndex = Awaited<ReturnType<typeof ensureVectorIndex>>;
+
+let cached: VectorIndex = null;
+let inflight: Promise<VectorIndex> | null = null;
+
+export async function getSharedVectorIndex(
+	db: Database,
+	modelKey: string,
+	dataDir: string,
+): Promise<VectorIndex> {
+	if (cached) return cached;
+	if (!inflight) {
+		inflight = ensureVectorIndex(db, modelKey, dataDir)
+			.then((idx) => {
+				cached = idx;
+				return idx;
+			})
+			.catch((err) => {
+				inflight = null;
+				throw err;
+			});
+	}
+	return inflight;
+}
+
+/** Test-only: drop the cached index so unit tests can force a fresh load. */
+export function _resetSharedVectorIndexForTests(): void {
+	cached = null;
+	inflight = null;
+}

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -12,11 +12,13 @@
 		"astro": "6.1.9",
 		"diff2html": "3.4.56",
 		"js-yaml": "4.1.1",
+		"markdown-it": "^14.1.1",
 		"react": "^19.2.5",
 		"react-dom": "^19.2.5",
 		"sanitize-html": "^2.17.2"
 	},
 	"devDependencies": {
+		"@types/markdown-it": "^14.1.2",
 		"@types/react": "^19.2.14",
 		"@types/react-dom": "^19.2.3",
 		"@types/sanitize-html": "^2.16.1",

--- a/packages/web/src/components/AskChat.tsx
+++ b/packages/web/src/components/AskChat.tsx
@@ -6,7 +6,14 @@
  * Uses SSE streaming for real-time text display.
  */
 
+import MarkdownIt from "markdown-it";
 import { type ReactNode, useEffect, useRef, useState } from "react";
+
+// ── Markdown renderer ──
+// `html: false` means raw HTML inside the markdown is escaped — Gemini output
+// is trusted but we still keep the guard. `linkify: false` so we don't
+// auto-link random URLs (the rendered text is already very citation-heavy).
+const md = new MarkdownIt({ html: false, breaks: true, linkify: false });
 
 interface Citation {
 	normId: string;
@@ -32,10 +39,27 @@ interface AskResponse {
 	meta: AskMeta;
 }
 
+type ProgressStep = "analyzing" | "retrieving" | "ranking" | "writing";
+
+const PROGRESS_ORDER: ProgressStep[] = [
+	"analyzing",
+	"retrieving",
+	"ranking",
+	"writing",
+];
+
+const PROGRESS_LABELS: Record<ProgressStep, string> = {
+	analyzing: "Analizando tu pregunta",
+	retrieving: "Buscando artículos relevantes",
+	ranking: "Seleccionando las fuentes más fiables",
+	writing: "Redactando la respuesta",
+};
+
 interface Turn {
 	question: string;
 	response: AskResponse | null;
 	error: string | null;
+	currentStep?: ProgressStep;
 }
 
 const API_BASE =
@@ -66,105 +90,229 @@ function buildCitationMap(
 	return map;
 }
 
+/**
+ * Render a plain text run, splitting out citation matches and replacing them
+ * with interactive React links + tooltips. Used both for the markdown path
+ * (per text-node) and as a fallback during SSR / pre-hydration.
+ */
+function renderTextWithCitations(
+	text: string,
+	citationMap: Map<string, Map<string, Citation>>,
+	keyPrefix: string,
+): ReactNode[] {
+	const parts: ReactNode[] = [];
+	let lastIndex = 0;
+	let matchIdx = 0;
+
+	for (const match of text.matchAll(CITE_PATTERN)) {
+		const start = match.index;
+		if (start > lastIndex) {
+			parts.push(text.slice(lastIndex, start));
+		}
+
+		const normId = match[1]!;
+		const articleRef = match[2]!;
+		const fullMatch = match[0];
+		const citationByArticle = citationMap.get(normId);
+		const citation =
+			citationByArticle?.get(articleRef.toLowerCase()) ??
+			[...(citationByArticle?.values() ?? [])][0];
+
+		if (citation) {
+			parts.push(
+				<span
+					key={`${keyPrefix}-cite-${matchIdx}`}
+					className="ask-cite-wrapper"
+				>
+					<a
+						href={`/laws/${normId}/${citation.anchor ? `#${citation.anchor}` : ""}`}
+						target="_blank"
+						rel="noopener noreferrer"
+						className={`ask-cite-link${citation.verified === false ? " ask-cite-approx" : ""}`}
+						title={
+							citation.verified === false ? "Referencia aproximada" : undefined
+						}
+					>
+						{articleRef}
+						<svg
+							className="ask-cite-icon"
+							width="12"
+							height="12"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							strokeWidth="2.5"
+							strokeLinecap="round"
+							strokeLinejoin="round"
+							aria-hidden="true"
+						>
+							<path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+							<polyline points="15 3 21 3 21 9" />
+							<line x1="10" y1="14" x2="21" y2="3" />
+						</svg>
+					</a>
+					<span className="ask-cite-tooltip" role="tooltip">
+						<span className="ask-cite-tooltip-norm">
+							{citation.normTitle || normId}
+						</span>
+						<span className="ask-cite-tooltip-article">
+							{citation.articleTitle}
+						</span>
+						{citation.citizenSummary && (
+							<span className="ask-cite-tooltip-summary">
+								{citation.citizenSummary}
+							</span>
+						)}
+						<span className="ask-cite-tooltip-action">Ver en Ley Abierta</span>
+					</span>
+				</span>,
+			);
+		} else {
+			parts.push(fullMatch);
+		}
+
+		lastIndex = start + fullMatch.length;
+		matchIdx++;
+	}
+
+	if (lastIndex < text.length) {
+		parts.push(text.slice(lastIndex));
+	}
+
+	return parts;
+}
+
+/**
+ * Convert a DOM node tree (from markdown-it output, parsed via DOMParser) into
+ * a React element tree. Text nodes go through `renderTextWithCitations` so the
+ * `[BOE-A-XXXX-XXXX, Artículo N]` patterns become tooltipped links even when
+ * they appear inside list items, paragraphs, headings, etc.
+ */
+function domToReact(
+	node: Node,
+	citationMap: Map<string, Map<string, Citation>>,
+	keyPrefix: string,
+): ReactNode {
+	if (node.nodeType === Node.TEXT_NODE) {
+		const text = node.nodeValue ?? "";
+		if (!text) return null;
+		const rendered = renderTextWithCitations(text, citationMap, keyPrefix);
+		// Single string fragment: return as-is (React handles it fine).
+		if (rendered.length === 1 && typeof rendered[0] === "string") {
+			return rendered[0];
+		}
+		return <>{rendered}</>;
+	}
+
+	if (node.nodeType !== Node.ELEMENT_NODE) return null;
+
+	const el = node as Element;
+	const tag = el.tagName.toLowerCase();
+
+	// Skip <script>/<style> defensively (markdown-it shouldn't emit these
+	// with `html: false` but belt-and-braces).
+	if (tag === "script" || tag === "style") return null;
+
+	const children: ReactNode[] = [];
+	for (let i = 0; i < el.childNodes.length; i++) {
+		const child = el.childNodes[i];
+		if (!child) continue;
+		const rendered = domToReact(child, citationMap, `${keyPrefix}-${i}`);
+		if (rendered !== null && rendered !== undefined) children.push(rendered);
+	}
+
+	const props: Record<string, unknown> = { key: keyPrefix };
+
+	// Carry over href on links (markdown-it can still emit links from auto-
+	// detected URLs even with linkify off — be safe).
+	if (tag === "a") {
+		const href = el.getAttribute("href");
+		if (href) {
+			props.href = href;
+			props.target = "_blank";
+			props.rel = "noopener noreferrer";
+		}
+	}
+
+	// Self-closing tags
+	if (tag === "br") return <br key={keyPrefix} />;
+	if (tag === "hr") return <hr key={keyPrefix} />;
+
+	// Allow-list of structural tags markdown-it produces. Anything outside
+	// this set falls back to <span>.
+	const allowed = new Set([
+		"p",
+		"strong",
+		"em",
+		"ul",
+		"ol",
+		"li",
+		"h1",
+		"h2",
+		"h3",
+		"h4",
+		"h5",
+		"h6",
+		"code",
+		"pre",
+		"blockquote",
+		"a",
+		"br",
+		"hr",
+		"del",
+		"s",
+		"span",
+		"div",
+		"table",
+		"thead",
+		"tbody",
+		"tr",
+		"th",
+		"td",
+	]);
+	const safeTag = allowed.has(tag) ? tag : "span";
+
+	// biome-ignore lint/suspicious/noExplicitAny: dynamic tag name needs cast for React.createElement equivalent
+	const Tag = safeTag as any;
+	return (
+		<Tag {...props} key={keyPrefix}>
+			{children.length > 0 ? children : null}
+		</Tag>
+	);
+}
+
 function renderAnswerWithCitations(
 	text: string,
 	citations: Citation[],
-): ReactNode[] {
+): ReactNode {
 	const citationMap = buildCitationMap(citations);
-	const paragraphs = text.split("\n").filter((p) => p.trim());
 
-	return paragraphs.map((paragraph, pIdx) => {
-		const parts: ReactNode[] = [];
-		let lastIndex = 0;
-
-		for (const match of paragraph.matchAll(CITE_PATTERN)) {
-			if (match.index > lastIndex) {
-				parts.push(paragraph.slice(lastIndex, match.index));
-			}
-
-			const normId = match[1];
-			const articleRef = match[2];
-			const fullMatch = match[0];
-			const citationByArticle = citationMap.get(normId);
-			const citation =
-				citationByArticle?.get(articleRef.toLowerCase()) ??
-				[...(citationByArticle?.values() ?? [])][0];
-
-			if (citation) {
-				parts.push(
-					<span
-						key={`${normId}-${articleRef}-${match.index}`}
-						className="ask-cite-wrapper"
-					>
-						<a
-							href={`/laws/${normId}/${citation.anchor ? `#${citation.anchor}` : ""}`}
-							target="_blank"
-							rel="noopener noreferrer"
-							className={`ask-cite-link${citation.verified === false ? " ask-cite-approx" : ""}`}
-							title={
-								citation.verified === false
-									? "Referencia aproximada"
-									: undefined
-							}
-						>
-							{articleRef}
-							<svg
-								className="ask-cite-icon"
-								width="12"
-								height="12"
-								viewBox="0 0 24 24"
-								fill="none"
-								stroke="currentColor"
-								strokeWidth="2.5"
-								strokeLinecap="round"
-								strokeLinejoin="round"
-								aria-hidden="true"
-							>
-								<path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
-								<polyline points="15 3 21 3 21 9" />
-								<line x1="10" y1="14" x2="21" y2="3" />
-							</svg>
-						</a>
-						<span className="ask-cite-tooltip" role="tooltip">
-							<span className="ask-cite-tooltip-norm">
-								{citation.normTitle || normId}
-							</span>
-							<span className="ask-cite-tooltip-article">
-								{citation.articleTitle}
-							</span>
-							{citation.citizenSummary && (
-								<span className="ask-cite-tooltip-summary">
-									{citation.citizenSummary}
-								</span>
-							)}
-							<span className="ask-cite-tooltip-action">
-								Ver en Ley Abierta
-							</span>
-						</span>
-					</span>,
-				);
-			} else {
-				parts.push(fullMatch);
-			}
-
-			lastIndex = match.index + match[0].length;
-		}
-
-		if (lastIndex < paragraph.length) {
-			parts.push(paragraph.slice(lastIndex));
-		}
-
-		if (parts.length === 0) {
-			parts.push(paragraph);
-		}
-
+	// SSR / no DOMParser (shouldn't happen in this island, but be defensive):
+	// render as a single paragraph with citation replacement only.
+	if (typeof DOMParser === "undefined") {
 		return (
-			// biome-ignore lint/suspicious/noArrayIndexKey: paragraphs have no stable ID
-			<p key={pIdx} className="ask-answer-paragraph">
-				{parts}
+			<p className="ask-answer-paragraph">
+				{renderTextWithCitations(text, citationMap, "ssr")}
 			</p>
 		);
-	});
+	}
+
+	const html = md.render(text);
+	const doc = new DOMParser().parseFromString(
+		`<div>${html}</div>`,
+		"text/html",
+	);
+	const root = doc.body.firstElementChild;
+	if (!root) return null;
+
+	const children: ReactNode[] = [];
+	for (let i = 0; i < root.childNodes.length; i++) {
+		const child = root.childNodes[i];
+		if (!child) continue;
+		const rendered = domToReact(child, citationMap, `md-${i}`);
+		if (rendered !== null && rendered !== undefined) children.push(rendered);
+	}
+	return <>{children}</>;
 }
 
 // ── SSE parsing ──
@@ -221,6 +369,203 @@ function saveTurns(turns: Turn[]) {
 	} catch {
 		/* ignore */
 	}
+}
+
+// ── Progress stepper ──
+
+function StepIcon({
+	step,
+	state,
+}: {
+	step: ProgressStep;
+	state: "done" | "active" | "pending";
+}) {
+	if (state === "done") {
+		return (
+			<svg
+				className="ask-step-icon ask-step-icon-done"
+				width="22"
+				height="22"
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				strokeWidth="2.5"
+				strokeLinecap="round"
+				strokeLinejoin="round"
+				aria-hidden="true"
+			>
+				<polyline points="20 6 9 17 4 12" />
+			</svg>
+		);
+	}
+
+	const animClass = state === "active" ? " ask-step-anim" : "";
+
+	if (step === "analyzing") {
+		// Magnifying glass with a soft pulse on the lens.
+		return (
+			<svg
+				className={`ask-step-icon ask-step-icon-analyzing${animClass}`}
+				width="22"
+				height="22"
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				strokeWidth="2"
+				strokeLinecap="round"
+				strokeLinejoin="round"
+				aria-hidden="true"
+			>
+				<circle cx="11" cy="11" r="7" className="ask-step-lens" />
+				<line x1="21" y1="21" x2="16.65" y2="16.65" />
+			</svg>
+		);
+	}
+
+	if (step === "retrieving") {
+		// Stack of three documents that gently shift up/down.
+		return (
+			<svg
+				className={`ask-step-icon ask-step-icon-retrieving${animClass}`}
+				width="22"
+				height="22"
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				strokeWidth="1.6"
+				strokeLinecap="round"
+				strokeLinejoin="round"
+				aria-hidden="true"
+			>
+				<rect
+					x="6"
+					y="3"
+					width="12"
+					height="14"
+					rx="1.5"
+					className="ask-doc ask-doc-1"
+				/>
+				<rect
+					x="6"
+					y="5"
+					width="12"
+					height="14"
+					rx="1.5"
+					className="ask-doc ask-doc-2"
+				/>
+				<rect
+					x="6"
+					y="7"
+					width="12"
+					height="14"
+					rx="1.5"
+					className="ask-doc ask-doc-3"
+				/>
+			</svg>
+		);
+	}
+
+	if (step === "ranking") {
+		// Three bars that scale vertically at staggered phases.
+		return (
+			<svg
+				className={`ask-step-icon ask-step-icon-ranking${animClass}`}
+				width="22"
+				height="22"
+				viewBox="0 0 24 24"
+				fill="currentColor"
+				stroke="none"
+				aria-hidden="true"
+			>
+				<rect
+					x="4"
+					y="14"
+					width="4"
+					height="6"
+					rx="1"
+					className="ask-bar ask-bar-1"
+				/>
+				<rect
+					x="10"
+					y="10"
+					width="4"
+					height="10"
+					rx="1"
+					className="ask-bar ask-bar-2"
+				/>
+				<rect
+					x="16"
+					y="6"
+					width="4"
+					height="14"
+					rx="1"
+					className="ask-bar ask-bar-3"
+				/>
+			</svg>
+		);
+	}
+
+	// writing — pen + a blinking underline cursor.
+	return (
+		<svg
+			className={`ask-step-icon ask-step-icon-writing${animClass}`}
+			width="22"
+			height="22"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="2"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			aria-hidden="true"
+		>
+			<path d="M16 3l5 5-11 11H5v-5L16 3z" />
+			<line
+				x1="5"
+				y1="22"
+				x2="14"
+				y2="22"
+				className="ask-cursor"
+				strokeWidth="2.5"
+			/>
+		</svg>
+	);
+}
+
+function AskProgressStepper({ current }: { current: ProgressStep }) {
+	const currentIdx = PROGRESS_ORDER.indexOf(current);
+	return (
+		<div
+			className="ask-progress-stepper"
+			role="status"
+			aria-live="polite"
+			aria-label="Progreso de la respuesta"
+		>
+			<ol className="ask-progress-list">
+				{PROGRESS_ORDER.map((step, idx) => {
+					const state =
+						idx < currentIdx
+							? "done"
+							: idx === currentIdx
+								? "active"
+								: "pending";
+					return (
+						<li
+							key={step}
+							className={`ask-progress-item ask-progress-${state}`}
+						>
+							<span className="ask-progress-icon-wrap" aria-hidden="true">
+								<StepIcon step={step} state={state} />
+							</span>
+							<span className="ask-progress-label">
+								{PROGRESS_LABELS[step]}
+							</span>
+						</li>
+					);
+				})}
+			</ol>
+		</div>
+	);
 }
 
 export default function AskChat() {
@@ -322,7 +667,29 @@ export default function AskChat() {
 			}
 
 			for await (const sseEvent of parseSSE(res)) {
-				if (sseEvent.event === "chunk") {
+				if (sseEvent.event === "progress") {
+					try {
+						const progress = JSON.parse(sseEvent.data) as {
+							step: ProgressStep;
+							label?: string;
+						};
+						if (PROGRESS_ORDER.includes(progress.step)) {
+							setTurns((prev) => {
+								const updated = [...prev];
+								const turn = updated[turnIndex];
+								if (turn) {
+									updated[turnIndex] = {
+										...turn,
+										currentStep: progress.step,
+									};
+								}
+								return updated;
+							});
+						}
+					} catch {
+						/* ignore malformed progress events */
+					}
+				} else if (sseEvent.event === "chunk") {
 					pendingText += JSON.parse(sseEvent.data) as string;
 					if (!rafId) {
 						rafId = requestAnimationFrame(() => {
@@ -560,12 +927,21 @@ export default function AskChat() {
 						</div>
 					))}
 
-					{loading && !turns[turns.length - 1]?.response?.answer && (
-						<div className="ask-loading" role="status" aria-live="polite">
-							<span className="ask-spinner-large" aria-hidden="true" />
-							<p>Buscando en la legislación española...</p>
-						</div>
-					)}
+					{loading &&
+						!turns[turns.length - 1]?.response?.answer &&
+						(() => {
+							const lastTurn = turns[turns.length - 1];
+							const step = lastTurn?.currentStep;
+							if (step) {
+								return <AskProgressStepper current={step} />;
+							}
+							return (
+								<div className="ask-loading" role="status" aria-live="polite">
+									<span className="ask-spinner-large" aria-hidden="true" />
+									<p>Buscando en la legislación española...</p>
+								</div>
+							);
+						})()}
 
 					<div ref={bottomRef} />
 				</div>

--- a/packages/web/src/components/AskChat.tsx
+++ b/packages/web/src/components/AskChat.tsx
@@ -284,8 +284,25 @@ function domToReact(
 function renderAnswerWithCitations(
 	text: string,
 	citations: Citation[],
+	streaming = false,
 ): ReactNode {
 	const citationMap = buildCitationMap(citations);
+
+	// During streaming, skip the expensive markdown parse + DOMParser round-trip.
+	// Citations aren't available yet (they arrive with the `done` event), so we
+	// just render plain paragraphs split by newline.
+	if (streaming) {
+		return (
+			<>
+				{text.split("\n").map((line, i) => (
+					// biome-ignore lint/suspicious/noArrayIndexKey: streaming lines have no stable ID
+					<p key={i} className="ask-answer-paragraph">
+						{line}
+					</p>
+				))}
+			</>
+		);
+	}
 
 	// SSR / no DOMParser (shouldn't happen in this island, but be defensive):
 	// render as a single paragraph with citation replacement only.
@@ -574,11 +591,18 @@ export default function AskChat() {
 	const [loading, setLoading] = useState(false);
 	const inputRef = useRef<HTMLTextAreaElement>(null);
 	const bottomRef = useRef<HTMLDivElement>(null);
+	const abortRef = useRef<AbortController | null>(null);
 
 	useEffect(() => {
 		saveTurns(turns);
 		bottomRef.current?.scrollIntoView({ behavior: "smooth" });
 	}, [turns]);
+
+	useEffect(() => {
+		return () => {
+			abortRef.current?.abort();
+		};
+	}, []);
 
 	async function handleSubmit(q?: string) {
 		const text = (q ?? question).trim();
@@ -593,10 +617,15 @@ export default function AskChat() {
 		setLoading(true);
 
 		try {
+			abortRef.current?.abort();
+			const controller = new AbortController();
+			abortRef.current = controller;
+
 			const res = await fetch(`${API_BASE}/v1/ask/stream`, {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ question: text }),
+				signal: controller.signal,
 			});
 
 			if (res.status === 429) {
@@ -738,7 +767,11 @@ export default function AskChat() {
 					});
 				}
 			}
-		} catch {
+		} catch (err) {
+			if (err instanceof Error && err.name === "AbortError") {
+				// Expected on unmount or new submit — don't show error.
+				return;
+			}
 			setTurns((prev) => {
 				const updated = [...prev];
 				updated[turnIndex] = {
@@ -773,6 +806,8 @@ export default function AskChat() {
 	}
 
 	const hasHistory = turns.length > 0;
+	const lastTurn = turns.at(-1);
+	const showStepper = loading && !lastTurn?.response?.answer;
 
 	return (
 		<div className="ask-chat">
@@ -842,6 +877,7 @@ export default function AskChat() {
 												{renderAnswerWithCitations(
 													turn.response.answer,
 													turn.response.citations,
+													loading && turn === lastTurn,
 												)}
 											</div>
 
@@ -927,21 +963,15 @@ export default function AskChat() {
 						</div>
 					))}
 
-					{loading &&
-						!turns[turns.length - 1]?.response?.answer &&
-						(() => {
-							const lastTurn = turns[turns.length - 1];
-							const step = lastTurn?.currentStep;
-							if (step) {
-								return <AskProgressStepper current={step} />;
-							}
-							return (
-								<div className="ask-loading" role="status" aria-live="polite">
-									<span className="ask-spinner-large" aria-hidden="true" />
-									<p>Buscando en la legislación española...</p>
-								</div>
-							);
-						})()}
+					{showStepper &&
+						(lastTurn?.currentStep ? (
+							<AskProgressStepper current={lastTurn.currentStep} />
+						) : (
+							<div className="ask-loading" role="status" aria-live="polite">
+								<span className="ask-spinner-large" aria-hidden="true" />
+								<p>Buscando en la legislación española...</p>
+							</div>
+						))}
 
 					<div ref={bottomRef} />
 				</div>

--- a/packages/web/src/components/AskChat.tsx
+++ b/packages/web/src/components/AskChat.tsx
@@ -700,7 +700,6 @@ export default function AskChat() {
 					try {
 						const progress = JSON.parse(sseEvent.data) as {
 							step: ProgressStep;
-							label?: string;
 						};
 						if (PROGRESS_ORDER.includes(progress.step)) {
 							setTurns((prev) => {

--- a/packages/web/src/pages/pregunta.astro
+++ b/packages/web/src/pages/pregunta.astro
@@ -453,7 +453,7 @@ import AskChat from "../components/AskChat.tsx";
 	:global(.ask-progress-pending .ask-step-icon) { color: var(--border-medium); }
 	:global(.ask-progress-active .ask-step-icon) { color: var(--accent); }
 	:global(.ask-step-icon-done) {
-		color: #2f855a; /* institutional green, calm */
+		color: var(--success); /* institutional green, calm */
 	}
 
 	/* analyzing — soft lens pulse */

--- a/packages/web/src/pages/pregunta.astro
+++ b/packages/web/src/pages/pregunta.astro
@@ -500,7 +500,7 @@ import AskChat from "../components/AskChat.tsx";
 	}
 
 	@media (prefers-reduced-motion: reduce) {
-		:global(.ask-step-anim .ask-lens),
+		:global(.ask-step-anim .ask-step-lens),
 		:global(.ask-step-anim .ask-doc),
 		:global(.ask-step-anim .ask-bar),
 		:global(.ask-step-anim .ask-cursor) {

--- a/packages/web/src/pages/pregunta.astro
+++ b/packages/web/src/pages/pregunta.astro
@@ -290,6 +290,224 @@ import AskChat from "../components/AskChat.tsx";
 		margin-bottom: 0;
 	}
 
+	/* Markdown elements rendered inside the answer.
+	   Tuned for institutional reading — no "ChatGPT" defaults. */
+	:global(.ask-answer-text h1),
+	:global(.ask-answer-text h2),
+	:global(.ask-answer-text h3),
+	:global(.ask-answer-text h4) {
+		font-family: var(--font-serif, Georgia, serif);
+		color: var(--text);
+		line-height: 1.3;
+		margin: 1.25rem 0 0.5rem;
+		font-weight: 600;
+	}
+
+	:global(.ask-answer-text h1) { font-size: 1.125rem; }
+	:global(.ask-answer-text h2) { font-size: 1.0625rem; }
+	:global(.ask-answer-text h3) { font-size: 1rem; }
+	:global(.ask-answer-text h4) { font-size: 0.9375rem; }
+
+	:global(.ask-answer-text h1:first-child),
+	:global(.ask-answer-text h2:first-child),
+	:global(.ask-answer-text h3:first-child),
+	:global(.ask-answer-text h4:first-child) {
+		margin-top: 0;
+	}
+
+	:global(.ask-answer-text strong) {
+		font-weight: 600;
+		color: var(--text);
+	}
+
+	:global(.ask-answer-text em) {
+		font-style: italic;
+	}
+
+	:global(.ask-answer-text ul),
+	:global(.ask-answer-text ol) {
+		margin: 0.5rem 0 0.75rem;
+		padding-left: 1.4rem;
+	}
+
+	:global(.ask-answer-text ul) { list-style: disc; }
+	:global(.ask-answer-text ol) { list-style: decimal; }
+
+	:global(.ask-answer-text li) {
+		margin-bottom: 0.3rem;
+		padding-left: 0.15rem;
+	}
+
+	:global(.ask-answer-text li:last-child) {
+		margin-bottom: 0;
+	}
+
+	:global(.ask-answer-text li::marker) {
+		color: var(--text-muted);
+	}
+
+	:global(.ask-answer-text code) {
+		font-family: var(--font-mono);
+		font-size: 0.85em;
+		background: var(--accent-bg-light);
+		color: var(--text);
+		padding: 0.1em 0.35em;
+		border-radius: 4px;
+		border: 1px solid var(--border-light);
+	}
+
+	:global(.ask-answer-text pre) {
+		background: var(--accent-bg-light);
+		border: 1px solid var(--border-light);
+		border-radius: 8px;
+		padding: 0.75rem 0.9rem;
+		overflow-x: auto;
+		font-size: 0.8125rem;
+		line-height: 1.5;
+		margin: 0.5rem 0 0.75rem;
+	}
+
+	:global(.ask-answer-text pre code) {
+		background: transparent;
+		border: 0;
+		padding: 0;
+		font-size: inherit;
+	}
+
+	:global(.ask-answer-text blockquote) {
+		border-left: 3px solid var(--border-medium);
+		padding: 0.15rem 0 0.15rem 0.85rem;
+		margin: 0.5rem 0 0.75rem;
+		color: var(--text-muted);
+		font-style: italic;
+	}
+
+	:global(.ask-answer-text a:not(.ask-cite-link)) {
+		color: var(--accent);
+		text-decoration: underline;
+		text-underline-offset: 2px;
+	}
+
+	:global(.ask-answer-text hr) {
+		border: 0;
+		border-top: 1px solid var(--border-light);
+		margin: 1rem 0;
+	}
+
+	/* ── Progress stepper (during loading) ── */
+	:global(.ask-progress-stepper) {
+		padding: 1rem 1.25rem;
+		background: var(--surface);
+		border: 1px solid var(--border-light);
+		border-radius: 12px;
+		animation: fadeInUp 0.3s var(--ease-out-quart) both;
+	}
+
+	:global(.ask-progress-list) {
+		list-style: none;
+		padding: 0;
+		margin: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 0.65rem;
+	}
+
+	:global(.ask-progress-item) {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+		font-size: 0.875rem;
+		line-height: 1.3;
+		transition: color 0.2s var(--ease-out-quart), opacity 0.2s var(--ease-out-quart);
+	}
+
+	:global(.ask-progress-pending) {
+		color: var(--text-muted);
+		opacity: 0.55;
+	}
+
+	:global(.ask-progress-active) {
+		color: var(--text);
+		font-weight: 500;
+	}
+
+	:global(.ask-progress-done) {
+		color: var(--text-secondary);
+	}
+
+	:global(.ask-progress-icon-wrap) {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 28px;
+		height: 28px;
+		flex-shrink: 0;
+		border-radius: 50%;
+		background: var(--bg, transparent);
+	}
+
+	:global(.ask-step-icon) {
+		display: block;
+	}
+
+	:global(.ask-progress-pending .ask-step-icon) { color: var(--border-medium); }
+	:global(.ask-progress-active .ask-step-icon) { color: var(--accent); }
+	:global(.ask-step-icon-done) {
+		color: #2f855a; /* institutional green, calm */
+	}
+
+	/* analyzing — soft lens pulse */
+	@keyframes ask-lens-pulse {
+		0%, 100% { transform-origin: center; transform: scale(1); opacity: 1; }
+		50% { transform: scale(1.08); opacity: 0.7; }
+	}
+	:global(.ask-step-anim .ask-step-lens) {
+		transform-origin: 11px 11px;
+		animation: ask-lens-pulse 1.6s ease-in-out infinite;
+	}
+
+	/* retrieving — documents lift in sequence */
+	@keyframes ask-doc-lift {
+		0%, 100% { transform: translateY(0); opacity: 0.55; }
+		50% { transform: translateY(-1.5px); opacity: 1; }
+	}
+	:global(.ask-step-anim .ask-doc) { transform-box: fill-box; transform-origin: center; }
+	:global(.ask-step-anim .ask-doc-1) { animation: ask-doc-lift 1.8s ease-in-out infinite; animation-delay: 0s; }
+	:global(.ask-step-anim .ask-doc-2) { animation: ask-doc-lift 1.8s ease-in-out infinite; animation-delay: 0.25s; }
+	:global(.ask-step-anim .ask-doc-3) { animation: ask-doc-lift 1.8s ease-in-out infinite; animation-delay: 0.5s; }
+
+	/* ranking — bars rise at staggered phase */
+	@keyframes ask-bar-grow {
+		0%, 100% { transform: scaleY(0.55); }
+		50% { transform: scaleY(1); }
+	}
+	:global(.ask-step-anim .ask-bar) {
+		transform-box: fill-box;
+		transform-origin: bottom center;
+	}
+	:global(.ask-step-anim .ask-bar-1) { animation: ask-bar-grow 1.4s ease-in-out infinite; animation-delay: 0s; }
+	:global(.ask-step-anim .ask-bar-2) { animation: ask-bar-grow 1.4s ease-in-out infinite; animation-delay: 0.18s; }
+	:global(.ask-step-anim .ask-bar-3) { animation: ask-bar-grow 1.4s ease-in-out infinite; animation-delay: 0.36s; }
+
+	/* writing — underline cursor blink */
+	@keyframes ask-cursor-blink {
+		0%, 45% { opacity: 1; }
+		50%, 95% { opacity: 0; }
+		100% { opacity: 1; }
+	}
+	:global(.ask-step-anim .ask-cursor) {
+		animation: ask-cursor-blink 1.2s ease-in-out infinite;
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		:global(.ask-step-anim .ask-lens),
+		:global(.ask-step-anim .ask-doc),
+		:global(.ask-step-anim .ask-bar),
+		:global(.ask-step-anim .ask-cursor) {
+			animation: none !important;
+		}
+	}
+
 	:global(.ask-declined) {
 		font-size: 0.9375rem;
 		color: var(--text-muted);


### PR DESCRIPTION
## Summary

- **Backend**: new `progress` SSE event type (`analyzing`/`retrieving`/`ranking`/`writing`) so the chat UI can show users which phase the pipeline is in instead of a mute 30s spinner.
- **Backend**: singleton-cache the in-memory vector index so `/v1/laws` and `/v1/ask` share the same load. Was paying ~5s extra on the first ask after a laws hit (or vice versa) because `RagPipeline` and `HybridSearcherImpl` each had their own private cache.
- **Web**: render markdown (bold, italics, lists, headings, code, blockquote) on chat answers — citations still work because the DOM walk preserves them inside any node.
- **Web**: 4-step animated progress stepper with inline SVG icons (lupa pulse, docs lift, ranking bars, quill+cursor). Institutional feel, `prefers-reduced-motion` respected.

## Why now

User reported a 50s wait on https://leyabierta.es/pregunta/ for "¿Cómo cambio de sexo en el DNI?". Logs showed (a) the double vector-index load and (b) the synthesis stream finally producing markdown that the UI rendered as plain text. Plus, even with the perf wins from #64 (int8), the first query post-deploy still feels eternal without progress feedback.

## Test plan

- [ ] `bun test packages/api` — 202/202 pass
- [ ] `bun run --cwd packages/web build` — Astro build clean
- [ ] Deploy to KonarServer, repeat the DNI query, observe stepper transitions
- [ ] Confirm markdown lists/bold render in answers with inline citations still working
- [ ] Hit `/v1/laws` then `/v1/ask` post-deploy, confirm only ONE `[rag] Loaded vectors-int8.bin` log line

🤖 Generated with [Claude Code](https://claude.com/claude-code)