### PR TITLE
fix(web): add is:inline to Umami tracker script tag

### DIFF
--- a/packages/web/src/layouts/Base.astro
+++ b/packages/web/src/layouts/Base.astro
@@ -578,6 +578,7 @@ const resolvedOgUrl = resolvedCanonicalUrl ?? `${SITE_URL}${Astro.url.pathname}`
 
 	{isProd && UMAMI_WEBSITE_ID && (
 		<script
+			is:inline
 			defer
 			src="https://analytics.leyabierta.es/ley.js"
 			data-website-id={UMAMI_WEBSITE_ID}


### PR DESCRIPTION
Astro processes and bundles `<script>` tags by default. For external scripts (with src), it silently drops them when it cannot bundle them across origins.

Without `is:inline`, the Umami tracker tag never reached the rendered HTML, verified by inspecting dist/<page>/index.html locally before/after this fix.

After this fix, the rendered HTML contains:
```html
<script defer src="https://analytics.leyabierta.es/ley.js" data-website-id="..." data-domains="leyabierta.es" data-cache="true"></script>
```

Refs #70