### PR TITLE
feat: Umami self-hosted analytics (sin banner de cookies)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,3 +40,71 @@ services:
           cpus: "0.5"
     profiles:
       - production
+
+  # Privacy-first analytics. Cookieless, IP hashed with daily rotating salt.
+  # AEPD-compliant for analytics without cookie consent.
+  # Exposed via Cloudflare Tunnel at analytics.leyabierta.es.
+  # Major version pinned (postgresql-v2) so Watchtower auto-updates only patch+minor.
+  umami:
+    image: ghcr.io/umami-software/umami:postgresql-v2
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:3001:3000"
+    env_file:
+      - path: .env.prod
+        required: false
+    environment:
+      DATABASE_URL: postgresql://umami:${UMAMI_DB_PASSWORD}@umami-db:5432/umami
+      DATABASE_TYPE: postgresql
+      APP_SECRET: ${UMAMI_APP_SECRET}
+      DISABLE_TELEMETRY: "1"
+      TRACKER_SCRIPT_NAME: "ley.js"
+      COLLECT_API_ENDPOINT: "/data/event"
+      REMOVE_TRAILING_SLASH: "1"
+      CLIENT_IP_HEADER: "CF-Connecting-IP"
+    depends_on:
+      umami-db:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:3000/api/heartbeat"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 60s
+    labels:
+      - "com.centurylinklabs.watchtower.enable=true"
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+          cpus: "1.0"
+    profiles:
+      - production
+
+  umami-db:
+    image: postgres:17-alpine
+    restart: unless-stopped
+    env_file:
+      - path: .env.prod
+        required: false
+    environment:
+      POSTGRES_USER: umami
+      POSTGRES_PASSWORD: ${UMAMI_DB_PASSWORD}
+      POSTGRES_DB: umami
+    volumes:
+      - umami-pg-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U umami"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+          cpus: "1.0"
+    profiles:
+      - production
+
+volumes:
+  umami-pg-data:

