### PR TITLE
ci(deploy): wire PUBLIC_UMAMI_WEBSITE_ID into web build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -322,6 +322,9 @@ jobs:
         env:
           LAWS_PATH: content/laws
           API_BYPASS_KEY: ${{ secrets.API_BYPASS_KEY }}
+          # Umami website ID (public, AEPD-compliant analytics).
+          # See packages/web/src/layouts/Base.astro: gated by isProd && PUBLIC_UMAMI_WEBSITE_ID
+          PUBLIC_UMAMI_WEBSITE_ID: ${{ vars.PUBLIC_UMAMI_WEBSITE_ID }}
 
       - name: Notify — Deploying
         continue-on-error: true


### PR DESCRIPTION
Follow-up to #71. The Umami tracker script in `Base.astro` is gated by `isProd && PUBLIC_UMAMI_WEBSITE_ID`, so without this var injected at build time the script never renders.

Reads from a GH repo **variable** (not secret) since the website ID is public by design (rendered into every page's HTML).

The variable was set with the actual UUID and is visible at https://github.com/leyabierta/leyabierta/settings/variables/actions

After merge: trigger a manual web deploy via workflow_dispatch and verify `https://leyabierta.es` has the `<script src="https://analytics.leyabierta.es/ley.js">` tag in HTML.

Refs #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)