### PR TITLE
feat(web): add /datos page (Sprint 7 of mega-plan)

### DIFF
--- a/packages/web/src/pages/datos.astro
+++ b/packages/web/src/pages/datos.astro
@@ -48,7 +48,7 @@ import Base from "../layouts/Base.astro";
 				<div class="card">
 					<div class="card-head">
 						<span class="card-mono">llms.txt</span>
-						<a href="/llms.txt" class="card-link" target="_blank">Ver archivo →</a>
+						<a href="/llms.txt" class="card-link" target="_blank" rel="noopener">Ver archivo →</a>
 					</div>
 					<p class="card-body">
 						Descripción concisa del proyecto, páginas principales y endpoints de la API.
@@ -58,7 +58,7 @@ import Base from "../layouts/Base.astro";
 				<div class="card">
 					<div class="card-head">
 						<span class="card-mono">llms-full.txt</span>
-						<a href="/llms-full.txt" class="card-link" target="_blank">Ver archivo →</a>
+						<a href="/llms-full.txt" class="card-link" target="_blank" rel="noopener">Ver archivo →</a>
 					</div>
 					<p class="card-body">
 						Documentación extendida con referencia completa de la API, cobertura por
@@ -133,7 +133,7 @@ import Base from "../layouts/Base.astro";
 				<div class="snippet-item">
 					<p class="snippet-label">Ver el texto de una ley en un commit concreto</p>
 					<div class="code-block">
-						<button class="copy-btn" data-copy="git show <sha> es/BOE-A-1978-31229.md" aria-label="Copiar comando">Copiar</button>
+						<button class="copy-btn" data-copy="git show &lt;sha&gt; es/BOE-A-1978-31229.md" aria-label="Copiar comando">Copiar</button>
 						<pre><code>git show &lt;sha&gt; es/BOE-A-1978-31229.md</code></pre>
 					</div>
 				</div>
@@ -234,7 +234,7 @@ import Base from "../layouts/Base.astro";
 				<div class="feed-item">
 					<div class="feed-head">
 						<span class="feed-name">Reformas recientes</span>
-						<a href="/feed.xml" class="feed-url" target="_blank">/feed.xml</a>
+						<a href="/feed.xml" class="feed-url" target="_blank" rel="noopener">/feed.xml</a>
 					</div>
 					<p class="feed-desc">
 						Todas las reformas procesadas, ordenadas por fecha. Compatible con cualquier
@@ -249,7 +249,7 @@ import Base from "../layouts/Base.astro";
 				<div class="feed-item">
 					<div class="feed-head">
 						<span class="feed-name">Leyes ómnibus</span>
-						<a href="/feed-omnibus.xml" class="feed-url" target="_blank">/feed-omnibus.xml</a>
+						<a href="/feed-omnibus.xml" class="feed-url" target="_blank" rel="noopener">/feed-omnibus.xml</a>
 					</div>
 					<p class="feed-desc">
 						Feed específico para leyes que modifican múltiples normas simultáneamente,

--- a/packages/web/src/pages/datos.astro
+++ b/packages/web/src/pages/datos.astro
@@ -347,16 +347,17 @@ curl -s 'https://api.leyabierta.es/v1/changelog?jurisdiction=es&amp;limit=50' \
 					<button class="copy-btn" aria-label="Copiar script">Copiar</button>
 					<pre><code
 ># Extraer todos los identificadores y títulos
-find leyes/es -name '*.md' | head -100 | while read f; do
+find leyes/es -name '*.md' | head -100 | while read -r f; do
   python3 -c "
-import sys, re
-content = open('$f').read()
+import re, sys
+with open(sys.argv[1]) as fh:
+    content = fh.read()
 match = re.search(r'---\n(.*?)---', content, re.DOTALL)
 if match:
     for line in match.group(1).splitlines():
         if line.startswith('titulo:') or line.startswith('identificador:'):
             print(line.split(':', 1)[1].strip())
-  "
+" "$f"
 done</code></pre>
 				</div>
 				<p class="usecase-note">
@@ -569,8 +570,8 @@ git log --before="2011-01-01" --format="%H" -1 es/BOE-A-1978-31229.md \
 
 	/* ── Prompt block ──────────────────────────────────────── */
 	.prompt-block {
-		background: var(--accent-bg-light);
-		border: 1px solid #d9e3ef;
+		background: var(--accent-faint);
+		border: 1px solid var(--border-light);
 		border-radius: 10px;
 		padding: 1.5rem;
 		margin-bottom: 2rem;
@@ -665,7 +666,6 @@ git log --before="2011-01-01" --format="%H" -1 es/BOE-A-1978-31229.md \
 		gap: 1.5rem;
 		margin-bottom: 2rem;
 	}
-	.snippet-item {}
 	.snippet-label {
 		font-size: 0.8125rem;
 		font-weight: 500;
@@ -707,7 +707,6 @@ git log --before="2011-01-01" --format="%H" -1 es/BOE-A-1978-31229.md \
 		gap: 2rem;
 		margin-bottom: 1.5rem;
 	}
-	.endpoint-group {}
 	.endpoint-title {
 		font-family: var(--font-sans);
 		font-size: 0.875rem;
@@ -725,8 +724,8 @@ git log --before="2011-01-01" --format="%H" -1 es/BOE-A-1978-31229.md \
 		font-size: 0.75rem;
 	}
 	.api-note {
-		background: var(--accent-bg-light);
-		border: 1px solid #d9e3ef;
+		background: var(--accent-faint);
+		border: 1px solid var(--border-light);
 		border-radius: 8px;
 		padding: 1rem 1.25rem;
 	}