--- a/packages/web/src/__tests__/analytics.test.ts
+++ b/packages/web/src/__tests__/analytics.test.ts
@@ -1,0 +1,284 @@
+/**
+ * Tests for the privacy-first analytics helper.
+ *
+ * Covered:
+ * - track() is a no-op in SSR (no window)
+ * - track() queues events when window.umami is missing and flushes when it appears
+ * - sanitizeQueryForTracking() detects DNI/NIE/email/phone PII patterns
+ * - sanitizeQueryForTracking() truncates clean queries to 100 chars
+ * - sendOutboundClick() uses sendBeacon with Blob(application/json)
+ * - debouncedTrack() coalesces rapid calls and supports flush()
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+
+import {
+	debouncedTrack,
+	sanitizeQueryForTracking,
+	sendOutboundClick,
+	track,
+} from "../lib/analytics.ts";
+
+// ---------- DOM stubs (bun:test runs without jsdom by default) ----------
+
+interface UmamiStub {
+	track: ReturnType<typeof mock>;
+}
+
+function installWindow(umami?: UmamiStub) {
+	const win: Record<string, unknown> = {
+		umami,
+		requestAnimationFrame: (cb: FrameRequestCallback) => {
+			cb(0);
+			return 0;
+		},
+		setTimeout: (cb: () => void, _ms: number) => {
+			cb();
+			return 0 as unknown as ReturnType<typeof setTimeout>;
+		},
+		clearTimeout: () => undefined,
+		location: { hostname: "leyabierta.es", pathname: "/laws/BOE-A-1978-31229" },
+		screen: { width: 1920, height: 1080 },
+	};
+	(globalThis as { window?: unknown }).window = win;
+	(globalThis as { requestAnimationFrame?: unknown }).requestAnimationFrame =
+		win.requestAnimationFrame;
+	(globalThis as { setTimeout?: unknown }).setTimeout = win.setTimeout;
+	(globalThis as { clearTimeout?: unknown }).clearTimeout = win.clearTimeout;
+	(globalThis as { navigator?: unknown }).navigator = {
+		language: "es-ES",
+		sendBeacon: mock(() => true),
+	};
+	(globalThis as { Blob?: unknown }).Blob =
+		(globalThis as { Blob?: typeof Blob }).Blob ??
+		class FakeBlob {
+			parts: BlobPart[];
+			type: string;
+			constructor(parts: BlobPart[], opts?: BlobPropertyBag) {
+				this.parts = parts;
+				this.type = opts?.type ?? "";
+			}
+		};
+}
+
+function uninstallWindow() {
+	(globalThis as { window?: unknown }).window = undefined;
+	(globalThis as { navigator?: unknown }).navigator = undefined;
+}
+
+// ---------- track() ----------
+
+describe("track()", () => {
+	afterEach(uninstallWindow);
+
+	it("is a no-op when window is undefined (SSR safety)", () => {
+		uninstallWindow();
+		expect(() => track("test_event")).not.toThrow();
+	});
+
+	it("calls window.umami.track immediately when umami is loaded", () => {
+		const umami = { track: mock(() => undefined) };
+		installWindow(umami);
+		track("digest_subscribe_attempt", { digest: "sanitario" });
+		expect(umami.track).toHaveBeenCalledWith("digest_subscribe_attempt", {
+			digest: "sanitario",
+		});
+	});
+
+	it("queues events when umami is missing, flushes via rAF backstop once it arrives", () => {
+		// Install window WITHOUT umami first.
+		installWindow(undefined);
+		// Make rAF defer until we say so.
+		const rafCallbacks: FrameRequestCallback[] = [];
+		(
+			globalThis as {
+				window: { requestAnimationFrame: typeof requestAnimationFrame };
+			}
+		).window.requestAnimationFrame = (cb: FrameRequestCallback) => {
+			rafCallbacks.push(cb);
+			return 0;
+		};
+		(
+			globalThis as { requestAnimationFrame: typeof requestAnimationFrame }
+		).requestAnimationFrame = (cb: FrameRequestCallback) => {
+			rafCallbacks.push(cb);
+			return 0;
+		};
+		// setTimeout: never fire (we want to test rAF path).
+		(globalThis as { setTimeout: unknown }).setTimeout = () => 0;
+
+		track("search_submit", { len: 5 });
+
+		// Now Umami "loads" between fire and flush.
+		const umami = { track: mock(() => undefined) };
+		(globalThis as { window: { umami?: UmamiStub } }).window.umami = umami;
+
+		// Fire the queued rAF callbacks.
+		for (const cb of rafCallbacks) cb(0);
+
+		expect(umami.track).toHaveBeenCalledTimes(1);
+		expect(umami.track).toHaveBeenCalledWith("search_submit", { len: 5 });
+	});
+});
+
+// ---------- sanitizeQueryForTracking() ----------
+
+describe("sanitizeQueryForTracking()", () => {
+	it("detects valid Spanish DNI (8 digits + letter)", () => {
+		expect(sanitizeQueryForTracking("12345678Z reforma laboral")).toEqual({
+			had_pii: true,
+		});
+	});
+
+	it("detects valid Spanish NIE (X/Y/Z + 7 digits + letter)", () => {
+		expect(sanitizeQueryForTracking("X1234567L permiso")).toEqual({
+			had_pii: true,
+		});
+	});
+
+	it("detects email addresses", () => {
+		expect(sanitizeQueryForTracking("ayuda usuario@example.com")).toEqual({
+			had_pii: true,
+		});
+	});
+
+	it("detects Spanish phone numbers with country prefix and separators", () => {
+		expect(sanitizeQueryForTracking("llama al +34 612 345 678")).toEqual({
+			had_pii: true,
+		});
+		expect(sanitizeQueryForTracking("612345678 ayuda")).toEqual({
+			had_pii: true,
+		});
+	});
+
+	it("returns clean queries unchanged (under 100 chars)", () => {
+		const result = sanitizeQueryForTracking("ley de educacion");
+		expect(result.had_pii).toBe(false);
+		expect(result.query).toBe("ley de educacion");
+	});
+
+	it("truncates clean queries longer than 100 chars", () => {
+		const long = "a".repeat(150);
+		const result = sanitizeQueryForTracking(long);
+		expect(result.had_pii).toBe(false);
+		expect(result.query?.length).toBe(100);
+	});
+
+	it("does not match digits without DNI letter (just numbers)", () => {
+		// 8 digits without final letter = not a DNI under our regex.
+		const result = sanitizeQueryForTracking("articulo 12345678 boe");
+		expect(result.had_pii).toBe(false);
+	});
+});
+
+// ---------- sendOutboundClick() ----------
+
+describe("sendOutboundClick()", () => {
+	beforeEach(() => {
+		installWindow();
+		(
+			import.meta.env as { PUBLIC_UMAMI_WEBSITE_ID?: string }
+		).PUBLIC_UMAMI_WEBSITE_ID = "test-uuid";
+	});
+	afterEach(() => {
+		(
+			import.meta.env as { PUBLIC_UMAMI_WEBSITE_ID?: string }
+		).PUBLIC_UMAMI_WEBSITE_ID = undefined;
+		uninstallWindow();
+	});
+
+	it("calls sendBeacon with a Blob of application/json type", () => {
+		const beacon = mock(() => true);
+		(
+			globalThis as { navigator: { sendBeacon: typeof beacon } }
+		).navigator.sendBeacon = beacon;
+
+		sendOutboundClick("https://www.boe.es/eli/es/c/1978/12/27/(1)", {
+			law_id: "BOE-A-1978-31229",
+		});
+
+		expect(beacon).toHaveBeenCalledTimes(1);
+		const [url, body] = beacon.mock.calls[0] as [string, Blob];
+		expect(url).toBe("https://analytics.leyabierta.es/data/event");
+		// Bun's Blob normalizes the MIME type; just verify the prefix.
+		expect((body as { type: string }).type.startsWith("application/json")).toBe(
+			true,
+		);
+	});
+
+	it("is a no-op when sendBeacon is unavailable", () => {
+		(
+			globalThis as { navigator: { sendBeacon?: unknown } }
+		).navigator.sendBeacon = undefined;
+		expect(() => sendOutboundClick("https://example.com")).not.toThrow();
+	});
+
+	it("is a no-op when website ID env var is missing", () => {
+		(
+			import.meta.env as { PUBLIC_UMAMI_WEBSITE_ID?: string }
+		).PUBLIC_UMAMI_WEBSITE_ID = undefined;
+		const beacon = mock(() => true);
+		(
+			globalThis as { navigator: { sendBeacon: typeof beacon } }
+		).navigator.sendBeacon = beacon;
+		sendOutboundClick("https://example.com");
+		expect(beacon).not.toHaveBeenCalled();
+	});
+});
+
+// ---------- debouncedTrack() ----------
+
+describe("debouncedTrack()", () => {
+	afterEach(uninstallWindow);
+
+	it("debounces rapid calls and fires once after the delay", () => {
+		const umami = { track: mock(() => undefined) };
+		installWindow(umami);
+		// Make setTimeout deferred so we control timing.
+		let pending: (() => void) | undefined;
+		(globalThis as { setTimeout: unknown }).setTimeout = (cb: () => void) => {
+			pending = cb;
+			return 42; // non-zero so the source's `if (timer)` truthiness check passes
+		};
+		(globalThis as { clearTimeout: unknown }).clearTimeout = () => {
+			pending = undefined;
+		};
+
+		const debounced = debouncedTrack("search_submit", 500);
+		debounced.fire({ q: "le" });
+		debounced.fire({ q: "ley" });
+		debounced.fire({ q: "ley educa" });
+
+		expect(umami.track).not.toHaveBeenCalled();
+		// Trigger the timer.
+		pending?.();
+
+		expect(umami.track).toHaveBeenCalledTimes(1);
+		expect(umami.track).toHaveBeenCalledWith("search_submit", {
+			q: "ley educa",
+		});
+	});
+
+	it("flush() fires immediately and clears any pending timer", () => {
+		const umami = { track: mock(() => undefined) };
+		installWindow(umami);
+		let pending: (() => void) | undefined;
+		(globalThis as { setTimeout: unknown }).setTimeout = (cb: () => void) => {
+			pending = cb;
+			return 42; // non-zero so the source's `if (timer)` truthiness check passes
+		};
+		(globalThis as { clearTimeout: unknown }).clearTimeout = () => {
+			pending = undefined;
+		};
+
+		const debounced = debouncedTrack("search_submit", 500);
+		debounced.fire({ q: "ley" });
+		debounced.flush({ q: "ley educacion" });
+
+		expect(umami.track).toHaveBeenCalledTimes(1);
+		expect(umami.track).toHaveBeenCalledWith("search_submit", {
+			q: "ley educacion",
+		});
+		expect(pending).toBeUndefined();
+	});
+});

--- a/packages/web/src/layouts/Base.astro
+++ b/packages/web/src/layouts/Base.astro
@@ -15,6 +15,13 @@ const SITE_URL = "https://leyabierta.es";
 const API_BASE = import.meta.env.PUBLIC_API_URL
 	?? (import.meta.env.DEV ? "http://localhost:3000" : "https://api.leyabierta.es");
 
+// Privacy-first analytics. Loaded only in production builds where the website
+// ID env var is set. The script itself is cookieless and AEPD-compliant for
+// analytics without consent. data-domains scopes events to leyabierta.es so
+// the same script (e.g. on a fork or local dev) does not pollute production.
+const UMAMI_WEBSITE_ID = import.meta.env.PUBLIC_UMAMI_WEBSITE_ID as string | undefined;
+const isProd = import.meta.env.PROD;
+
 const {
 	title,
 	description = "Legislación española consolidada, accesible para todos.",
@@ -568,6 +575,16 @@ const resolvedOgUrl = resolvedCanonicalUrl ?? `${SITE_URL}${Astro.url.pathname}`
 			outline-offset: 2px;
 		}
 	</style>
+
+	{isProd && UMAMI_WEBSITE_ID && (
+		<script
+			defer
+			src="https://analytics.leyabierta.es/ley.js"
+			data-website-id={UMAMI_WEBSITE_ID}
+			data-domains="leyabierta.es"
+			data-cache="true"
+		/>
+	)}
 </head>
 <body>
 	<a href="#main" class="skip-to-content">Saltar al contenido</a>

--- a/packages/web/src/lib/analytics.ts
+++ b/packages/web/src/lib/analytics.ts
@@ -1,0 +1,183 @@
+// Privacy-first analytics helper for Umami (self-hosted).
+//
+// The Umami tracker script is loaded with `defer` from analytics.leyabierta.es,
+// so window.umami may be undefined when this module first runs. Calls to
+// track() before the script loads are queued and flushed once umami appears.
+//
+// Compliant with AEPD criteria for analytics without cookie consent:
+// no cookies, no UserID, no fingerprinting, no cross-site tracking.
+
+declare global {
+	interface Window {
+		umami?: {
+			track: (event: string, data?: Record<string, unknown>) => void;
+		};
+	}
+}
+
+const queue: Array<[string, Record<string, unknown>?]> = [];
+let flushed = false;
+
+function flushIfReady(): void {
+	if (flushed || !window.umami) return;
+	while (queue.length) {
+		const [event, data] = queue.shift() as [string, Record<string, unknown>?];
+		window.umami.track(event, data);
+	}
+	flushed = true;
+}
+
+/**
+ * Track a custom event. Safe in SSR (no-op when window is undefined).
+ * Queues events that fire before the Umami tracker loads (typical first-paint window).
+ */
+export function track(event: string, data?: Record<string, unknown>): void {
+	if (typeof window === "undefined") return;
+
+	if (window.umami) {
+		window.umami.track(event, data);
+		return;
+	}
+
+	queue.push([event, data]);
+	requestAnimationFrame(flushIfReady);
+	// Backstop: 2s later, retry. If umami never loads (adblocker, network),
+	// queued events stay in memory and are lost on tab close. Acceptable.
+	setTimeout(flushIfReady, 2000);
+}
+
+// PII patterns common in legal-search queries on a Spanish site.
+// Bias is toward false positives (privacy first): if any pattern matches,
+// the query is dropped from the tracking payload.
+const PII_PATTERNS: RegExp[] = [
+	/\b\d{8}[A-HJ-NP-TV-Z]\b/i, // DNI
+	/\b[XYZ]\d{7}[A-HJ-NP-TV-Z]\b/i, // NIE
+	/\b[\w.+-]+@[\w-]+\.[\w.-]+\b/, // email
+	/\b(?:\+?34)?[\s-]?[679]\d{2}[\s-]?\d{3}[\s-]?\d{3}\b/, // tel ES
+];
+
+export interface SanitizedQuery {
+	query?: string;
+	had_pii: boolean;
+}
+
+/**
+ * Sanitize a search query for tracking.
+ * Returns { had_pii: true } if any PII pattern matches (query is dropped).
+ * Otherwise returns the query truncated to 100 chars.
+ */
+export function sanitizeQueryForTracking(q: string): SanitizedQuery {
+	if (PII_PATTERNS.some((p) => p.test(q))) {
+		return { had_pii: true };
+	}
+	return { query: q.slice(0, 100), had_pii: false };
+}
+
+/**
+ * Send an outbound-click event using sendBeacon so the request survives
+ * navigation. Falls back to no-op if sendBeacon is unavailable.
+ *
+ * sendBeacon requires a Blob with explicit MIME type for Umami to accept JSON.
+ */
+export function sendOutboundClick(
+	href: string,
+	extra?: Record<string, unknown>,
+): void {
+	if (
+		typeof navigator === "undefined" ||
+		typeof navigator.sendBeacon !== "function"
+	)
+		return;
+	const websiteId = import.meta.env.PUBLIC_UMAMI_WEBSITE_ID as
+		| string
+		| undefined;
+	if (!websiteId) return;
+
+	const payload = {
+		type: "event",
+		payload: {
+			website: websiteId,
+			hostname: window.location.hostname,
+			language: navigator.language,
+			screen: `${window.screen.width}x${window.screen.height}`,
+			url: window.location.pathname,
+			name: "outbound_click",
+			data: { destination: href, ...extra },
+		},
+	};
+
+	const blob = new Blob([JSON.stringify(payload)], {
+		type: "application/json",
+	});
+	navigator.sendBeacon("https://analytics.leyabierta.es/data/event", blob);
+}
+
+/**
+ * Initialize a 75% scroll-depth observer for the current page.
+ * Fires `scroll_depth_75` exactly once per pageview, with reset on the
+ * `pageshow` event so back/forward cache navigation re-arms the trigger.
+ *
+ * Pass an element ref for the sentinel (an empty div positioned at 75% of
+ * the article container is the typical pattern). If null/undefined, no-op.
+ */
+export function initScrollDepth(
+	sentinel: Element | null,
+	eventData?: Record<string, unknown>,
+): void {
+	if (!sentinel || typeof IntersectionObserver === "undefined") return;
+	let fired = false;
+
+	const observer = new IntersectionObserver(
+		(entries) => {
+			for (const entry of entries) {
+				if (entry.isIntersecting && !fired) {
+					fired = true;
+					track("scroll_depth_75", eventData);
+					observer.disconnect();
+				}
+			}
+		},
+		{ threshold: 0.1 },
+	);
+	observer.observe(sentinel);
+
+	// Reset on bfcache navigation so the trigger re-arms on the same page.
+	window.addEventListener("pageshow", (e) => {
+		if (e.persisted) {
+			fired = false;
+			observer.observe(sentinel);
+		}
+	});
+}
+
+/**
+ * Debounce helper for search-as-you-type tracking.
+ * Returns a callable that fires `event` only after `delay` ms of quiet.
+ * Calling .flush() fires immediately (use on Enter / explicit submit).
+ */
+export function debouncedTrack(
+	event: string,
+	delay = 500,
+): {
+	fire: (data?: Record<string, unknown>) => void;
+	flush: (data?: Record<string, unknown>) => void;
+} {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	let lastData: Record<string, unknown> | undefined;
+
+	return {
+		fire(data) {
+			lastData = data;
+			if (timer) clearTimeout(timer);
+			timer = setTimeout(() => {
+				track(event, lastData);
+				timer = undefined;
+			}, delay);
+		},
+		flush(data) {
+			if (timer) clearTimeout(timer);
+			timer = undefined;
+			track(event, data ?? lastData);
+		},
+	};
+}

