### PR TITLE
feat(web): add /cambios hub + reorganise change pages (Sprint 2)

### DIFF
--- a/packages/web/public/_redirects
+++ b/packages/web/public/_redirects
@@ -16,7 +16,8 @@
 /privacidad /privacidad/ 301
 /omnibus /omnibus/ 301
 /omnibus/detalle /omnibus/detalle/ 301
-/reforma /reforma/ 301
+/reforma /cambios/recientes/ 301
+/reforma/ /cambios/recientes/ 301
 /situaciones /situaciones/ 301
 
 # === Reorganización Cambios hub (2026-05-03) ===
@@ -24,7 +25,7 @@
 /omnibus/detalle/:normId /cambios/omnibus/:normId/ 301
 /omnibus/detalle/:normId/ /cambios/omnibus/:normId/ 301
 /mis-cambios/ /cambios/mias/ 301
-/reforma/:reformaId /cambios/:reformaId 301
+/reforma/:reformaId /cambios/:reformaId/ 301
 /reforma/:reformaId/ /cambios/:reformaId/ 301
 
 # === Migración /laws/ → /leyes/ (2026-05-03) ===

--- a/packages/web/public/_redirects
+++ b/packages/web/public/_redirects
@@ -1,6 +1,9 @@
 # Force trailing slash on internal routes (Astro trailingSlash: "always")
 /pregunta /pregunta/ 301
 /cambios /cambios/ 301
+/cambios/recientes /cambios/recientes/ 301
+/cambios/omnibus /cambios/omnibus/ 301
+/cambios/mias /cambios/mias/ 301
 /mis-cambios /mis-cambios/ 301
 /mi-situacion /mi-situacion/ 301
 /alertas /alertas/ 301
@@ -15,6 +18,14 @@
 /omnibus/detalle /omnibus/detalle/ 301
 /reforma /reforma/ 301
 /situaciones /situaciones/ 301
+
+# === Reorganización Cambios hub (2026-05-03) ===
+/omnibus/ /cambios/omnibus/ 301
+/omnibus/detalle/:normId /cambios/omnibus/:normId/ 301
+/omnibus/detalle/:normId/ /cambios/omnibus/:normId/ 301
+/mis-cambios/ /cambios/mias/ 301
+/reforma/:reformaId /cambios/:reformaId 301
+/reforma/:reformaId/ /cambios/:reformaId/ 301
 
 # === Migración /laws/ → /leyes/ (2026-05-03) ===
 # Two named-param rules cover both bare and trailing-slash variants

