### PR TITLE
feat(api+web): tldr, nextQuestions, feedback y redesign de /pregunta

### DIFF
--- a/packages/api/src/routes/ask.ts
+++ b/packages/api/src/routes/ask.ts
@@ -117,7 +117,7 @@ export function askRoutes(pipeline: RagPipeline | null) {
 						} else if (event.type === "progress") {
 							yield `event: progress\ndata: ${JSON.stringify({ step: event.step })}\n\n`;
 						} else {
-							yield `event: done\ndata: ${JSON.stringify({ citations: event.citations, meta: event.meta, declined: event.declined })}\n\n`;
+							yield `event: done\ndata: ${JSON.stringify({ citations: event.citations, meta: event.meta, declined: event.declined, tldr: event.tldr, nextQuestions: event.nextQuestions, suggestedQuestions: event.suggestedQuestions })}\n\n`;
 						}
 					}
 				} catch (err) {

--- a/packages/api/src/services/rag/pipeline.ts
+++ b/packages/api/src/services/rag/pipeline.ts
@@ -31,7 +31,9 @@ import {
 import {
 	buildEvidence,
 	type Citation,
+	generateDeclinedSuggestions,
 	generateMissingSummaries,
+	generatePostSynthExtras,
 	INLINE_CITE_PATTERN,
 	SYNTHESIS_MODEL,
 	synthesizeAnswer,
@@ -64,6 +66,9 @@ export interface AskResponse {
 	answer: string;
 	citations: Citation[];
 	declined: boolean;
+	tldr?: string;
+	nextQuestions?: string[];
+	suggestedQuestions?: string[];
 	meta: {
 		articlesRetrieved: number;
 		temporalEnriched: boolean;
@@ -229,6 +234,15 @@ export class RagPipeline {
 					: retrieval.reason === "no_articles"
 						? DECLINE_NO_ARTICLES
 						: DECLINE_LOW_CONFIDENCE;
+
+			let suggestedQuestions: string[] | undefined;
+			if (retrieval.reason === "non_legal") {
+				suggestedQuestions = await generateDeclinedSuggestions({
+					apiKey: this.apiKey,
+					question: request.question,
+				});
+			}
+
 			const result: AskResponse & {
 				_bestScore?: number;
 				_cost?: number;
@@ -238,6 +252,7 @@ export class RagPipeline {
 				answer,
 				citations: [],
 				declined: true,
+				suggestedQuestions,
 				meta: {
 					articlesRetrieved: 0,
 					temporalEnriched: false,
@@ -362,6 +377,8 @@ export class RagPipeline {
 			answer: finalAnswer,
 			citations: validCitations,
 			declined: synthesis.declined,
+			tldr: synthesis.tldr,
+			nextQuestions: synthesis.nextQuestions,
 			meta: {
 				articlesRetrieved: articles.length,
 				temporalEnriched: useTemporal,
@@ -402,6 +419,9 @@ export class RagPipeline {
 				citations: Citation[];
 				meta: AskResponse["meta"];
 				declined: boolean;
+				tldr?: string;
+				nextQuestions?: string[];
+				suggestedQuestions?: string[];
 		  }
 	> {
 		const start = Date.now();
@@ -488,7 +508,22 @@ export class RagPipeline {
 					model: SYNTHESIS_MODEL,
 				};
 				yield { type: "chunk", text: answer };
-				yield { type: "done", citations: [], meta, declined: true };
+
+				let declinedSuggestedQuestions: string[] | undefined;
+				if (retrieval.reason === "non_legal") {
+					declinedSuggestedQuestions = await generateDeclinedSuggestions({
+						apiKey: this.apiKey,
+						question: request.question,
+					});
+				}
+
+				yield {
+					type: "done",
+					citations: [],
+					meta,
+					declined: true,
+					suggestedQuestions: declinedSuggestedQuestions,
+				};
 				try {
 					this.insertAskLogStmt.run(
 						request.question,
@@ -635,6 +670,12 @@ export class RagPipeline {
 				totalTokensOut,
 			});
 
+			const { tldr, nextQuestions } = await generatePostSynthExtras({
+				apiKey: this.apiKey,
+				question: request.question,
+				answer: fullText,
+			});
+
 			yield {
 				type: "done",
 				citations: validCitations,
@@ -645,6 +686,8 @@ export class RagPipeline {
 					model: SYNTHESIS_MODEL,
 				},
 				declined,
+				tldr,
+				nextQuestions,
 			};
 		} catch (err) {
 			trace.end({

--- a/packages/api/src/services/rag/synthesis.ts
+++ b/packages/api/src/services/rag/synthesis.ts
@@ -83,7 +83,20 @@ CUÁNDO DECLINAR (declined=true):
 - Los artículos NO responden a la pregunta DE FONDO (ignorando nombres de leyes erróneos) → declined=true.
 En todos los demás casos, INTENTA responder.
 
-Responde con JSON: {"answer": "texto con citas inline [norm_id, Artículo N]...", "citations": [{"norm_id": "...", "article_title": "..."}], "declined": false}`;
+RESPUESTA CORTA (tldr):
+- Una frase de máximo 200 caracteres que responda la pregunta de forma directa.
+- Empieza por "Sí", "No", "Depende" o el dato concreto. No la prefijes con "TL;DR:" ni "Respuesta corta:".
+- No incluyas citas inline aquí. La respuesta corta es para escaneo rápido.
+- Si declined=true, deja tldr como cadena vacía.
+
+PREGUNTAS DE SEGUIMIENTO (next_questions):
+- Exactamente 3 preguntas que el ciudadano se haría DESPUÉS de leer tu respuesta.
+- Naturales, en primera persona ("¿Y si...?", "¿Qué pasa si...?", "¿Puedo...?").
+- Específicas a su situación, no genéricas. Si la respuesta menciona un tope del 3%, una pregunta podría ser "¿Y si me suben más del 3%, qué hago?".
+- Máximo 90 caracteres cada una.
+- Si declined=true, devuelve [].
+
+Responde con JSON: {"answer": "...", "citations": [...], "declined": false, "tldr": "...", "next_questions": ["...", "...", "..."]}`;
 
 export const SYSTEM_PROMPT_STREAM = SYSTEM_PROMPT.replace(
 	/\nResponde con JSON:.*$/s,
@@ -199,6 +212,8 @@ export type SynthesisResult = {
 	answer: string;
 	citations: Array<{ normId: string; articleTitle: string }>;
 	declined: boolean;
+	tldr: string;
+	nextQuestions: string[];
 	cost: number;
 	tokensIn: number;
 	tokensOut: number;
@@ -215,6 +230,8 @@ export async function synthesizeAnswer(opts: {
 		answer: string;
 		citations: Array<{ norm_id: string; article_title: string }>;
 		declined: boolean;
+		tldr: string;
+		next_questions: string[];
 	}>(apiKey, {
 		model: SYNTHESIS_MODEL,
 		messages: [
@@ -248,8 +265,15 @@ export async function synthesizeAnswer(opts: {
 						},
 					},
 					declined: { type: "boolean" },
+					tldr: { type: "string" },
+					next_questions: {
+						type: "array",
+						items: { type: "string" },
+						minItems: 0,
+						maxItems: 3,
+					},
 				},
-				required: ["answer", "citations", "declined"],
+				required: ["answer", "citations", "declined", "tldr", "next_questions"],
 				additionalProperties: false,
 			},
 		},
@@ -262,6 +286,8 @@ export async function synthesizeAnswer(opts: {
 			articleTitle: c.article_title,
 		})),
 		declined: result.data.declined ?? false,
+		tldr: result.data.tldr ?? "",
+		nextQuestions: result.data.next_questions ?? [],
 		cost: result.cost,
 		tokensIn: result.tokensIn,
 		tokensOut: result.tokensOut,
@@ -423,6 +449,129 @@ export function generateMissingSummaries(opts: {
 					err instanceof Error ? err.message : "unknown error",
 				);
 			});
+	}
+}
+
+// ── Evidence assembly with optional temporal enrichment ──
+
+// ── Post-synthesis enrichment (streaming path) ──
+
+export async function generatePostSynthExtras(opts: {
+	apiKey: string;
+	question: string;
+	answer: string;
+}): Promise<{ tldr: string; nextQuestions: string[] }> {
+	const { apiKey, question, answer } = opts;
+	try {
+		const result = await callOpenRouter<{
+			tldr: string;
+			next_questions: string[];
+		}>(apiKey, {
+			model: SYNTHESIS_MODEL,
+			messages: [
+				{
+					role: "system",
+					content: `Eres un postprocesador de Ley Abierta. Recibes una pregunta de un ciudadano y la respuesta legal que se le ha dado. Genera dos cosas:
+
+1) tldr: respuesta corta de máximo 200 caracteres que destile la respuesta principal. Empieza por "Sí", "No", "Depende" o el dato concreto. Sin citas inline. Sin prefijos como "TL;DR".
+
+2) next_questions: exactamente 3 preguntas de seguimiento que el ciudadano se haría DESPUÉS de leer la respuesta. Naturales, primera persona, específicas a la situación (no genéricas). Máximo 90 caracteres cada una.
+
+Responde con JSON: {"tldr": "...", "next_questions": ["...", "...", "..."]}`,
+				},
+				{
+					role: "user",
+					content: `PREGUNTA:\n${question}\n\nRESPUESTA:\n${answer}`,
+				},
+			],
+			temperature: 0,
+			maxTokens: 400,
+			jsonSchema: {
+				name: "post_synth_extras",
+				schema: {
+					type: "object",
+					properties: {
+						tldr: { type: "string" },
+						next_questions: {
+							type: "array",
+							items: { type: "string" },
+							minItems: 0,
+							maxItems: 3,
+						},
+					},
+					required: ["tldr", "next_questions"],
+					additionalProperties: false,
+				},
+			},
+		});
+		return {
+			tldr: result.data.tldr ?? "",
+			nextQuestions: result.data.next_questions ?? [],
+		};
+	} catch (err) {
+		console.warn(
+			"generatePostSynthExtras failed:",
+			err instanceof Error ? err.message : "unknown error",
+		);
+		return { tldr: "", nextQuestions: [] };
+	}
+}
+
+export async function generateDeclinedSuggestions(opts: {
+	apiKey: string;
+	question: string;
+}): Promise<string[]> {
+	const { apiKey, question } = opts;
+	try {
+		const result = await callOpenRouter<{ suggested_questions: string[] }>(
+			apiKey,
+			{
+				model: SYNTHESIS_MODEL,
+				messages: [
+					{
+						role: "system",
+						content: `Un ciudadano ha hecho una pregunta a Ley Abierta que está fuera de alcance porque NO trata sobre legislación española (ej. precios de mercado, opiniones, predicciones). Tu trabajo: proponer 3 reformulaciones legales plausibles que SÍ estarían en alcance, manteniendo el espíritu de la pregunta original.
+
+Reglas:
+- Cada sugerencia es una pregunta concreta sobre derechos, plazos, requisitos, obligaciones, o procedimientos regulados por ley española.
+- Mantén el tema (vivienda, trabajo, familia, consumo, etc.) de la pregunta original.
+- Primera persona, lenguaje natural, máximo 90 caracteres cada una.
+- Si no puedes proponer reformulaciones razonables, devuelve [].
+
+Responde con JSON: {"suggested_questions": ["...", "...", "..."]}`,
+					},
+					{
+						role: "user",
+						content: `PREGUNTA: ${question}`,
+					},
+				],
+				temperature: 0.2,
+				maxTokens: 250,
+				jsonSchema: {
+					name: "declined_suggestions",
+					schema: {
+						type: "object",
+						properties: {
+							suggested_questions: {
+								type: "array",
+								items: { type: "string" },
+								minItems: 0,
+								maxItems: 3,
+							},
+						},
+						required: ["suggested_questions"],
+						additionalProperties: false,
+					},
+				},
+			},
+		);
+		return result.data.suggested_questions ?? [];
+	} catch (err) {
+		console.warn(
+			"generateDeclinedSuggestions failed:",
+			err instanceof Error ? err.message : "unknown error",
+		);
+		return [];
 	}
 }
 

--- a/packages/web/src/components/AskChat.tsx
+++ b/packages/web/src/components/AskChat.tsx
@@ -36,6 +36,9 @@ interface AskResponse {
 	answer: string;
 	citations: Citation[];
 	declined: boolean;
+	tldr?: string;
+	nextQuestions?: string[];
+	suggestedQuestions?: string[];
 	meta: AskMeta;
 }
 
@@ -67,11 +70,35 @@ const API_BASE =
 		? (document.documentElement.dataset.api ?? "https://api.leyabierta.es")
 		: "https://api.leyabierta.es";
 
-const EXAMPLE_QUESTIONS = [
-	"¿Cuántos días de vacaciones me corresponden por ley?",
-	"¿Me pueden despedir estando embarazada?",
-	"¿Cuánto preaviso tiene que dar mi casero para subir el alquiler?",
-	"¿Qué derechos tengo si me venden un producto defectuoso?",
+const EXAMPLE_CATEGORIES: { name: string; questions: string[] }[] = [
+	{
+		name: "Vivienda",
+		questions: [
+			"¿Cuánto preaviso tiene que dar mi casero para subirme el alquiler?",
+			"¿Pueden echarme si llevo 3 años en el piso?",
+		],
+	},
+	{
+		name: "Trabajo",
+		questions: [
+			"¿Cuántos días de vacaciones me corresponden por ley?",
+			"¿Me pueden despedir estando embarazada?",
+		],
+	},
+	{
+		name: "Familia",
+		questions: [
+			"¿Cuánto dura el permiso de paternidad en 2026?",
+			"¿Cómo se reparte una herencia sin testamento?",
+		],
+	},
+	{
+		name: "Consumidor",
+		questions: [
+			"¿Qué derechos tengo si un producto sale defectuoso?",
+			"¿Puedo cancelar una compra online en 14 días?",
+		],
+	},
 ];
 
 // ── Citation parsing ──
@@ -585,6 +612,87 @@ function AskProgressStepper({ current }: { current: ProgressStep }) {
 	);
 }
 
+// ── Per-turn feedback + share actions ──
+
+function TurnActions({ turn }: { turn: Turn }) {
+	const [feedback, setFeedback] = useState<"up" | "down" | null>(null);
+	const [shared, setShared] = useState(false);
+
+	async function handleShare() {
+		const text = turn.question;
+		const shareData = {
+			title: "Ley Abierta",
+			text,
+			url: typeof location !== "undefined" ? location.href : "",
+		};
+		if (typeof navigator === "undefined") return;
+		const nav = navigator as Navigator & {
+			share?: (d: ShareData) => Promise<void>;
+		};
+		try {
+			if (typeof nav.share === "function") {
+				await nav.share(shareData);
+				return;
+			}
+			if (nav.clipboard) {
+				await nav.clipboard.writeText(`${text}\n${shareData.url}`);
+				setShared(true);
+				setTimeout(() => setShared(false), 1800);
+			}
+		} catch {
+			/* user cancelled or unavailable */
+		}
+	}
+
+	return (
+		<div className="ask-turn-actions">
+			<span className="ask-turn-actions-label">¿Te ha sido útil?</span>
+			<button
+				type="button"
+				className="ask-action-btn"
+				aria-pressed={feedback === "up"}
+				onClick={() => setFeedback(feedback === "up" ? null : "up")}
+			>
+				<span aria-hidden="true">👍</span> Sí
+			</button>
+			<button
+				type="button"
+				className="ask-action-btn"
+				aria-pressed={feedback === "down"}
+				onClick={() => setFeedback(feedback === "down" ? null : "down")}
+			>
+				<span aria-hidden="true">👎</span> No
+			</button>
+			<span className="ask-action-spacer" />
+			<button
+				type="button"
+				className="ask-action-btn"
+				onClick={handleShare}
+				aria-label="Compartir"
+			>
+				<svg
+					width="13"
+					height="13"
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					strokeWidth="2"
+					strokeLinecap="round"
+					strokeLinejoin="round"
+					aria-hidden="true"
+				>
+					<circle cx="18" cy="5" r="3" />
+					<circle cx="6" cy="12" r="3" />
+					<circle cx="18" cy="19" r="3" />
+					<line x1="8.59" y1="13.51" x2="15.42" y2="17.49" />
+					<line x1="15.41" y1="6.51" x2="8.59" y2="10.49" />
+				</svg>
+				{shared ? "Copiado" : "Compartir"}
+			</button>
+		</div>
+	);
+}
+
 export default function AskChat() {
 	const [turns, setTurns] = useState<Turn[]>(loadTurns);
 	const [question, setQuestion] = useState("");
@@ -736,6 +844,9 @@ export default function AskChat() {
 						citations: Citation[];
 						meta: AskMeta;
 						declined: boolean;
+						tldr?: string;
+						nextQuestions?: string[];
+						suggestedQuestions?: string[];
 					};
 					setTurns((prev) => {
 						const updated = [...prev];
@@ -747,6 +858,9 @@ export default function AskChat() {
 									answer: accumulated,
 									citations: done.citations,
 									declined: done.declined,
+									tldr: done.tldr,
+									nextQuestions: done.nextQuestions,
+									suggestedQuestions: done.suggestedQuestions,
 									meta: done.meta,
 								},
 							};
@@ -810,46 +924,16 @@ export default function AskChat() {
 
 	return (
 		<div className="ask-chat">
-			<div className="ask-disclaimer" role="status">
-				<svg
-					width="16"
-					height="16"
-					viewBox="0 0 24 24"
-					fill="none"
-					stroke="currentColor"
-					strokeWidth="2"
-					strokeLinecap="round"
-					strokeLinejoin="round"
-					aria-hidden="true"
-				>
-					<circle cx="12" cy="12" r="10" />
-					<line x1="12" y1="8" x2="12" y2="12" />
-					<line x1="12" y1="16" x2="12.01" y2="16" />
-				</svg>
-				<span>
-					Esta información es orientativa y no constituye asesoramiento
-					jurídico. Para tu caso concreto, consulta con un profesional del
-					derecho.
-				</span>
-			</div>
-
 			{!hasHistory && !loading && (
-				<div className="ask-examples">
-					<p className="ask-examples-label">
-						Prueba con una de estas preguntas:
+				<div className="ask-empty">
+					<p className="ask-empty-eyebrow">Pregunta</p>
+					<h1 className="ask-empty-h1">
+						Pregunta lo que quieras saber sobre la ley.
+					</h1>
+					<p className="ask-empty-lede">
+						Tu duda en lenguaje normal. Te respondemos citando los artículos
+						concretos que aplican, con enlace al texto oficial.
 					</p>
-					<div className="ask-examples-grid">
-						{EXAMPLE_QUESTIONS.map((q) => (
-							<button
-								key={q}
-								type="button"
-								className="ask-example-btn"
-								onClick={() => handleExample(q)}
-							>
-								{q}
-							</button>
-						))}
-					</div>
 				</div>
 			)}
 
@@ -864,14 +948,62 @@ export default function AskChat() {
 							</div>
 
 							{turn.response && (
-								<div className="ask-turn-answer">
+								<div
+									className={`ask-turn-answer${turn.response.declined ? " ask-turn-declined" : ""}`}
+								>
 									{turn.response.declined ? (
-										<p className="ask-declined">
-											{turn.response.answer ||
-												"Esta pregunta no está relacionada con la legislación española."}
-										</p>
+										<>
+											<p className="ask-declined-eyebrow">
+												Esto está fuera de mi alcance
+											</p>
+											<h2 className="ask-declined-heading">
+												No puedo darte una respuesta fiable a esta pregunta.
+											</h2>
+											<div className="ask-declined-body">
+												{turn.response.answer ? (
+													renderAnswerWithCitations(
+														turn.response.answer,
+														[],
+														false,
+													)
+												) : (
+													<p>
+														Solo respondo basándome en la legislación española.
+														Reformula la pregunta dando más contexto sobre tu
+														situación concreta y lo intentamos de nuevo.
+													</p>
+												)}
+											</div>
+											{turn.response.suggestedQuestions &&
+												turn.response.suggestedQuestions.length > 0 && (
+													<div className="ask-declined-suggestions">
+														<p className="ask-declined-suggestions-label">
+															¿Quizá querías saber…?
+														</p>
+														<div className="ask-declined-suggestions-list">
+															{turn.response.suggestedQuestions.map((q) => (
+																<button
+																	key={q}
+																	type="button"
+																	className="ask-declined-suggestion"
+																	onClick={() => handleSubmit(q)}
+																	disabled={loading}
+																>
+																	→ {q}
+																</button>
+															))}
+														</div>
+													</div>
+												)}
+										</>
 									) : (
 										<>
+											{turn.response.tldr && (
+												<div className="ask-tldr">
+													<p className="ask-tldr-eyebrow">Respuesta corta</p>
+													<p className="ask-tldr-body">{turn.response.tldr}</p>
+												</div>
+											)}
 											<div className="ask-answer-text">
 												{renderAnswerWithCitations(
 													turn.response.answer,
@@ -924,6 +1056,28 @@ export default function AskChat() {
 												</div>
 											)}
 
+											{turn.response.nextQuestions &&
+												turn.response.nextQuestions.length > 0 && (
+													<div className="ask-next">
+														<p className="ask-next-label">Continuar con</p>
+														<div className="ask-next-chips">
+															{turn.response.nextQuestions.map((q) => (
+																<button
+																	key={q}
+																	type="button"
+																	className="ask-next-chip"
+																	onClick={() => handleSubmit(q)}
+																	disabled={loading}
+																>
+																	{q}
+																</button>
+															))}
+														</div>
+													</div>
+												)}
+
+											<TurnActions turn={turn} />
+
 											{turn.response.meta.model && (
 												<details className="ask-meta-details">
 													<summary className="ask-meta-summary">
@@ -952,6 +1106,14 @@ export default function AskChat() {
 										</>
 									)}
 								</div>
+							)}
+
+							{turn.response && !turn.response.declined && (
+								<p className="ask-turn-disclaimer">
+									Respuestas generadas automáticamente a partir del texto
+									oficial. No son asesoramiento jurídico — para casos serios
+									consulta con un profesional.
+								</p>
 							)}
 
 							{turn.error && (
@@ -990,7 +1152,7 @@ export default function AskChat() {
 					placeholder={
 						hasHistory
 							? "Haz otra pregunta..."
-							: "Escribe tu pregunta sobre legislación española..."
+							: "¿Mi casero puede subirme el alquiler un 10%?"
 					}
 					rows={hasHistory ? 1 : 2}
 					maxLength={1000}
@@ -1040,6 +1202,39 @@ export default function AskChat() {
 					</button>
 				</div>
 			</div>
+
+			{!hasHistory && !loading && (
+				<>
+					<p className="ask-empty-hint">
+						Pulsa Enter para enviar · O elige uno de los ejemplos
+					</p>
+					<div className="ask-examples">
+						<p className="ask-examples-label">Ejemplos por área</p>
+						<div className="ask-categories">
+							{EXAMPLE_CATEGORIES.map((cat) => (
+								<div key={cat.name}>
+									<p className="ask-category-name">{cat.name}</p>
+									{cat.questions.map((q) => (
+										<button
+											key={q}
+											type="button"
+											className="ask-example-btn"
+											onClick={() => handleExample(q)}
+										>
+											{q}
+										</button>
+									))}
+								</div>
+							))}
+						</div>
+					</div>
+					<div className="ask-empty-trust">
+						<span>Solo legislación española vigente</span>
+						<span>Citas verificables al BOE</span>
+						<span>Gratuito y open source</span>
+					</div>
+				</>
+			)}
 		</div>
 	);
 }

--- a/packages/web/src/pages/pregunta.astro
+++ b/packages/web/src/pages/pregunta.astro
@@ -9,63 +9,93 @@ import AskChat from "../components/AskChat.tsx";
 	canonicalUrl="/pregunta/"
 >
 	<div class="ask-page">
-		<div class="ask-header">
-			<h1>Pregunta tus derechos</h1>
-			<p class="ask-subtitle">
-				Haz una pregunta sobre la legislación española y recibirás una respuesta
-				basada en artículos reales, con enlaces verificables al texto original.
-			</p>
-		</div>
-
 		<AskChat client:load />
 	</div>
 </Base>
 
 <style>
 	.ask-page {
-		max-width: 44rem;
+		max-width: 45rem;
 		margin: 0 auto;
 	}
 
-	.ask-header {
+	/* ── Empty state · editorial header ── */
+	:global(.ask-empty) {
 		text-align: center;
-		margin-bottom: 2rem;
+		padding: 2.5rem 0 0;
 	}
 
-	.ask-header h1 {
+	:global(.ask-empty-eyebrow) {
+		font-family: var(--font-mono);
+		font-size: 0.6875rem;
+		letter-spacing: 0.16em;
+		text-transform: uppercase;
+		color: var(--text-muted);
+		margin-bottom: 1rem;
+	}
+
+	:global(.ask-empty-h1) {
 		font-family: var(--font-serif);
-		font-size: 1.75rem;
+		font-size: clamp(1.75rem, 4.5vw, 2.625rem);
 		font-weight: 700;
+		line-height: 1.1;
+		letter-spacing: -0.015em;
 		color: var(--text);
-		margin-bottom: 0.5rem;
+		margin: 0 0 1rem;
+		text-wrap: balance;
 	}
 
-	.ask-subtitle {
-		font-size: 0.9375rem;
+	:global(.ask-empty-lede) {
+		font-family: var(--font-serif);
+		font-size: 1.125rem;
+		line-height: 1.55;
 		color: var(--text-secondary);
-		line-height: 1.6;
-		max-width: 36rem;
-		margin: 0 auto;
+		max-width: 35rem;
+		margin: 0 auto 2.25rem;
+		text-wrap: pretty;
 	}
 
-	/* ── Disclaimer banner ── */
-	:global(.ask-disclaimer) {
-		display: flex;
-		align-items: flex-start;
-		gap: 0.625rem;
-		padding: 0.75rem 1rem;
-		background: var(--warning-bg);
-		color: var(--warning-text);
-		border: 1px solid color-mix(in srgb, var(--warning) 20%, transparent);
-		border-radius: 8px;
+	:global(.ask-empty-hint) {
 		font-size: 0.8125rem;
-		line-height: 1.5;
-		margin-bottom: 1.5rem;
+		color: var(--text-muted);
+		text-align: center;
+		margin: 0.75rem 0 0;
 	}
 
-	:global(.ask-disclaimer svg) {
-		flex-shrink: 0;
-		margin-top: 0.125rem;
+	:global(.ask-empty-trust) {
+		display: flex;
+		flex-wrap: wrap;
+		justify-content: center;
+		gap: 1.5rem 2.25rem;
+		padding-top: 2rem;
+		margin-top: 3.5rem;
+		border-top: 1px solid var(--border-light);
+		font-family: var(--font-mono);
+		font-size: 0.75rem;
+		letter-spacing: 0.02em;
+		color: var(--text-muted);
+	}
+
+	:global(.ask-empty-trust span) {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.4rem;
+	}
+
+	:global(.ask-empty-trust span::before) {
+		content: "●";
+		color: var(--accent);
+		font-size: 0.625rem;
+	}
+
+	/* ── Per-turn disclaimer ── */
+	:global(.ask-turn-disclaimer) {
+		font-size: 0.75rem;
+		color: var(--text-muted);
+		line-height: 1.5;
+		margin: 1.25rem 0 0;
+		font-style: italic;
+		text-align: center;
 	}
 
 	/* ── Input area ── */
@@ -181,49 +211,163 @@ import AskChat from "../components/AskChat.tsx";
 		border-width: 3px;
 	}
 
-	/* ── Example questions ── */
+	/* ── Example questions · grouped by category ── */
 	:global(.ask-examples) {
-		margin-bottom: 1.5rem;
+		margin-top: 4rem;
+		text-align: left;
 	}
 
 	:global(.ask-examples-label) {
-		font-size: 0.8125rem;
+		font-family: var(--font-mono);
+		font-size: 0.6875rem;
+		letter-spacing: 0.16em;
+		text-transform: uppercase;
 		color: var(--text-muted);
-		margin-bottom: 0.75rem;
+		margin: 0 0 1.25rem;
+		text-align: center;
 	}
 
-	:global(.ask-examples-grid) {
+	:global(.ask-categories) {
 		display: grid;
-		grid-template-columns: 1fr 1fr;
-		gap: 0.5rem;
+		grid-template-columns: repeat(2, 1fr);
+		gap: 1.25rem 1.75rem;
 	}
 
 	@media (max-width: 640px) {
-		:global(.ask-examples-grid) {
+		:global(.ask-categories) {
 			grid-template-columns: 1fr;
 		}
+	}
+
+	:global(.ask-category-name) {
+		font-family: var(--font-serif);
+		font-size: 0.9375rem;
+		font-weight: 700;
+		color: var(--accent);
+		margin: 0 0 0.4rem;
+		padding-bottom: 0.4rem;
+		border-bottom: 1px solid var(--tierra-deep);
 	}
 
 	:global(.ask-example-btn) {
 		display: block;
 		width: 100%;
 		text-align: left;
-		padding: 0.75rem 1rem;
-		background: var(--surface);
-		border: 1px solid var(--border-light);
-		border-radius: 8px;
+		padding: 0.5rem 0;
+		background: none;
+		border: none;
 		font-family: var(--font-sans);
-		font-size: 0.8125rem;
+		font-size: 0.875rem;
 		color: var(--text-secondary);
+		line-height: 1.5;
 		cursor: pointer;
-		line-height: 1.4;
-		transition: border-color 0.15s var(--ease-out-quart), color 0.15s var(--ease-out-quart), background 0.15s var(--ease-out-quart);
+		transition: color 0.15s var(--ease-out-quart);
+	}
+
+	:global(.ask-example-btn::before) {
+		content: "↗ ";
+		color: var(--text-muted);
+		margin-right: 0.15rem;
 	}
 
 	:global(.ask-example-btn:hover) {
-		border-color: var(--accent);
 		color: var(--accent);
+	}
+
+	:global(.ask-example-btn:hover::before) {
+		color: var(--accent);
+	}
+
+	/* ── Per-turn actions (útil / compartir) ── */
+	:global(.ask-turn-actions) {
+		display: flex;
+		gap: 0.5rem;
+		margin-top: 1.125rem;
+		padding-top: 0.875rem;
+		border-top: 1px solid var(--border-light);
+		align-items: center;
+		flex-wrap: wrap;
+	}
+
+	:global(.ask-turn-actions-label) {
+		font-size: 0.75rem;
+		color: var(--text-muted);
+		margin-right: 0.25rem;
+	}
+
+	:global(.ask-action-btn) {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.3rem;
+		padding: 0.3rem 0.7rem;
+		font-size: 0.75rem;
+		font-weight: 500;
+		font-family: var(--font-sans);
+		border: 1px solid var(--border);
+		border-radius: 999px;
+		background: var(--bg);
+		color: var(--text-secondary);
+		cursor: pointer;
+		transition: color 0.15s var(--ease-out-quart), border-color 0.15s var(--ease-out-quart), background 0.15s var(--ease-out-quart);
+	}
+
+	:global(.ask-action-btn:hover) {
+		color: var(--accent);
+		border-color: var(--accent);
 		background: var(--accent-faint);
+	}
+
+	:global(.ask-action-btn[aria-pressed="true"]) {
+		color: var(--accent);
+		border-color: var(--accent);
+		background: var(--accent-faint);
+	}
+
+	:global(.ask-action-spacer) {
+		flex: 1;
+	}
+
+	/* ── Declined state · editorial ── */
+	:global(.ask-turn-declined) {
+		background: var(--surface);
+		border: 1px solid var(--border-light);
+		border-left: 3px solid var(--warning);
+		border-radius: 8px;
+		padding: 1.25rem 1.4rem;
+	}
+
+	:global(.ask-declined-eyebrow) {
+		font-family: var(--font-mono);
+		font-size: 0.6875rem;
+		letter-spacing: 0.14em;
+		text-transform: uppercase;
+		color: var(--warning-text);
+		font-weight: 700;
+		margin: 0 0 0.5rem;
+	}
+
+	:global(.ask-declined-heading) {
+		font-family: var(--font-serif);
+		font-size: 1.1875rem;
+		font-weight: 700;
+		color: var(--text);
+		line-height: 1.3;
+		margin: 0 0 0.6rem;
+	}
+
+	:global(.ask-declined-body) {
+		font-size: 0.9375rem;
+		color: var(--text-secondary);
+		line-height: 1.6;
+		margin: 0;
+	}
+
+	:global(.ask-declined-body p) {
+		margin: 0 0 0.6rem;
+	}
+
+	:global(.ask-declined-body p:last-child) {
+		margin-bottom: 0;
 	}
 
 	/* ── Conversation ── */
@@ -800,5 +944,125 @@ import AskChat from "../components/AskChat.tsx";
 		clip: rect(0, 0, 0, 0);
 		white-space: nowrap;
 		border: 0;
+	}
+
+	/* ── TL;DR card ── */
+	:global(.ask-tldr) {
+		background: var(--tierra-warm);
+		border-left: 3px solid var(--accent);
+		border-radius: 8px;
+		padding: 0.875rem 1rem;
+		margin-bottom: 1.125rem;
+	}
+
+	:global(.ask-tldr-eyebrow) {
+		font-family: var(--font-mono);
+		font-size: 0.6875rem;
+		letter-spacing: 0.14em;
+		text-transform: uppercase;
+		color: var(--accent);
+		font-weight: 700;
+		margin: 0 0 0.3rem;
+	}
+
+	:global(.ask-tldr-body) {
+		font-family: var(--font-serif);
+		font-size: 0.9375rem;
+		line-height: 1.55;
+		color: var(--text);
+		margin: 0;
+		text-wrap: pretty;
+	}
+
+	/* ── Next questions chips ── */
+	:global(.ask-next) {
+		margin-top: 1.125rem;
+		padding-top: 0.875rem;
+		border-top: 1px solid var(--border-light);
+	}
+
+	:global(.ask-next-label) {
+		font-family: var(--font-mono);
+		font-size: 0.6875rem;
+		letter-spacing: 0.14em;
+		text-transform: uppercase;
+		color: var(--text-muted);
+		font-weight: 600;
+		margin: 0 0 0.6rem;
+	}
+
+	:global(.ask-next-chips) {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.4rem;
+	}
+
+	:global(.ask-next-chip) {
+		font-family: var(--font-sans);
+		font-size: 0.8125rem;
+		padding: 0.35rem 0.75rem;
+		border-radius: 999px;
+		border: 1px solid var(--border);
+		background: var(--bg);
+		color: var(--accent);
+		cursor: pointer;
+		line-height: 1.3;
+		transition: color 0.15s var(--ease-out-quart), border-color 0.15s var(--ease-out-quart), background 0.15s var(--ease-out-quart);
+	}
+
+	:global(.ask-next-chip:hover:not(:disabled)) {
+		border-color: var(--accent);
+		background: var(--accent-faint);
+	}
+
+	:global(.ask-next-chip:disabled) {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	/* ── Declined suggestions ── */
+	:global(.ask-declined-suggestions) {
+		margin-top: 1rem;
+		padding: 0.875rem 1rem;
+		background: var(--bg);
+		border: 1px solid var(--border-light);
+		border-radius: 6px;
+	}
+
+	:global(.ask-declined-suggestions-label) {
+		font-family: var(--font-mono);
+		font-size: 0.6875rem;
+		letter-spacing: 0.14em;
+		text-transform: uppercase;
+		color: var(--text-muted);
+		font-weight: 600;
+		margin: 0 0 0.5rem;
+	}
+
+	:global(.ask-declined-suggestions-list) {
+		display: flex;
+		flex-direction: column;
+		gap: 0.1rem;
+	}
+
+	:global(.ask-declined-suggestion) {
+		text-align: left;
+		font-family: var(--font-sans);
+		font-size: 0.875rem;
+		color: var(--accent);
+		padding: 0.3rem 0;
+		border: none;
+		background: none;
+		cursor: pointer;
+		transition: color 0.15s var(--ease-out-quart);
+	}
+
+	:global(.ask-declined-suggestion:hover:not(:disabled)) {
+		color: var(--accent-light);
+	}
+
+	:global(.ask-declined-suggestion:disabled) {
+		opacity: 0.5;
+		cursor: not-allowed;
 	}
 </style>


### PR DESCRIPTION
## Resumen

Feature completa que añade post-synthesis extras y rediseña la página /pregunta.

### Backend (API)
- **tldr**: respuesta corta de máximo 200 caracteres para escaneo rápido
- **nextQuestions**: 3 preguntas de seguimiento específicas a la situación del ciudadano
- **suggestedQuestions**: reformulaciones cuando la pregunta está fuera de alcance (no legal)
- `generatePostSynthExtras()`: segunda llamada LLM para generar tldr/nextQuestions (path streaming)
- `generateDeclinedSuggestions()`: sugiere reformulaciones legales para preguntas no legales

### Frontend (Web)
- **Ejemplos categorizados**: Vivienda, Trabajo, Familia, Consumidor
- **Header editorial**: título serif + lede + trust indicators
- **Per-turn feedback**: 👍/👍 botones y acción de compartir
- **Display tldr**: una frase destacada antes de la respuesta completa
- **Display nextQuestions**: sugerencias de seguimiento debajo de la respuesta
- **Display declined suggestions**: reformulaciones cuando la pregunta no es legal
- Mejoras de espaciado, tipografía y responsive

### Commits
1. `feat(api): post-synthesis extras (tldr, nextQuestions, declined suggestions)`
2. `feat(web): redesign pregunta page + show tldr/nextQuestions/feedback