--- a/packages/web/src/pages/privacidad.astro
+++ b/packages/web/src/pages/privacidad.astro
@@ -8,7 +8,7 @@ import Legal from "../layouts/Legal.astro";
 	canonicalUrl="/privacidad/"
 >
 		<h1>Política de privacidad</h1>
-		<p class="legal-updated">Última actualización: 2 de abril de 2026</p>
+		<p class="legal-updated">Última actualización: 3 de mayo de 2026</p>
 
 		<h2>Responsable del tratamiento</h2>
 		<p>
@@ -63,9 +63,9 @@ import Legal from "../layouts/Legal.astro";
 				</tr>
 				<tr>
 					<td>Datos de navegación agregados</td>
-					<td>Estadísticas anónimas del sitio (Cloudflare Web Analytics)</td>
-					<td>Interés legítimo (art. 6.1.f RGPD)</td>
-					<td>Agregados, sin datos personales</td>
+					<td>Estadísticas anónimas del sitio (Umami self-hosted)</td>
+					<td>Interés legítimo (art. 6.1.f RGPD); exención AEPD para analítica de medición de audiencia</td>
+					<td>25 meses (purga automática)</td>
 				</tr>
 			</tbody>
 		</table>
@@ -102,20 +102,33 @@ import Legal from "../layouts/Legal.astro";
 			datos con ningún otro tercero.
 		</p>
 