--- a/packages/web/src/lib/analytics-init.ts
+++ b/packages/web/src/lib/analytics-init.ts
@@ -67,12 +67,12 @@ function wireOutboundClicks() {
 }
 
 function wireScrollDepthIfArticle() {
-	// Long-content pages: /leyes/<id>/, /reforma/, /omnibus/<id>/, /sobre-leyabierta/
+	// Long-content pages: /leyes/<id>/, /cambios/<id>/, /cambios/omnibus/<id>/, /sobre-leyabierta/
 	const path = window.location.pathname;
 	const isArticle =
 		/^\/leyes\/[^/]+\/?$/.test(path) ||
-		/^\/reforma\/?$/.test(path) ||
-		/^\/omnibus\/[^/]+\/?$/.test(path) ||
+		/^\/cambios\/[^/]+\/?$/.test(path) ||
+		/^\/cambios\/omnibus\/[^/]+\/?$/.test(path) ||
 		/^\/sobre-leyabierta\/?$/.test(path);
 	if (!isArticle) return;
 

--- a/packages/web/src/lib/analytics-init.ts
+++ b/packages/web/src/lib/analytics-init.ts
@@ -71,7 +71,7 @@ function wireScrollDepthIfArticle() {
 	const path = window.location.pathname;
 	const isArticle =
 		/^\/leyes\/[^/]+\/?$/.test(path) ||
-		/^\/cambios\/[^/]+\/?$/.test(path) ||
+		/^\/cambios\/(?!recientes\/?$|mias\/?$|omnibus\/?$)[^/]+\/?$/.test(path) ||
 		/^\/cambios\/omnibus\/[^/]+\/?$/.test(path) ||
 		/^\/sobre-leyabierta\/?$/.test(path);
 	if (!isArticle) return;

--- a/packages/web/src/pages/alertas/confirmar.astro
+++ b/packages/web/src/pages/alertas/confirmar.astro
@@ -86,7 +86,7 @@ import Base from "../../layouts/Base.astro";
 							'<div class="confirm-icon success">&#10003;</div>' +
 							'<h1>Suscripción confirmada</h1>' +
 							'<p>Tu alerta legislativa está activa. Recibirás una notificación cuando se publiquen cambios que te afecten.</p>' +
-							'<a href="/mis-cambios/" class="btn btn-primary">Ver mis cambios</a>';
+							'<a href="/cambios/mias/" class="btn btn-primary">Ver mis cambios</a>';
 					} else {
 						el.innerHTML =
 							'<div class="confirm-icon error">&#10007;</div>' +

--- a/packages/web/src/pages/cambios/[reformaId].astro
+++ b/packages/web/src/pages/cambios/[reformaId].astro
@@ -1,5 +1,5 @@
 ---
-import Base from "../layouts/Base.astro";
+import Base from "../../layouts/Base.astro";
 ---
 
 <Base
@@ -198,7 +198,7 @@ import Base from "../layouts/Base.astro";
 	</style>
 
 	<div class="reforma-wrap">
-		<a href="/mis-cambios/" class="reforma-back" id="reforma-back">&larr; Volver</a>
+		<a href="/cambios/recientes/" class="reforma-back" id="reforma-back">&larr; Volver</a>
 		<div id="reforma-content">
 			<div class="reforma-header">
 				<div class="skeleton-line" style="width:30%"></div>
@@ -224,12 +224,17 @@ import Base from "../layouts/Base.astro";
 				// Set label based on context
 				if (from === "cambios") {
 					backLink.innerHTML = "&larr; Volver a cambios recientes";
+				} else if (from === "mis-cambios") {
+					backLink.innerHTML = "&larr; Volver a mis cambios";
+					backLink.href = "/cambios/mias/";
 				} else if (from === "omnibus" || from === "law") {
 					backLink.innerHTML = "&larr; Volver a la ley";
 				} else if (document.referrer && document.referrer.indexOf(location.origin) === 0) {
 					var refPath = new URL(document.referrer).pathname;
-					if (refPath === "/cambios/") {
+					if (refPath === "/cambios/recientes/" || refPath === "/cambios/") {
 						backLink.innerHTML = "&larr; Volver a cambios recientes";
+					} else if (refPath === "/cambios/mias/") {
+						backLink.innerHTML = "&larr; Volver a mis cambios";
 					} else if (refPath.indexOf("/leyes/") === 0) {
 						backLink.innerHTML = "&larr; Volver a la ley";
 					}
@@ -242,7 +247,7 @@ import Base from "../layouts/Base.astro";
 						history.back();
 					});
 				} else if (from === "cambios") {
-					backLink.href = "/cambios/";
+					backLink.href = "/cambios/recientes/";
 				} else if ((from === "omnibus" || from === "law") && normId) {
 					backLink.href = "/leyes/" + encodeURIComponent(normId) + "/";
 				}
@@ -272,6 +277,20 @@ import Base from "../layouts/Base.astro";
 				var months = ["ene", "feb", "mar", "abr", "may", "jun", "jul", "ago", "sep", "oct", "nov", "dic"];
 				return dt.getDate() + " " + months[dt.getMonth()] + " " + dt.getFullYear();
 			}