@@ -862,7 +861,7 @@ git log --before="2011-01-01" --format="%H" -1 es/BOE-A-1978-31229.md \
 
 	/* ── License section ───────────────────────────────────── */
 	.section-license {
-		background: var(--tierra);
+		background: var(--tierra-warm);
 		border-radius: 12px;
 		padding: 2.5rem 2rem;
 		border: 1px solid var(--tierra-deep);
@@ -914,7 +913,7 @@ git log --before="2011-01-01" --format="%H" -1 es/BOE-A-1978-31229.md \
 		display: inline-flex;
 		align-items: center;
 		padding: 0.5rem 1rem;
-		border: 1.5px solid var(--border-medium);
+		border: 1.5px solid var(--border);
 		border-radius: 6px;
 		font-size: 0.875rem;
 		color: var(--text-secondary);

--- a/packages/web/src/pages/datos.astro
+++ b/packages/web/src/pages/datos.astro
@@ -1,0 +1,971 @@
+---
+/**
+ * /datos — Open data page for developers and LLMs.
+ * Sprint 7 of the Ley Abierta mega-plan.
+ *
+ * Blocks (in order):
+ * 1. Hero
+ * 2. Para LLMs y herramientas legaltech
+ * 3. Repositorio `leyes` (Git)
+ * 4. API REST
+ * 5. RSS feeds
+ * 6. Descargas masivas
+ * 7. Casos de uso técnicos
+ * 8. Licencia + atribución
+ */
+import Base from "../layouts/Base.astro";
+---
+
+<Base
+	title="Datos abiertos de legislación española"
+	description="Legislación española consolidada en abierto: repositorio Git, API REST, feeds RSS y archivos llms.txt para desarrolladores, investigadores y herramientas de IA."
+	canonicalUrl="/datos/"
+>
+	<!-- ── Hero ─────────────────────────────────────────────────── -->
+	<section class="hero">
+		<div class="hero-inner">
+			<p class="kicker">DATOS ABIERTOS</p>
+			<h1>Datos abiertos de legislación española.</h1>
+			<p class="lede">Para desarrolladores e investigadores. Sin límites, sin registro.</p>
+		</div>
+	</section>
+
+	<!-- ── Content wrapper ──────────────────────────────────────── -->
+	<div class="page-body">
+
+		<!-- ── 1. Para LLMs y herramientas legaltech ────────────── -->
+		<section class="section" id="llms">
+			<p class="section-kicker">PARA LLMs Y HERRAMIENTAS LEGALTECH</p>
+			<h2>Integración con modelos de lenguaje</h2>
+			<p class="section-desc">
+				La legislación consolidada española está disponible en formato optimizado para LLMs
+				siguiendo la convención <a href="https://llmstxt.org/" target="_blank" rel="noopener">llms.txt</a>.
+				Estos archivos permiten que ChatGPT, Claude, Perplexity y otras herramientas
+				citen artículos concretos con sus identificadores oficiales.
+			</p>
+
+			<div class="card-grid">
+				<div class="card">
+					<div class="card-head">
+						<span class="card-mono">llms.txt</span>
+						<a href="/llms.txt" class="card-link" target="_blank">Ver archivo →</a>
+					</div>
+					<p class="card-body">
+						Descripción concisa del proyecto, páginas principales y endpoints de la API.
+						Ideal como contexto inicial para cualquier LLM. Se regenera en cada build.
+					</p>
+				</div>
+				<div class="card">
+					<div class="card-head">
+						<span class="card-mono">llms-full.txt</span>
+						<a href="/llms-full.txt" class="card-link" target="_blank">Ver archivo →</a>
+					</div>
+					<p class="card-body">
+						Documentación extendida con referencia completa de la API, cobertura por
+						jurisdicción y rangos normativos. Regenerado en cada build con datos reales.
+					</p>
+				</div>
+			</div>
+
+			<div class="prompt-block">
+				<p class="prompt-label">
+					<span class="kicker-inline">EJEMPLO DE PROMPT</span>
+					Para que cualquier LLM cite leyes españolas con precisión:
+				</p>
+				<div class="code-block">
+					<button class="copy-btn" data-copy="Lee https://leyabierta.es/llms-full.txt y responde citando los identificadores BOE-A-..." aria-label="Copiar prompt">Copiar</button>
+					<pre><code>Lee https://leyabierta.es/llms-full.txt y responde citando los identificadores BOE-A-...</code></pre>
+				</div>
+				<p class="prompt-note">
+					Sustituye los puntos suspensivos por tu pregunta legal concreta.
+					El modelo tendrá contexto sobre cobertura, rangos y formato de identificadores.
+				</p>
+			</div>
+
+			<div class="format-info">
+				<p class="section-kicker-sm">FORMATO DEL ARCHIVO</p>
+				<ul class="format-list">
+					<li>Estructura Markdown siguiendo la especificación llms.txt</li>
+					<li>Cobertura: más de 12.000 leyes consolidadas, 18 jurisdicciones</li>
+					<li>Actualización: se regenera en cada despliegue del sitio (normalmente a diario)</li>
+					<li>Codificación: UTF-8, sin BOM</li>
+				</ul>
+			</div>
+		</section>
+
+		<!-- ── 2. Repositorio leyes (Git) ───────────────────────── -->
+		<section class="section" id="git">
+			<p class="section-kicker">REPOSITORIO GIT</p>
+			<h2>Cada ley es un archivo Markdown. Cada reforma es un commit.</h2>
+			<p class="section-desc">
+				El repositorio <code class="inline-code">leyes</code> contiene toda la legislación
+				española consolidada como archivos Markdown con historial Git. Cada reforma
+				legislativa corresponde a un commit con fecha oficial del BOE como
+				<code class="inline-code">GIT_AUTHOR_DATE</code>.
+				Clona el repositorio y trabaja localmente sin depender de ninguna API.
+			</p>
+
+			<div class="snippets">
+				<div class="snippet-item">
+					<p class="snippet-label">Clonar el repositorio</p>
+					<div class="code-block">
+						<button class="copy-btn" data-copy="git clone https://github.com/leyabierta/leyes.git" aria-label="Copiar comando">Copiar</button>
+						<pre><code>git clone https://github.com/leyabierta/leyes.git</code></pre>
+					</div>
+				</div>
+
+				<div class="snippet-item">
+					<p class="snippet-label">Leer una ley</p>
+					<div class="code-block">
+						<button class="copy-btn" data-copy="cat es/BOE-A-1978-31229.md" aria-label="Copiar comando">Copiar</button>
+						<pre><code>cat es/BOE-A-1978-31229.md</code></pre>
+					</div>
+				</div>
+
+				<div class="snippet-item">
+					<p class="snippet-label">Ver el historial de reformas de una ley</p>
+					<div class="code-block">
+						<button class="copy-btn" data-copy="git log --oneline es/BOE-A-1978-31229.md" aria-label="Copiar comando">Copiar</button>
+						<pre><code>git log --oneline es/BOE-A-1978-31229.md</code></pre>
+					</div>
+				</div>
+
+				<div class="snippet-item">
+					<p class="snippet-label">Ver el texto de una ley en un commit concreto</p>
+					<div class="code-block">
+						<button class="copy-btn" data-copy="git show <sha> es/BOE-A-1978-31229.md" aria-label="Copiar comando">Copiar</button>
+						<pre><code>git show &lt;sha&gt; es/BOE-A-1978-31229.md</code></pre>
+					</div>
+				</div>
+			</div>
+
+			<div class="repo-meta">
+				<p>
+					Estructura de carpetas: <code class="inline-code">es/</code> para legislación
+					estatal, <code class="inline-code">es-ct/</code>, <code class="inline-code">es-an/</code>,
+					<code class="inline-code">es-pv/</code>... para comunidades autónomas.
+					Sigue la convención ELI (European Legislation Identifier).
+				</p>
+				<a href="https://github.com/leyabierta/leyes" class="btn-outline" target="_blank" rel="noopener">
+					Ver repositorio en GitHub →
+				</a>
+			</div>
+		</section>
+
+		<!-- ── 3. API REST ──────────────────────────────────────── -->
+		<section class="section" id="api">
+			<p class="section-kicker">API REST</p>
+			<h2>Acceso programático a toda la legislación</h2>
+			<p class="section-desc">
+				API REST pública sobre toda la legislación española consolidada.
+				Sin autenticación, sin límite de peticiones. Endpoint base:
+				<code class="inline-code">https://api.leyabierta.es/v1</code>
+			</p>
+
+			<div class="api-endpoints">
+				<div class="endpoint-group">
+					<h3 class="endpoint-title">Buscar y listar leyes</h3>
+					<div class="code-block">
+						<button class="copy-btn" data-copy="curl 'https://api.leyabierta.es/v1/laws?q=contrato+trabajo&limit=10'" aria-label="Copiar comando">Copiar</button>
+						<pre><code>curl 'https://api.leyabierta.es/v1/laws?q=contrato+trabajo&amp;limit=10'</code></pre>
+					</div>
+					<p class="endpoint-desc">
+						Parámetros: <code class="inline-code">q</code> (texto),
+						<code class="inline-code">rank</code> (ley, real_decreto…),
+						<code class="inline-code">jurisdiction</code> (es, es-ct…),
+						<code class="inline-code">status</code> (vigente, derogada),
+						<code class="inline-code">limit</code>, <code class="inline-code">offset</code>.
+					</p>
+				</div>
+
+				<div class="endpoint-group">
+					<h3 class="endpoint-title">Obtener una ley completa</h3>
+					<div class="code-block">
+						<button class="copy-btn" data-copy="curl 'https://api.leyabierta.es/v1/laws/BOE-A-1978-31229'" aria-label="Copiar comando">Copiar</button>
+						<pre><code>curl 'https://api.leyabierta.es/v1/laws/BOE-A-1978-31229'</code></pre>
+					</div>
+					<p class="endpoint-desc">
+						Devuelve metadatos completos, artículos y lista de reformas.
+					</p>
+				</div>
+
+				<div class="endpoint-group">
+					<h3 class="endpoint-title">Comparar dos versiones de una ley</h3>
+					<div class="code-block">
+						<button class="copy-btn" data-copy="curl 'https://api.leyabierta.es/v1/laws/BOE-A-1978-31229/diff?from=2010-01-01&to=2024-01-01'" aria-label="Copiar comando">Copiar</button>
+						<pre><code>curl 'https://api.leyabierta.es/v1/laws/BOE-A-1978-31229/diff?from=2010-01-01&amp;to=2024-01-01'</code></pre>
+					</div>
+					<p class="endpoint-desc">
+						Diff unificado entre dos fechas. Útil para detectar qué artículos cambiaron
+						en un período concreto.
+					</p>
+				</div>
+
+				<div class="endpoint-group">
+					<h3 class="endpoint-title">Últimas reformas con resúmenes</h3>
+					<div class="code-block">
+						<button class="copy-btn" data-copy="curl 'https://api.leyabierta.es/v1/changelog?jurisdiction=es&limit=20'" aria-label="Copiar comando">Copiar</button>
+						<pre><code>curl 'https://api.leyabierta.es/v1/changelog?jurisdiction=es&amp;limit=20'</code></pre>
+					</div>
+					<p class="endpoint-desc">
+						Reformas recientes con resúmenes generados por IA. Filtra por jurisdicción
+						y por fecha con <code class="inline-code">since=YYYY-MM-DD</code>.
+					</p>
+				</div>
+			</div>
+
+			<div class="api-note">
+				<p>
+					Todos los endpoints devuelven JSON. Sin autenticación. Sin límites de tasa documentados —
+					aplica cortesía razonable si haces scraping masivo.
+				</p>
+			</div>
+		</section>
+
+		<!-- ── 4. RSS feeds ─────────────────────────────────────── -->
+		<section class="section" id="feeds">
+			<p class="section-kicker">RSS FEEDS</p>
+			<h2>Suscripción a reformas legislativas</h2>
+			<p class="section-desc">
+				Feeds RSS para integrar las últimas reformas en tu flujo de trabajo.
+			</p>
+
+			<div class="feed-list">
+				<div class="feed-item">
+					<div class="feed-head">
+						<span class="feed-name">Reformas recientes</span>
+						<a href="/feed.xml" class="feed-url" target="_blank">/feed.xml</a>
+					</div>
+					<p class="feed-desc">
+						Todas las reformas procesadas, ordenadas por fecha. Compatible con cualquier
+						lector RSS.
+					</p>
+					<div class="code-block">
+						<button class="copy-btn" data-copy="https://leyabierta.es/feed.xml" aria-label="Copiar URL">Copiar URL</button>
+						<pre><code>https://leyabierta.es/feed.xml</code></pre>
+					</div>
+				</div>
+
+				<div class="feed-item">
+					<div class="feed-head">
+						<span class="feed-name">Leyes ómnibus</span>
+						<a href="/feed-omnibus.xml" class="feed-url" target="_blank">/feed-omnibus.xml</a>
+					</div>
+					<p class="feed-desc">
+						Feed específico para leyes que modifican múltiples normas simultáneamente,
+						con desglose por temas.
+					</p>
+					<div class="code-block">
+						<button class="copy-btn" data-copy="https://leyabierta.es/feed-omnibus.xml" aria-label="Copiar URL">Copiar URL</button>
+						<pre><code>https://leyabierta.es/feed-omnibus.xml</code></pre>
+					</div>
+				</div>
+			</div>
+		</section>
+
+		<!-- ── 5. Descargas masivas ─────────────────────────────── -->
+		<section class="section" id="descargas">
+			<p class="section-kicker">DESCARGAS MASIVAS</p>
+			<h2>Corpus completo</h2>
+			<p class="section-desc">
+				Para análisis a gran escala o para construir tu propio índice.
+			</p>
+
+			<div class="download-grid">
+				<div class="download-card">
+					<div class="download-head">
+						<span class="download-format">JSONL</span>
+						<span class="download-badge coming-soon">Próximamente</span>
+					</div>
+					<p class="download-body">
+						Corpus completo en formato JSONL (una ley por línea), con metadatos y
+						artículos. Pensado para ingesta en pipelines de datos o entrenamiento.
+					</p>
+				</div>
+
+				<div class="download-card">
+					<div class="download-head">
+						<span class="download-format">SQLite</span>
+						<span class="download-badge coming-soon">Próximamente</span>
+					</div>
+					<p class="download-body">
+						Snapshot de la base de datos SQLite con índice FTS5. Permite búsqueda
+						local sin depender de la API.
+					</p>
+				</div>
+
+				<div class="download-card git-download">
+					<div class="download-head">
+						<span class="download-format">Git (disponible hoy)</span>
+					</div>
+					<p class="download-body">
+						El repositorio <code class="inline-code">leyes</code> en GitHub contiene
+						todo el corpus en archivos Markdown con historial completo. Es la forma
+						más directa de obtener los datos hoy.
+					</p>
+					<a href="https://github.com/leyabierta/leyes" class="btn-outline" target="_blank" rel="noopener">
+						github.com/leyabierta/leyes →
+					</a>
+				</div>
+			</div>
+		</section>
+
+		<!-- ── 6. Casos de uso técnicos ─────────────────────────── -->
+		<section class="section" id="ejemplos">
+			<p class="section-kicker">CASOS DE USO</p>
+			<h2>Ejemplos prácticos</h2>
+
+			<div class="usecase">
+				<h3 class="usecase-title">Alertador de reformas en 20 líneas con jq</h3>
+				<p class="usecase-desc">
+					Obtén las últimas reformas de una jurisdicción y filtra las que afectan
+					a un tema concreto:
+				</p>
+				<div class="code-block" data-snippet="jq-alertador">
+					<button class="copy-btn" aria-label="Copiar script">Copiar</button>
+					<pre><code
+>#!/bin/sh
+# Últimas reformas laborales en España
+curl -s 'https://api.leyabierta.es/v1/changelog?jurisdiction=es&amp;limit=50' \
+  | jq -r '
+      .reforms[]
+      | select(.materias[]? | test("Trabajo|Empleo|Laboral"; "i"))
+      | "\(.date) \(.title)"
+    '</code></pre>
+				</div>
+			</div>
+
+			<div class="usecase">
+				<h3 class="usecase-title">Indexa el corpus en tu propio RAG</h3>
+				<p class="usecase-desc">
+					Ley Abierta incluye 483.983 embeddings de artículos vigentes (Gemini embedding,
+					3072 dimensiones). Si prefieres construir tu propio índice vectorial, clona el
+					repositorio <code class="inline-code">leyes</code> y extrae los artículos del
+					frontmatter YAML:
+				</p>
+				<div class="code-block" data-snippet="rag-extract">
+					<button class="copy-btn" aria-label="Copiar script">Copiar</button>
+					<pre><code
+># Extraer todos los identificadores y títulos
+find leyes/es -name '*.md' | head -100 | while read f; do
+  python3 -c "
+import sys, re
+content = open('$f').read()
+match = re.search(r'---\n(.*?)---', content, re.DOTALL)
+if match:
+    for line in match.group(1).splitlines():
+        if line.startswith('titulo:') or line.startswith('identificador:'):
+            print(line.split(':', 1)[1].strip())
+  "
+done</code></pre>
+				</div>
+				<p class="usecase-note">
+					La arquitectura RAG completa de Ley Abierta (hybrid BM25 + vector search +
+					Cohere reranking) está documentada en el
+					<a href="https://github.com/leyabierta/leyabierta" target="_blank" rel="noopener">código fuente</a>.
+				</p>
+			</div>
+
+			<div class="usecase">
+				<h3 class="usecase-title">Compara dos versiones con git diff</h3>
+				<p class="usecase-desc">
+					El historial Git permite comparar cualquier par de versiones de una ley.
+					Cada commit corresponde a una reforma oficial con fecha exacta:
+				</p>
+				<div class="code-block" data-snippet="git-diff">
+					<button class="copy-btn" aria-label="Copiar script">Copiar</button>
+					<pre><code
+>cd leyes
+
+# Ver todos los commits de la Constitución
+git log --oneline es/BOE-A-1978-31229.md
+
+# Comparar dos versiones concretas (sustituye los SHAs)
+git diff abc1234 def5678 -- es/BOE-A-1978-31229.md
+
+# Versión de una ley en una fecha concreta
+git log --before="2011-01-01" --format="%H" -1 es/BOE-A-1978-31229.md \
+  | xargs -I&#123;&#125; git show &#123;&#125;:es/BOE-A-1978-31229.md</code></pre>
+				</div>
+			</div>
+		</section>
+
+		<!-- ── 7. Licencia + atribución ─────────────────────────── -->
+		<section class="section section-license" id="licencia">
+			<p class="section-kicker">LICENCIA Y ATRIBUCIÓN</p>
+			<h2>Uso libre, atribución obligatoria</h2>
+
+			<div class="license-grid">
+				<div class="license-item">
+					<h3 class="license-title">Código fuente</h3>
+					<p class="license-body">
+						El motor, la API y el sitio web están publicados bajo la licencia
+						<strong>AGPL-3.0</strong>. Si distribuyes una versión modificada,
+						debes publicar el código fuente.
+					</p>
+					<a href="https://github.com/leyabierta/leyabierta" class="btn-outline" target="_blank" rel="noopener">
+						Ver código en GitHub →
+					</a>
+				</div>
+
+				<div class="license-item">
+					<h3 class="license-title">Contenido legislativo</h3>
+					<p class="license-body">
+						La legislación española es de <strong>dominio público</strong>.
+						Puedes usarla, redistribuirla y adaptarla sin restricciones de copyright.
+					</p>
+					<p class="attribution-note">
+						Atribución requerida por la fuente oficial:
+					</p>
+					<div class="attribution-block">
+						<span>Fuente: <a href="https://www.boe.es/" target="_blank" rel="noopener">Agencia Estatal BOE</a></span>
+					</div>
+				</div>
+			</div>
+		</section>
+
+	</div><!-- /page-body -->
+</Base>
+
+<style>
+	/* ── Page-level layout ─────────────────────────────────── */
+	.page-body {
+		max-width: 52rem;
+		margin: 0 auto;
+		padding: 0 1.5rem 5rem;
+	}
+
+	/* ── Hero ───────────────────────────────────────────────── */
+	.hero {
+		background: var(--surface);
+		border-bottom: 1px solid var(--border);
+		padding: 4rem 1.5rem 3.5rem;
+	}
+	.hero-inner {
+		max-width: 52rem;
+		margin: 0 auto;
+	}
+	.kicker {
+		font-family: var(--font-mono);
+		font-size: 0.6875rem;
+		letter-spacing: 0.12em;
+		text-transform: uppercase;
+		color: var(--text-muted);
+		margin: 0 0 1rem;
+	}
+	.hero h1 {
+		font-family: var(--font-serif);
+		font-size: clamp(1.875rem, 5vw, 3rem);
+		font-weight: 700;
+		line-height: 1.1;
+		letter-spacing: -0.02em;
+		color: var(--text);
+		margin: 0 0 1rem;
+	}
+	.lede {
+		font-size: 1.125rem;
+		line-height: 1.55;
+		color: var(--text-secondary);
+		margin: 0;
+	}
+
+	/* ── Sections ──────────────────────────────────────────── */
+	.section {
+		padding: 4rem 0;
+		border-bottom: 1px solid var(--border);
+	}
+	.section:last-child {
+		border-bottom: none;
+	}
+	.section-kicker {
+		font-family: var(--font-mono);
+		font-size: 0.6875rem;
+		letter-spacing: 0.12em;
+		text-transform: uppercase;
+		color: var(--text-muted);
+		margin: 0 0 0.75rem;
+	}
+	.section-kicker-sm {
+		font-family: var(--font-mono);
+		font-size: 0.6875rem;
+		letter-spacing: 0.12em;
+		text-transform: uppercase;
+		color: var(--text-muted);
+		margin: 0 0 0.5rem;
+	}
+	.kicker-inline {
+		font-family: var(--font-mono);
+		font-size: 0.6875rem;
+		letter-spacing: 0.12em;
+		text-transform: uppercase;
+		color: var(--text-muted);
+		display: block;
+		margin-bottom: 0.375rem;
+	}
+	.section h2 {
+		font-family: var(--font-serif);
+		font-size: 1.5rem;
+		font-weight: 600;
+		color: var(--text);
+		margin: 0 0 1rem;
+		line-height: 1.25;
+	}
+	.section-desc {
+		font-size: 0.9375rem;
+		line-height: 1.65;
+		color: var(--text-secondary);
+		margin: 0 0 2rem;
+	}
+	.section-desc a {
+		color: var(--accent);
+		text-decoration: underline;
+		text-decoration-thickness: 1px;
+		text-underline-offset: 2px;
+	}
+
+	/* ── Cards (LLMs) ──────────────────────────────────────── */
+	.card-grid {
+		display: grid;
+		grid-template-columns: 1fr;
+		gap: 1rem;
+		margin-bottom: 2rem;
+	}
+	@media (min-width: 600px) {
+		.card-grid { grid-template-columns: 1fr 1fr; }
+	}
+	.card {
+		background: var(--surface);
+		border: 1px solid var(--border);
+		border-radius: 10px;
+		padding: 1.25rem;
+	}
+	.card-head {
+		display: flex;
+		align-items: baseline;
+		justify-content: space-between;
+		margin-bottom: 0.75rem;
+		gap: 0.5rem;
+	}
+	.card-mono {
+		font-family: var(--font-mono);
+		font-size: 0.875rem;
+		font-weight: 500;
+		color: var(--accent);
+		letter-spacing: 0.04em;
+	}
+	.card-link {
+		font-size: 0.8125rem;
+		color: var(--text-muted);
+		text-decoration: none;
+		white-space: nowrap;
+	}
+	.card-link:hover { color: var(--accent); }
+	.card-body {
+		font-size: 0.875rem;
+		line-height: 1.6;
+		color: var(--text-secondary);
+		margin: 0;
+	}
+
+	/* ── Prompt block ──────────────────────────────────────── */
+	.prompt-block {
+		background: var(--accent-bg-light);
+		border: 1px solid #d9e3ef;
+		border-radius: 10px;
+		padding: 1.5rem;
+		margin-bottom: 2rem;
+	}
+	.prompt-label {
+		font-size: 0.875rem;
+		color: var(--text-secondary);
+		margin: 0 0 0.875rem;
+		line-height: 1.5;
+	}
+	.prompt-note {
+		font-size: 0.8125rem;
+		color: var(--text-muted);
+		margin: 0.75rem 0 0;
+		line-height: 1.55;
+	}
+
+	/* ── Format info ───────────────────────────────────────── */
+	.format-info {
+		margin-top: 1.5rem;
+	}
+	.format-list {
+		list-style: none;
+		padding: 0;
+		margin: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+	}
+	.format-list li {
+		font-size: 0.875rem;
+		color: var(--text-secondary);
+		padding-left: 1.25rem;
+		position: relative;
+		line-height: 1.55;
+	}
+	.format-list li::before {
+		content: "—";
+		position: absolute;
+		left: 0;
+		color: var(--text-muted);
+	}
+
+	/* ── Code blocks ───────────────────────────────────────── */
+	.code-block {
+		position: relative;
+		background: #0f172a;
+		border-radius: 8px;
+		overflow: hidden;
+	}
+	.code-block pre {
+		margin: 0;
+		padding: 1rem 1.25rem;
+		overflow-x: auto;
+		-webkit-overflow-scrolling: touch;
+	}
+	.code-block code {
+		font-family: var(--font-mono);
+		font-size: 0.8125rem;
+		line-height: 1.6;
+		color: #e2e8f0;
+		white-space: pre;
+	}
+	.copy-btn {
+		position: absolute;
+		top: 0.625rem;
+		right: 0.625rem;
+		background: rgba(255, 255, 255, 0.08);
+		border: 1px solid rgba(255, 255, 255, 0.15);
+		border-radius: 4px;
+		color: #94a3b8;
+		font-family: var(--font-sans);
+		font-size: 0.75rem;
+		padding: 0.25rem 0.625rem;
+		cursor: pointer;
+		transition: background 0.15s, color 0.15s;
+		z-index: 1;
+	}
+	.copy-btn:hover {
+		background: rgba(255, 255, 255, 0.15);
+		color: #e2e8f0;
+	}
+	.copy-btn.copied {
+		color: #4ade80;
+		border-color: rgba(74, 222, 128, 0.3);
+	}
+
+	/* ── Snippets (Git section) ────────────────────────────── */
+	.snippets {
+		display: flex;
+		flex-direction: column;
+		gap: 1.5rem;
+		margin-bottom: 2rem;
+	}
+	.snippet-item {}
+	.snippet-label {
+		font-size: 0.8125rem;
+		font-weight: 500;
+		color: var(--text-secondary);
+		margin: 0 0 0.5rem;
+	}
+
+	/* ── Repo meta ─────────────────────────────────────────── */
+	.repo-meta {
+		background: var(--surface);
+		border: 1px solid var(--border);
+		border-radius: 10px;
+		padding: 1.25rem;
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+	}
+	.repo-meta p {
+		font-size: 0.875rem;
+		color: var(--text-secondary);
+		margin: 0;
+		line-height: 1.6;
+	}
+
+	/* ── Inline code ───────────────────────────────────────── */
+	.inline-code {
+		font-family: var(--font-mono);
+		font-size: 0.8125rem;
+		background: var(--accent-bg);
+		color: var(--accent);
+		padding: 0.1em 0.35em;
+		border-radius: 3px;
+	}
+
+	/* ── API endpoints ─────────────────────────────────────── */
+	.api-endpoints {
+		display: flex;
+		flex-direction: column;
+		gap: 2rem;
+		margin-bottom: 1.5rem;
+	}
+	.endpoint-group {}
+	.endpoint-title {
+		font-family: var(--font-sans);
+		font-size: 0.875rem;
+		font-weight: 600;
+		color: var(--text);
+		margin: 0 0 0.625rem;
+	}
+	.endpoint-desc {
+		font-size: 0.8125rem;
+		color: var(--text-muted);
+		margin: 0.625rem 0 0;
+		line-height: 1.55;
+	}
+	.endpoint-desc .inline-code {
+		font-size: 0.75rem;
+	}
+	.api-note {
+		background: var(--accent-bg-light);
+		border: 1px solid #d9e3ef;
+		border-radius: 8px;
+		padding: 1rem 1.25rem;
+	}
+	.api-note p {
+		font-size: 0.8125rem;
+		color: var(--text-secondary);
+		margin: 0;
+		line-height: 1.55;
+	}
+
+	/* ── Feeds ─────────────────────────────────────────────── */
+	.feed-list {
+		display: flex;
+		flex-direction: column;
+		gap: 1.5rem;
+	}
+	.feed-item {
+		background: var(--surface);
+		border: 1px solid var(--border);
+		border-radius: 10px;
+		padding: 1.25rem;
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+	}
+	.feed-head {
+		display: flex;
+		align-items: baseline;
+		justify-content: space-between;
+		gap: 0.5rem;
+	}
+	.feed-name {
+		font-size: 0.9375rem;
+		font-weight: 600;
+		color: var(--text);
+	}
+	.feed-url {
+		font-family: var(--font-mono);
+		font-size: 0.75rem;
+		color: var(--text-muted);
+		text-decoration: none;
+		letter-spacing: 0.02em;
+	}
+	.feed-url:hover { color: var(--accent); }
+	.feed-desc {
+		font-size: 0.875rem;
+		color: var(--text-secondary);
+		margin: 0;
+		line-height: 1.55;
+	}
+
+	/* ── Downloads ─────────────────────────────────────────── */
+	.download-grid {
+		display: grid;
+		grid-template-columns: 1fr;
+		gap: 1rem;
+	}
+	@media (min-width: 600px) {
+		.download-grid { grid-template-columns: 1fr 1fr; }
+		.git-download { grid-column: 1 / -1; }
+	}
+	.download-card {
+		background: var(--surface);
+		border: 1px solid var(--border);
+		border-radius: 10px;
+		padding: 1.25rem;
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+	}
+	.download-head {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+	}
+	.download-format {
+		font-family: var(--font-mono);
+		font-size: 0.875rem;
+		font-weight: 500;
+		color: var(--accent);
+		letter-spacing: 0.04em;
+	}
+	.download-badge {
+		font-size: 0.6875rem;
+		font-weight: 600;
+		padding: 0.2rem 0.5rem;
+		border-radius: 4px;
+	}
+	.coming-soon {
+		background: var(--accent-bg);
+		color: var(--text-muted);
+	}
+	.download-body {
+		font-size: 0.875rem;
+		color: var(--text-secondary);
+		margin: 0;
+		line-height: 1.6;
+	}
+
+	/* ── Use cases ─────────────────────────────────────────── */
+	.usecase {
+		margin-bottom: 2.5rem;
+	}
+	.usecase:last-child { margin-bottom: 0; }
+	.usecase-title {
+		font-family: var(--font-sans);
+		font-size: 1rem;
+		font-weight: 600;
+		color: var(--text);
+		margin: 0 0 0.625rem;
+	}
+	.usecase-desc {
+		font-size: 0.875rem;
+		color: var(--text-secondary);
+		margin: 0 0 0.875rem;
+		line-height: 1.6;
+	}
+	.usecase-desc .inline-code {
+		font-size: 0.75rem;
+	}
+	.usecase-note {
+		font-size: 0.8125rem;
+		color: var(--text-muted);
+		margin: 0.75rem 0 0;
+		line-height: 1.55;
+	}
+	.usecase-note a {
+		color: var(--accent);
+		text-decoration: underline;
+		text-decoration-thickness: 1px;
+		text-underline-offset: 2px;
+	}
+
+	/* ── License section ───────────────────────────────────── */
+	.section-license {
+		background: var(--tierra);
+		border-radius: 12px;
+		padding: 2.5rem 2rem;
+		border: 1px solid var(--tierra-deep);
+		margin-top: 1rem;
+	}
+	.license-grid {
+		display: grid;
+		grid-template-columns: 1fr;
+		gap: 2rem;
+	}
+	@media (min-width: 600px) {
+		.license-grid { grid-template-columns: 1fr 1fr; }
+	}
+	.license-title {
+		font-family: var(--font-sans);
+		font-size: 0.9375rem;
+		font-weight: 600;
+		color: var(--text);
+		margin: 0 0 0.625rem;
+	}
+	.license-body {
+		font-size: 0.875rem;
+		color: var(--text-secondary);
+		margin: 0 0 1rem;
+		line-height: 1.6;
+	}
+	.attribution-note {
+		font-size: 0.8125rem;
+		color: var(--text-muted);
+		margin: 0 0 0.5rem;
+	}
+	.attribution-block {
+		background: var(--surface);
+		border: 1px solid var(--tierra-deep);
+		border-radius: 6px;
+		padding: 0.625rem 0.875rem;
+		font-size: 0.875rem;
+		color: var(--text-secondary);
+	}
+	.attribution-block a {
+		color: var(--accent);
+		text-decoration: underline;
+		text-decoration-thickness: 1px;
+		text-underline-offset: 2px;
+	}
+
+	/* ── Buttons ───────────────────────────────────────────── */
+	.btn-outline {
+		display: inline-flex;
+		align-items: center;
+		padding: 0.5rem 1rem;
+		border: 1.5px solid var(--border-medium);
+		border-radius: 6px;
+		font-size: 0.875rem;
+		color: var(--text-secondary);
+		text-decoration: none;
+		transition: border-color 0.15s, color 0.15s;
+		align-self: flex-start;
+	}
+	.btn-outline:hover {
+		border-color: var(--accent);
+		color: var(--accent);
+	}
+
+	/* ── Responsive adjustments ────────────────────────────── */
+	@media (max-width: 480px) {
+		.hero { padding: 2.5rem 1.25rem 2rem; }
+		.section { padding: 3rem 0; }
+		.section-license { padding: 2rem 1.25rem; }
+		.page-body { padding: 0 1.25rem 4rem; }
+		.card-head { flex-direction: column; align-items: flex-start; }
+		.feed-head { flex-direction: column; align-items: flex-start; }
+	}
+</style>
+
+<script>
+	// Copy button functionality for all code blocks on the page.
+	document.addEventListener("DOMContentLoaded", () => {
+		const copyBtns = document.querySelectorAll<HTMLButtonElement>(".copy-btn");
+		for (const btn of copyBtns) {
+			btn.addEventListener("click", async () => {
+				const text = btn.dataset.copy ?? btn.closest(".code-block")?.querySelector("code")?.textContent ?? "";
+				try {
+					await navigator.clipboard.writeText(text);
+					const orig = btn.textContent;
+					btn.textContent = "Copiado";
+					btn.classList.add("copied");
+					setTimeout(() => {
+						btn.textContent = orig;
+						btn.classList.remove("copied");
+					}, 2000);
+				} catch {
+					// Fallback: select the code text so the user can copy manually
+					const code = btn.closest(".code-block")?.querySelector("code");
+					if (code) {
+						const sel = window.getSelection();
+						const range = document.createRange();
+						range.selectNodeContents(code);
+						sel?.removeAllRanges();
+						sel?.addRange(range);
+					}
+				}
+			});
+		}
+	});
+</script>


### PR DESCRIPTION
## Summary

- Adds `packages/web/src/pages/datos.astro` — the new `/datos` developer landing page for Sprint 7 of the mega-plan
- Implements all 8 blocks in spec order: hero, LLMs integration, Git repo, API REST, RSS feeds, bulk downloads, use-case snippets, license + attribution
- Vanilla JS copy-to-clipboard with graceful fallback (select text) for all code blocks; no JS framework

## Block inventory

| # | Block | Notes |
|---|-------|-------|
| 1 | Hero | "Datos abiertos de legislación española. Para desarrolladores e investigadores. Sin límites, sin registro." |
| 2 | Para LLMs | Cards for llms.txt / llms-full.txt + copyable prompt example + format info |
| 3 | Repositorio Git | 4 copyable bash snippets (clone, cat, log --oneline, git show) |
| 4 | API REST | 4 curl examples (laws, laws/:id, diff, changelog) with param docs |
| 5 | RSS feeds | /feed.xml and /feed-omnibus.xml with copyable URLs |
| 6 | Descargas masivas | JSONL + SQLite marked "Próximamente" (honest), Git link available today |
| 7 | Casos de uso | jq alerter, RAG corpus extraction, git diff comparison — all verbatim-executable |
| 8 | Licencia + atribución | AGPL code, dominio público legislation, "Fuente: Agencia Estatal BOE" |

## Design compliance

- Follows DESIGN.md strictly: Source Serif 4 for headings, Inter for body, JetBrains Mono for kickers and code, `--accent` / `--tierra` palette
- No shadows (borders only), no gradients, no centered-everything layouts
- Mobile-first with breakpoints at 480px and 600px
- Warm `--tierra` background for the license section (human/citizen context, per DESIGN.md warm/cool distinction)

## What was NOT touched (per spec hard rules)

- `Navbar.astro` — not touched
- `BaseLayout.astro` — not touched (uses existing `Base.astro` layout like all other flat pages)
- `_redirects` — not touched

## Decisions for human review

1. **Bulk downloads "Próximamente"**: JSONL and SQLite downloads don't exist yet, so they're marked "Próximamente" with a clear honest label. The Git repo is highlighted as the "available today" path.
2. **Code display in use-case blocks**: Complex multi-line scripts with shell metacharacters (backreferences, pipes, `{}` in `xargs`) use raw HTML in `<pre><code>` with HTML entity encoding for `&`, `{`, `}` where Astro would otherwise interpret them. The copy button falls back to reading `code.textContent` (actual unescaped text) for correct clipboard output.
3. **Section URL is `/datos/`** (flat file `datos.astro`, not `datos/index.astro`) — matches the existing convention of `pregunta.astro`, `cambios.astro`, etc. Astro with `trailingSlash: "always"` will serve it at `/datos/`.

## Test plan

- [x] `bun run check` — 0 issues (167 files checked)
- [x] `bun test packages/web/` — 42 pass, 0 fail
- [x] `bun test` (full suite via pre-push hook) — 497 pass, 5 skip, 0 fail
- [ ] Visual review: open `/datos/` in dev server and verify 8 blocks render in order
- [ ] Mobile review: verify layout at 375px (hero, cards, code blocks)
- [ ] Copy buttons: test clipboard copy + select-text fallback (Safari / restricted context)
- [ ] Verify `/llms.txt` and `/llms-full.txt` links resolve correctly

## Reference

Implements Sprint 7 per `~/.gstack/projects/leyabierta-leyabierta/MEGA-PLAN-2026-05-03.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)