-		<h2>Analytics</h2>
+		<h2>Analítica</h2>
 		<p>
-			Utilizamos <strong>Cloudflare Web Analytics</strong>, un servicio de analítica que:
+			Utilizamos <strong>Umami</strong>, un servicio de analítica web open source
+			<strong>auto-alojado en nuestros servidores en Alemania</strong> (Hetzner, Frankfurt).
+			Umami se ha diseñado específicamente para respetar la privacidad:
 		</p>
 		<ul>
-			<li>No utiliza cookies.</li>
-			<li>No recoge direcciones IP ni datos personales.</li>
-			<li>No realiza seguimiento entre sitios.</li>
-			<li>Cumple con el RGPD sin necesidad de consentimiento.</li>
+			<li>No utiliza cookies ni almacenamiento local en tu navegador.</li>
+			<li>No recoge tu dirección IP (se hashea con un salt rotativo diario y se descarta).</li>
+			<li>No te identifica entre visitas ni te sigue en otros sitios web.</li>
+			<li>No usa fingerprinting, tag managers, heatmaps ni grabaciones de sesión.</li>
+			<li>No comparte datos con terceros: el procesamiento ocurre íntegramente en nuestros servidores.</li>
 		</ul>
 		<p>
-			Más información en la
-			<a href="https://www.cloudflare.com/web-analytics/" target="_blank" rel="noopener">documentación
-			de Cloudflare Web Analytics</a>.
+			Solo medimos páginas visitadas, país, navegador, dispositivo y referrer de forma
+			agregada y anónima, exclusivamente para mejorar el servicio. Los datos se conservan
+			un máximo de <strong>25 meses</strong> con purga automática.
+		</p>
+		<p>
+			Esta medición está <strong>exenta de consentimiento</strong> conforme a los criterios
+			de la AEPD para herramientas de medición de audiencia
+			(<a href="https://www.aepd.es/guias/guia-cookies.pdf" target="_blank" rel="noopener">Guía de cookies AEPD</a>;
+			<a href="https://www.aepd.es/guias/orientaciones-analitica-web-aapp.pdf" target="_blank" rel="noopener">Orientaciones para AAPP, febrero 2023</a>),
+			por lo que no mostramos banner de cookies.
+		</p>
+		<p>
+			Umami es <a href="https://github.com/umami-software/umami" target="_blank" rel="noopener">software libre con licencia MIT</a>.
 		</p>
 
 		<h2>Tus derechos</h2>