+
+			// Read normId from path: /cambios/{normId}?date=...
+			var pathParts = window.location.pathname.split("/").filter(Boolean);
+			// pathParts = ["cambios", normId]
+			var normId = pathParts[pathParts.length - 1] || "";
+			// Fallback to query param for backwards compat
+			var qParams = new URLSearchParams(window.location.search);
+			if (!normId || normId === "cambios") {
+				normId = qParams.get("id") || "";
+			}
+			var date = qParams.get("date");
+			var topicParam = qParams.get("topic");
+			var topicIndex = topicParam !== null ? parseInt(topicParam, 10) : NaN;
+			var fromOmnibus = qParams.get("from") === "omnibus";
 
 			// Render paragraph-level diff with word highlighting
 			function renderBlockDiff(beforeText, afterText, container) {
@@ -348,12 +367,6 @@ import Base from "../layouts/Base.astro";
 
 			var API = document.documentElement.dataset.api;
 			var contentDiv = document.getElementById("reforma-content");
-			var params = new URLSearchParams(window.location.search);
-			var normId = params.get("id");
-			var date = params.get("date");
-			var topicParam = params.get("topic");
-			var topicIndex = topicParam !== null ? parseInt(topicParam, 10) : NaN;
-			var fromOmnibus = params.get("from") === "omnibus";
 
 			if (!normId || !date) {
 				contentDiv.innerHTML = '<div class="error-state"><p>Faltan parámetros.</p></div>';
@@ -397,20 +410,11 @@ import Base from "../layouts/Base.astro";
 					var rankLabel = RANK_LABELS[law.rank] || law.rank || "";
 
 					// Bug fix #1: detect if this reform is the one that derogated the law.
-					// Signal: law.status === "derogada" AND law.last_reform_date === reform.date
-					// (last_reform_date is set by the API only when next_reform_date is null, i.e. this IS the latest reform)
 					var isDerogatingReform = law.status === "derogada" && law.last_reform_date === reform.date;
 
 					// Resolve type label — override to "Derogación" when derogating reform
 					var typeLabel = isDerogatingReform ? "Derogación" : (TYPE_LABELS[reform.reform_type] || "");
 
-					// H1 priority: AI-generated reform headline first (citizen-friendly, plain
-					// language, already includes the verb for derogations); fall back to the
-					// law's official title. Never use short_title here — its regex is geared
-					// to "Ley X/YEAR" patterns and produces awkward truncations on Resolución/
-					// Orden titles ("Resolución de 31 de enero..." → "Resolución de 31").
-					// No "Derogada:" prefix — the type badge and the status chip already
-					// communicate the derogation, prefixing it would be redundant.
 					var headline = hasHeadline ? reform.headline : law.title;
 
 					// ── Header ──
@@ -427,8 +431,6 @@ import Base from "../layouts/Base.astro";
 					html += ' · <a href="/leyes/' + encodeURIComponent(law.id) + '/">' + esc(law.title) + '</a>';
 					html += '</div></div>';
 
-					// ── Topic tag in date row (when filtering by omnibus topic) ──
-
 					// ── Summary ──
 					if (reform.summary) {
 						html += '<div class="reforma-summary">' + esc(reform.summary) + '</div>';
@@ -437,7 +439,7 @@ import Base from "../layouts/Base.astro";
 					// ── Empty topic intersection ──
 					if (topicBlockIds && blocks.length === 0) {
 						html += '<p style="color:var(--text-muted);font-size:0.9375rem;margin-bottom:0.5rem">Los ' + topicBlockIds.length + ' artículo' + (topicBlockIds.length !== 1 ? 's' : '') + ' de este tema no se modificaron en esta reforma.</p>';
-						html += '<p style="font-size:0.875rem"><a href="/reforma?id=' + encodeURIComponent(law.id) + '&date=' + encodeURIComponent(reform.date) + '&from=omnibus" style="color:var(--accent-light)">Ver todos los cambios de esta reforma &rarr;</a></p>';
+						html += '<p style="font-size:0.875rem"><a href="/cambios/' + encodeURIComponent(law.id) + '?date=' + encodeURIComponent(reform.date) + '&from=omnibus" style="color:var(--accent-light)">Ver todos los cambios de esta reforma &rarr;</a></p>';
 					}
 
 					// ── Affected blocks ──
@@ -451,8 +453,6 @@ import Base from "../layouts/Base.astro";
 							var isOpen = i < 5;
 
 							html += '<div class="block-change">';
-							// Bug fix #3: nota_inicial blocks have id "no" and empty title.
-							// Show a citizen-readable label instead of the raw id.
 							var isNotaInicial = b.block_type === "nota_inicial" || b.block_id === "no";
 							var blockLabel = isNotaInicial ? "Nota oficial del BOE" : (b.title || b.block_id);
 
@@ -463,7 +463,6 @@ import Base from "../layouts/Base.astro";
 							html += '<div class="block-change-body' + (isOpen ? ' open' : '') + '" id="block-' + i + '">';
 
 							if (isNew) {
-								// Bug fix #4: nota_inicial is not a new article — it's a derogation notice.
 								var newBlockLabel = isNotaInicial ? "Aviso oficial" : "Artículo nuevo";
 								html += '<div class="new-block">';
 								html += '<div class="version-label">' + newBlockLabel + '</div>';
@@ -476,7 +475,6 @@ import Base from "../layouts/Base.astro";
 						}
 						html += '</section>';
 					} else if (data.prev_reform_date && !topicBlockIds) {
-						// No block-level data and NOT filtered by topic — show unified diff fallback
 						html += '<section class="reforma-changes">';
 						html += '<h2>Qué ha cambiado</h2>';
 						html += '<div id="unified-diff-container"><div class="diff-content" style="color:var(--text-muted);font-size:0.8125rem;padding:1rem">Cargando diferencias...</div></div>';
@@ -503,7 +501,7 @@ import Base from "../layouts/Base.astro";
 						});
 					});
 