@@ -146,6 +159,11 @@ import Legal from "../layouts/Legal.astro";
 			El sitio web está alojado en <strong>Cloudflare</strong> (red global de distribución
 			de contenido). Cloudflare cumple con las cláusulas contractuales tipo de la Comisión
 			Europea para transferencias internacionales de datos.
+		</p>
+		<p>
+			Los datos analíticos (Umami) se procesan íntegramente en nuestros servidores en
+			<strong>Hetzner Online GmbH</strong> (Frankfurt, Alemania), dentro del Espacio
+			Económico Europeo. <strong>No hay transferencia internacional de datos analíticos.</strong>
 		</p>
 		<p>
 			El servicio de envío de emails (<strong>Resend, Inc.</strong>) tiene sede en Estados

--- a/scripts/backup-umami-metadata.sh
+++ b/scripts/backup-umami-metadata.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Weekly backup of Umami metadata tables (NOT events).
+# Captures website UUID, users, team config, retention settings —
+# everything needed to recover the panel without forcing a full re-deploy
+# of the web with a new website ID.
+#
+# Events are NOT backed up: data is reproducible via continuous capture
+# and backing up event payloads (even hashed) complicates privacy posture.
+#
+# Run weekly via /etc/cron.d/leyabierta-umami-meta-backup.
+set -euo pipefail
+
+CONTAINER="${UMAMI_DB_CONTAINER:-code-umami-db-1}"
+BACKUP_DIR="${UMAMI_BACKUP_DIR:-/opt/leyabierta/backups}"
+RETAIN_COUNT="${UMAMI_BACKUP_RETAIN:-12}"
+
+mkdir -p "$BACKUP_DIR"
+TS=$(date -u +%Y%m%d)
+OUT="$BACKUP_DIR/umami-meta-$TS.sql"
+
+docker exec "$CONTAINER" pg_dump -U umami -d umami \
+  --table=website \
+  --table=account \
+  --table=team \
+  --table=team_user \
+  --table=team_website \
+  --table=role \
+  --table=user_role \
+  > "$OUT"
+
+gzip -f "$OUT"
+
+# Retain the last N dumps; remove older.
+ls -1t "$BACKUP_DIR"/umami-meta-*.sql.gz 2>/dev/null \
+  | tail -n +"$((RETAIN_COUNT + 1))" \
+  | xargs -r rm
+
+echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) umami-metadata-backup OK ($OUT.gz)"

--- a/scripts/smoke-umami.sh
+++ b/scripts/smoke-umami.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Smoke test for Umami analytics deployment.
+# Verifies heartbeat endpoint and that /data/event accepts events.
+# Run after deploying Umami or when verifying CF Tunnel ingress.
+set -euo pipefail
+
+UMAMI_URL="${UMAMI_URL:-https://analytics.leyabierta.es}"
+WEBSITE_ID="${UMAMI_WEBSITE_ID:?UMAMI_WEBSITE_ID env var required}"
+
+echo "Checking heartbeat at $UMAMI_URL/api/heartbeat ..."
+curl -fsS "$UMAMI_URL/api/heartbeat" > /dev/null
+echo "  OK"
+
+echo "Sending smoke event to $UMAMI_URL/data/event ..."
+curl -fsS -X POST "$UMAMI_URL/data/event" \
+  -H 'Content-Type: application/json' \
+  -H 'User-Agent: leyabierta-smoke/1.0' \
+  -d "$(cat <<EOF
+{
+  "type": "event",
+  "payload": {
+    "website": "$WEBSITE_ID",
+    "hostname": "leyabierta.es",
+    "language": "es-ES",
+    "screen": "1920x1080",
+    "url": "/__smoke__",
+    "name": "smoke_test"
+  }
+}
+EOF
+)" > /dev/null
+echo "  OK"
+
+echo "Umami smoke test passed."