-					// ── Unified diff fallback (when no block-level data and NOT topic-filtered) ──
+					// ── Unified diff fallback ──
 					if (blocks.length === 0 && data.prev_reform_date && !topicBlockIds) {
 						var diffUrl = API + "/v1/laws/" + encodeURIComponent(normId) + "/diff?from=" + encodeURIComponent(data.prev_reform_date) + "&to=" + encodeURIComponent(date);
 						fetch(diffUrl)
@@ -519,7 +517,6 @@ import Base from "../layouts/Base.astro";
 								var skippedHeader = false;
 								for (var j = 0; j < lines.length; j++) {
 									var line = lines[j];
-									// Skip git diff header lines (diff --git, index, ---, +++)
 									if (!skippedHeader) {
 										if (line.indexOf("diff --git") === 0 || line.indexOf("index ") === 0 || line.indexOf("---") === 0 || line.indexOf("+++") === 0) continue;
 										if (line.indexOf("@@") === 0) skippedHeader = true;
@@ -569,9 +566,9 @@ import Base from "../layouts/Base.astro";
 				.catch(function () {
 					var params2 = new URLSearchParams(window.location.search);
 					var from2 = params2.get("from") || "";
-					var errorBackHref = "/mis-cambios/";
+					var errorBackHref = "/cambios/mias/";
 					var errorBackLabel = "Volver a mis cambios";
-					if (from2 === "cambios") { errorBackHref = "/cambios/"; errorBackLabel = "Volver a cambios recientes"; }
+					if (from2 === "cambios") { errorBackHref = "/cambios/recientes/"; errorBackLabel = "Volver a cambios recientes"; }
 					else if (from2 === "omnibus") { errorBackHref = "/leyes/" + encodeURIComponent(params2.get("id") || "") + "/"; errorBackLabel = "Volver a la ley"; }
 					else if (from2 === "law") { errorBackHref = "/leyes/" + encodeURIComponent(params2.get("id") || "") + "/"; errorBackLabel = "Volver a la ley"; }
 					contentDiv.innerHTML = '<div class="error-state"><p>No se pudo cargar la reforma.</p><a href="' + errorBackHref + '" style="color:var(--accent)">' + errorBackLabel + '</a></div>';

--- a/packages/web/src/pages/cambios/index.astro
+++ b/packages/web/src/pages/cambios/index.astro
@@ -1,0 +1,206 @@
+---
+import Base from "../../layouts/Base.astro";
+---
+
+<Base
+	title="Cambios legislativos"
+	description="El seguimiento de las novedades legislativas en España: recientes, multitemáticas y personalizadas."
+	ogTitle="Cambios legislativos — Ley Abierta"
+	canonicalUrl="/cambios/"
+>
+	<style is:global>
+		.hub-wrap {
+			max-width: 720px;
+			margin: 0 auto;
+			padding: 0 1rem 4rem;
+		}
+
+		/* ── Header ── */
+		.hub-header {
+			margin-bottom: 2.5rem;
+			padding-bottom: 2rem;
+			border-bottom: 1px solid var(--border);
+		}
+		.hub-header h1 {
+			font-family: var(--font-serif);
+			font-size: 2.25rem;
+			font-weight: 700;
+			line-height: 1.15;
+			color: var(--text);
+			margin-bottom: 0.625rem;
+		}
+		.hub-header p {
+			color: var(--text-secondary);
+			font-size: 1rem;
+			line-height: 1.6;
+			max-width: 52ch;
+		}
+
+		/* ── Cards grid ── */
+		.hub-grid {
+			display: grid;
+			grid-template-columns: 1fr 1fr;
+			gap: 1rem;
+			margin-bottom: 2rem;
+		}
+		@media (max-width: 560px) {
+			.hub-grid { grid-template-columns: 1fr; }
+			.hub-header h1 { font-size: 1.75rem; }
+		}
+
+		.hub-card {
+			display: block;
+			background: var(--surface);
+			border: 1px solid var(--border);
+			border-radius: 12px;
+			padding: 1.5rem 1.5rem 1.25rem;
+			text-decoration: none;
+			transition: box-shadow 0.18s, border-color 0.18s;
+		}
+		.hub-card:hover {
+			box-shadow: 0 4px 16px rgba(0, 0, 0, 0.07);
+			border-color: var(--border-medium);
+		}
+		.hub-card-icon {
+			width: 40px;
+			height: 40px;
+			border-radius: 10px;
+			background: var(--accent-bg);
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			margin-bottom: 1rem;
+			font-size: 1.25rem;
+		}
+		.hub-card h2 {
+			font-family: var(--font-serif);
+			font-size: 1.125rem;
+			font-weight: 700;
+			color: var(--text);
+			margin-bottom: 0.375rem;
+			line-height: 1.3;
+		}
+		.hub-card p {
+			color: var(--text-secondary);
+			font-size: 0.875rem;
+			line-height: 1.55;
+			margin-bottom: 0.75rem;
+		}
+		.hub-card-arrow {
+			font-size: 0.8125rem;
+			font-weight: 600;
+			color: var(--accent);
+		}
+
+		/* ── CTA de suscripción ── */
+		.hub-cta {
+			padding: 1.75rem 2rem;
+			background: var(--accent-bg-light);
+			border: 1px solid var(--border);
+			border-radius: 12px;
+			display: flex;
+			align-items: center;
+			gap: 1.5rem;
+			flex-wrap: wrap;
+		}
+		.hub-cta-text h2 {
+			font-family: var(--font-serif);
+			font-size: 1.125rem;
+			font-weight: 700;
+			color: var(--text);
+			margin-bottom: 0.25rem;
+		}
+		.hub-cta-text p {
+			color: var(--text-secondary);
+			font-size: 0.9rem;
+			line-height: 1.5;
+		}
+		.hub-cta-actions {
+			display: flex;
+			gap: 0.75rem;
+			flex-wrap: wrap;
+			flex-shrink: 0;
+		}
+		.btn-primary-hub {
+			display: inline-flex;
+			align-items: center;
+			background: var(--accent);
+			color: #fff;
+			border-radius: 8px;
+			padding: 0.625rem 1.25rem;
+			font-size: 0.875rem;
+			font-weight: 600;
+			text-decoration: none;
+			min-height: 44px;
+			white-space: nowrap;
+		}
+		.btn-primary-hub:hover {
+			opacity: 0.9;
+		}
+		.btn-secondary-hub {
+			display: inline-flex;
+			align-items: center;
+			background: transparent;
+			color: var(--accent);
+			border: 1px solid var(--accent);
+			border-radius: 8px;
+			padding: 0.625rem 1.25rem;
+			font-size: 0.875rem;
+			font-weight: 600;
+			text-decoration: none;
+			min-height: 44px;
+			white-space: nowrap;
+		}
+		.btn-secondary-hub:hover {
+			background: var(--accent-bg);
+		}
+	</style>
+
+	<div class="hub-wrap">
+		<div class="hub-header">
+			<h1>Cambios legislativos</h1>
+			<p>Sigue la actividad legislativa en España: últimas modificaciones, leyes con múltiples temas y los cambios que te afectan a ti.</p>
+		</div>
+
+		<div class="hub-grid">
+			<a href="/cambios/recientes/" class="hub-card">
+				<div class="hub-card-icon" aria-hidden="true">📋</div>
+				<h2>Recientes</h2>
+				<p>Las últimas modificaciones legislativas explicadas en lenguaje ciudadano.</p>
+				<span class="hub-card-arrow">Ver cambios recientes →</span>
+			</a>
+
+			<a href="/cambios/omnibus/" class="hub-card">
+				<div class="hub-card-icon" aria-hidden="true">📦</div>
+				<h2>Ómnibus</h2>
+				<p>Leyes que agrupan múltiples temas en una sola norma, desglosadas por categoría.</p>
+				<span class="hub-card-arrow">Ver leyes ómnibus →</span>
+			</a>
+
+			<a href="/cambios/mias/" class="hub-card">
+				<div class="hub-card-icon" aria-hidden="true">👤</div>
+				<h2>Los míos</h2>
+				<p>Solo los cambios que afectan a tu situación: trabajo, vivienda, familia y más.</p>
+				<span class="hub-card-arrow">Ver mis cambios →</span>
+			</a>
+
+			<a href="/alertas/" class="hub-card">
+				<div class="hub-card-icon" aria-hidden="true">🔔</div>
+				<h2>Alertas por email</h2>
+				<p>Recibe un aviso cuando cambien leyes que te importan. Sin spam.</p>
+				<span class="hub-card-arrow">Configurar alertas →</span>
+			</a>
+		</div>
+
+		<div class="hub-cta">
+			<div class="hub-cta-text">
+				<h2>¿Quieres saber qué te afecta a ti?</h2>
+				<p>Cuéntanos tu situación en 1 minuto y filtramos los cambios que importan.</p>
+			</div>
+			<div class="hub-cta-actions">
+				<a href="/cambios/mias/" class="btn-primary-hub">Empezar</a>
+				<a href="/alertas/" class="btn-secondary-hub">Suscribirme</a>
+			</div>
+		</div>
+	</div>
+</Base>

--- a/packages/web/src/pages/cambios/mias.astro
+++ b/packages/web/src/pages/cambios/mias.astro
@@ -1,12 +1,12 @@
 ---
-import Base from "../layouts/Base.astro";
+import Base from "../../layouts/Base.astro";
 ---
 
 <Base
 	title="Mis cambios legislativos"
 	description="Los cambios legislativos que afectan a tu situación personal."
 	ogTitle="Mis cambios — Ley Abierta"
-	canonicalUrl="/mis-cambios/"
+	canonicalUrl="/cambios/mias/"
 >
 	<style is:global>
 		.cambios-wrap {
@@ -483,7 +483,7 @@ import Base from "../layouts/Base.astro";
 						html += '<h3 class="reform-title-fallback">' + esc(r.title) + '</h3>';
 					}
 
-					html += '<a href="/reforma?id=' + encodeURIComponent(r.id) + '&date=' + encodeURIComponent(r.date) + '&from=mis-cambios" class="reform-link">Ver qué cambió →</a>';
+					html += '<a href="/cambios/' + encodeURIComponent(r.id) + '?date=' + encodeURIComponent(r.date) + '&from=mis-cambios" class="reform-link">Ver qué cambió →</a>';
 					html += '</div>';
 				}
 				return html;

--- a/packages/web/src/pages/cambios/omnibus/[normId].astro
+++ b/packages/web/src/pages/cambios/omnibus/[normId].astro
@@ -1,5 +1,5 @@
 ---
-import Base from "../../layouts/Base.astro";
+import Base from "../../../layouts/Base.astro";
 ---
 
 <Base
@@ -8,12 +8,13 @@ import Base from "../../layouts/Base.astro";
 >
 	<script is:inline>
 		(function () {
-			var params = new URLSearchParams(window.location.search);
-			var normId = params.get("id") || "";
+			var parts = window.location.pathname.split("/").filter(Boolean);
+			// path: /cambios/omnibus/{normId}
+			var normId = parts[parts.length - 1] || "";
 			if (normId) {
 				window.location.replace("/leyes/" + encodeURIComponent(normId) + "/");
 			} else {
-				window.location.replace("/omnibus/");
+				window.location.replace("/cambios/omnibus/");
 			}
 		})();
 	</script>

--- a/packages/web/src/pages/cambios/omnibus/index.astro
+++ b/packages/web/src/pages/cambios/omnibus/index.astro
@@ -1,12 +1,12 @@
 ---
-import Base from "../../layouts/Base.astro";
+import Base from "../../../layouts/Base.astro";
 ---
 
 <Base
 	title="Leyes ómnibus"
 	description="Leyes que agrupan múltiples temas en una sola norma. Aquí desglosamos qué contiene cada una."
 	ogTitle="Leyes ómnibus — Ley Abierta"
-	canonicalUrl="/omnibus/"
+	canonicalUrl="/cambios/omnibus/"
 >
 	<style is:global>
 		.omnibus-wrap {

--- a/packages/web/src/pages/cambios/recientes.astro
+++ b/packages/web/src/pages/cambios/recientes.astro
@@ -1,12 +1,12 @@
 ---
-import Base from "../layouts/Base.astro";
+import Base from "../../layouts/Base.astro";
 ---
 
 <Base
 	title="Últimos cambios legislativos"
 	description="Novedades legislativas recientes en España, explicadas en lenguaje ciudadano."
 	ogTitle="Cambios legislativos — Ley Abierta"
-	canonicalUrl="/cambios/"
+	canonicalUrl="/cambios/recientes/"
 >
 	<style is:global>
 		.cambios-wrap {
@@ -244,7 +244,7 @@ import Base from "../layouts/Base.astro";
 		<div class="cambios-header">
 			<h1>Últimos cambios legislativos</h1>
 			<p>Las novedades legislativas más recientes, explicadas en lenguaje ciudadano.</p>
-			<p style="margin-top: 0.5rem;"><a href="/omnibus/" style="color: var(--accent); font-size: 0.875rem; font-weight: 500;">Ver leyes ómnibus recientes →</a></p>
+			<p style="margin-top: 0.5rem;"><a href="/cambios/omnibus/" style="color: var(--accent); font-size: 0.875rem; font-weight: 500;">Ver leyes ómnibus recientes →</a></p>
 			<div class="cambios-filters">
 				<label for="jur-filter" class="sr-only">Jurisdicción</label>
 				<select id="jur-filter">
@@ -291,7 +291,7 @@ import Base from "../layouts/Base.astro";
 		<section class="cambios-cta">
 			<h2>¿Quieres saber qué cambios te afectan?</h2>
 			<p>Configura tu situación y te mostramos solo lo que importa para ti.</p>
-			<a href="/mi-situacion/">Descúbrelo en 1 minuto</a>
+			<a href="/cambios/mias/">Descúbrelo en 1 minuto</a>
 		</section>
 	</div>
 
@@ -399,7 +399,7 @@ import Base from "../layouts/Base.astro";
 							if (rankLabel) html += '<span>' + esc(rankLabel) + '</span>';
 							if (statusLabel) html += '<span class="' + statusClass + '" style="text-transform:none">' + esc(statusLabel) + '</span>';
 							html += '</div>';
-							html += '<a href="/reforma?id=' + encodeURIComponent(r.id) + '&date=' + encodeURIComponent(r.date) + '&from=cambios" class="reform-link">Ver qué cambió →</a>';
+							html += '<a href="/cambios/' + encodeURIComponent(r.id) + '?date=' + encodeURIComponent(r.date) + '&from=cambios" class="reform-link">Ver qué cambió →</a>';
 							html += '</div>';
 						}
 						html += '</div>';

--- a/packages/web/src/pages/index.astro
+++ b/packages/web/src/pages/index.astro
@@ -882,7 +882,7 @@ const TOPICS = [
 					<span class="sep">·</span>
 					<a href="/cambios/">Cambios recientes</a>
 					<span class="sep">·</span>
-					<a href="/omnibus/">Ómnibus</a>
+					<a href="/cambios/omnibus/">Ómnibus</a>
 				</div>
 			</div>
 		</section>

--- a/packages/web/src/pages/leyes/[id].astro
+++ b/packages/web/src/pages/leyes/[id].astro
@@ -807,7 +807,7 @@ const seoDescription = [
 					link.textContent = "\u2190 Volver a resultados";
 				} else if (refPath === "/cambios/") {
 					link.textContent = "\u2190 Volver a cambios recientes";
-				} else if (refPath === "/mis-cambios/") {
+				} else if (refPath === "/cambios/mias/") {
 					link.textContent = "\u2190 Volver a mis cambios";
 				}
 			}
@@ -1013,7 +1013,7 @@ const seoDescription = [
 			<ul class="timeline">
 				{reforms.map((reform, i) => {
 					const isOriginal = i === reforms.length - 1;
-					const reformaUrl = !isOriginal ? `/reforma?id=${id}&date=${reform.fecha}&from=law` : null;
+					const reformaUrl = !isOriginal ? `/cambios/${id}?date=${reform.fecha}&from=law` : null;
 					return (
 						<li class="timeline-item">
 							<div class="timeline-dot"></div>

--- a/packages/web/src/pages/llms-full.txt.ts
+++ b/packages/web/src/pages/llms-full.txt.ts
@@ -101,7 +101,7 @@ ${rankLines}
 ## Páginas principales
 - [Inicio](https://leyabierta.es/): Buscador de leyes, estadísticas, últimas reformas
 - [Cambios legislativos](https://leyabierta.es/cambios/): Cronología de reformas recientes con resúmenes
-- [Leyes ómnibus](https://leyabierta.es/omnibus/): Detección de leyes que modifican múltiples normas
+- [Leyes ómnibus](https://leyabierta.es/cambios/omnibus/): Detección de leyes que modifican múltiples normas
 - [Alertas](https://leyabierta.es/alertas/): Suscripción a notificaciones por temas y jurisdicción
 - [Sobre Ley Abierta](https://leyabierta.es/sobre-leyabierta/): Misión, datos, metodología
 

--- a/packages/web/src/pages/llms.txt.ts
+++ b/packages/web/src/pages/llms.txt.ts
@@ -27,7 +27,7 @@ export const GET: APIRoute = async () => {
 ## Páginas principales
 - [Inicio](https://leyabierta.es/): Buscador de leyes, estadísticas, últimas reformas
 - [Cambios legislativos](https://leyabierta.es/cambios/): Cronología de reformas recientes con resúmenes
-- [Leyes ómnibus](https://leyabierta.es/omnibus/): Detección de leyes que modifican múltiples normas
+- [Leyes ómnibus](https://leyabierta.es/cambios/omnibus/): Detección de leyes que modifican múltiples normas
 - [Alertas](https://leyabierta.es/alertas/): Suscripción a notificaciones por temas y jurisdicción
 - [Sobre Ley Abierta](https://leyabierta.es/sobre-leyabierta/): Misión, datos, metodología
 

--- a/packages/web/src/pages/mi-situacion.astro
+++ b/packages/web/src/pages/mi-situacion.astro
@@ -727,7 +727,7 @@ const JURISDICTION_OPTIONS = [
 				try {
 					localStorage.setItem("leyabierta_perfil", JSON.stringify(data));
 				} catch (err) {}
-				window.location.href = "/mis-cambios/";
+				window.location.href = "/cambios/mias/";
 			}
 
 			document.getElementById("btn-next-extras").addEventListener("click", finishWizard);


### PR DESCRIPTION
## Resumen

- Nueva página hub `/cambios/` con 4 tarjetas: Recientes, Ómnibus, Los míos, Alertas
- 5 páginas reorganizadas bajo `/cambios/`:
  - `cambios.astro` → `cambios/recientes.astro`
  - `omnibus/index.astro` → `cambios/omnibus/index.astro`
  - `omnibus/detalle.astro` → `cambios/omnibus/[normId].astro`
  - `mis-cambios.astro` → `cambios/mias.astro`
  - `reforma.astro` → `cambios/[reformaId].astro`
- 301 redirects añadidos en `_redirects` para todas las URLs antiguas
- 7 archivos actualizados con enlaces internos corregidos

## Plan de prueba

- [ ] Verificar que `/cambios/` muestra el hub con las 4 tarjetas
- [ ] Verificar que `/cambios/recientes/` carga el feed de reformas
- [ ] Verificar que `/cambios/omnibus/` carga las leyes multitemáticas
- [ ] Verificar que `/cambios/mias/` redirige al wizard si no hay perfil
- [ ] Verificar que `/mis-cambios/` redirige a `/cambios/mias/` (301)
- [ ] Verificar que `/omnibus/` redirige a `/cambios/omnibus/` (301)
- [ ] Verificar que `/reforma?id=X&date=Y` — la nueva URL `/cambios/X?date=Y` funciona
- [ ] `bun run check` pasa (lint OK)
- [ ] `bun test` pasa (492 tests OK)

🤖 Generated with [Claude Code](https://claude.com/claude-code)