--- a/scripts/umami-purge.sh
+++ b/scripts/umami-purge.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Purge raw Umami events older than 25 months (AEPD retention limit).
+# Aggregates remain in derived tables (irreversibly anonymized).
+# Run monthly via /etc/cron.d/leyabierta-umami-purge.
+set -euo pipefail
+
+CONTAINER="${UMAMI_DB_CONTAINER:-code-umami-db-1}"
+
+docker exec "$CONTAINER" psql -U umami -d umami -c "
+  DELETE FROM website_event WHERE created_at < NOW() - INTERVAL '25 months';
+  DELETE FROM session WHERE created_at < NOW() - INTERVAL '25 months';
+"
+
+echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) umami-purge OK"


### PR DESCRIPTION
Closes #70

## Resumen

Sustituye Cloudflare Web Analytics por Umami self-hosted en KonarServer, expuesto en `analytics.leyabierta.es`. Cumple criterios AEPD para analítica sin consentimiento, así que no necesitamos banner de cookies. Opción first-party que bypassea adblockers que sí bloquean Plausible/GA4.

## Commits

| Commit | Qué |
|--------|-----|
| `feat(infra)` | docker-compose: servicios `umami` + `umami-db` (Postgres 17, named volume), 3 scripts ops (smoke, purge 25 meses, backup metadata semanal). Pin a `umami:postgresql-v2` para que Watchtower no pueda meter breaking changes. |
| `feat(web)` | Helper `analytics.ts` con queue pre-load, filtro PII (DNI/NIE/email/tel ES), `sendBeacon` con Blob JSON para outbound clicks, IntersectionObserver con re-arm en bfcache, debounce con flush para search. Script tag inyectado en `Base.astro` con triple guard (`isProd && WEBSITE_ID && data-domains`). |
| `docs(privacy)` | Política de privacidad actualizada: Umami in-EU, exención AEPD citada, no transferencia internacional para analítica. |

## Reviews completadas

- ✅ `/plan-ceo-review` (HOLD SCOPE) — 5 issues resueltos
- ✅ `/plan-eng-review` — 8 issues resueltos, 0 critical gaps
- ✅ Test diagram producido, **15 unit tests** (SSR safety, queue/flush, PII patterns, sendBeacon, debounce)

Plan detallado en `docs/analytics-plan.md` (privado, fuera del repo).

## Test plan

- [x] `bun test` — 452 tests passing (15 nuevos)
- [x] `bun run check` — biome clean
- [ ] **Server-side (manual, no automatizable):**
  - [ ] Generar y añadir `UMAMI_APP_SECRET` + `UMAMI_DB_PASSWORD` a `/opt/leyabierta/code/.env.prod` (mode 600)
  - [ ] Crear DNS CNAME `analytics.leyabierta.es → tunnel` en Cloudflare
  - [ ] Añadir hostname a `~/.cloudflared/config.yml`, `sudo systemctl restart cloudflared`
  - [ ] Configurar Cloudflare Access policy para `/login`, `/dashboard`, `/settings/*`, `/teams/*`
  - [ ] `docker compose --profile production up -d umami-db umami`
  - [ ] Login admin/umami → cambiar password → crear website "leyabierta.es" → copiar UUID
  - [ ] Añadir `PUBLIC_UMAMI_WEBSITE_ID` al environment "production" de Cloudflare Pages
  - [ ] Instalar crons: purga 25 meses + backup metadata semanal
  - [ ] Configurar Better Stack monitor → `https://analytics.leyabierta.es/api/heartbeat`
  - [ ] Smoke test: `bash scripts/smoke-umami.sh`

## Métricas de éxito (4 semanas post-merge)

- ≥95% pageviews capturados vs CF Web Analytics (durante el periodo de soak en paralelo)
- ≥90% bypass de adblockers (test manual con uBlock + Brave)
- 0 banner de cookies necesario
- <50ms latencia añadida al primer paint
- 12/12 eventos custom funcionando

## Reversibilidad

**4/5.** Borrar 2 contenedores + 1 hostname DNS + 1 line en Base.astro + 1 env var. ~10 min.

## NO en scope

- Triggers de eventos custom específicos (digest_subscribe_attempt en formulario, search_submit en searchbox, outbound_click en `<a target="_blank">`, scroll_depth_75 en law detail). Esto es **Fase 3** del plan, en commit separado o segundo PR cuando confirmemos que el script se carga bien tras el deploy.
- CSP headers (TODO separado)
- Microsoft Clarity / heatmaps (requeriría banner)
- A/B testing framework (premature)

🤖 Generated with [Claude Code](https://claude.com/claude-code)