### PR TITLE
feat: unified email subscriptions (replace Resend Audiences + norm_follows split)

### DIFF
--- a/packages/api/src/__tests__/subscriptions.test.ts
+++ b/packages/api/src/__tests__/subscriptions.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Tests for the unified subscriptions table and DbService methods.
+ *
+ * Covers the core invariants:
+ * - upsertSubscription is idempotent and preserves prior confirmed=1 state
+ * - confirmSubscriptionsByToken flips all rows sharing a token
+ * - getAllConfirmedSubscriptions returns only confirmed rows
+ * - delete by id+token is gated by token (cookie-equivalent)
+ */
+
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { createSchema } from "@leyabierta/pipeline";
+import { DbService } from "../services/db.ts";
+
+let db: Database;
+let svc: DbService;
+
+beforeEach(() => {
+	db = new Database(":memory:");
+	createSchema(db);
+	svc = new DbService(db);
+});
+
+afterEach(() => {
+	db.close();
+});
+
+describe("subscriptions table", () => {
+	it("upserts a new row and reads it back", () => {
+		svc.upsertSubscription({
+			email: "alice@example.com",
+			type: "materia",
+			scope: "IRPF",
+			confirmToken: "ctok-1",
+			unsubToken: "utok-1",
+			confirmed: false,
+		});
+
+		const rows = svc.getSubscriptionsByEmail("alice@example.com");
+		expect(rows).toHaveLength(1);
+		expect(rows[0]?.type).toBe("materia");
+		expect(rows[0]?.scope).toBe("IRPF");
+		expect(rows[0]?.confirmed).toBe(0);
+	});
+
+	it("upsert is idempotent on (email, type, scope)", () => {
+		const args = {
+			email: "alice@example.com",
+			type: "materia" as const,
+			scope: "IRPF",
+			confirmToken: "ctok-1",
+			unsubToken: "utok-1",
+			confirmed: false,
+		};
+		svc.upsertSubscription(args);
+		svc.upsertSubscription(args);
+		svc.upsertSubscription(args);
+
+		const rows = svc.getSubscriptionsByEmail("alice@example.com");
+		expect(rows).toHaveLength(1);
+	});
+
+	it("preserves confirmed=1 even when re-upserting with confirmed=false", () => {
+		// Initial confirmed insert
+		svc.upsertSubscription({
+			email: "alice@example.com",
+			type: "materia",
+			scope: "IRPF",
+			confirmToken: "ctok-1",
+			unsubToken: "utok-1",
+			confirmed: true,
+		});
+		// Re-upsert with confirmed=false (e.g., user re-subscribed)
+		svc.upsertSubscription({
+			email: "alice@example.com",
+			type: "materia",
+			scope: "IRPF",
+			confirmToken: "ctok-2",
+			unsubToken: "utok-2",
+			confirmed: false,
+		});
+
+		const rows = svc.getSubscriptionsByEmail("alice@example.com");
+		expect(rows[0]?.confirmed).toBe(1);
+		// Unsub token is preserved when row was already confirmed
+		const byUnsub = svc.getSubscriptionsByUnsubToken("utok-1");
+		expect(byUnsub).toHaveLength(1);
+	});
+
+	it("confirmSubscriptionsByToken flips all rows sharing the token", () => {
+		const ct = "shared-token";
+		const ut = "shared-utok";
+		svc.upsertSubscription({
+			email: "bob@example.com",
+			type: "materia",
+			scope: "IRPF",
+			confirmToken: ct,
+			unsubToken: ut,
+			confirmed: false,
+		});
+		svc.upsertSubscription({
+			email: "bob@example.com",
+			type: "jurisdiccion",
+			scope: "es-md",
+			confirmToken: ct,
+			unsubToken: ut,
+			confirmed: false,
+		});
+
+		const flipped = svc.confirmSubscriptionsByToken(ct);
+		expect(flipped).toBe(2);
+		const rows = svc.getSubscriptionsByEmail("bob@example.com");
+		expect(rows.every((r) => r.confirmed === 1)).toBe(true);
+	});
+
+	it("getAllConfirmedSubscriptions returns only confirmed", () => {
+		svc.upsertSubscription({
+			email: "a@x.com",
+			type: "materia",
+			scope: "IRPF",
+			confirmToken: "ct1",
+			unsubToken: "ut1",
+			confirmed: true,
+		});
+		svc.upsertSubscription({
+			email: "b@x.com",
+			type: "materia",
+			scope: "Empleo",
+			confirmToken: "ct2",
+			unsubToken: "ut2",
+			confirmed: false,
+		});
+
+		const all = svc.getAllConfirmedSubscriptions();
+		expect(all).toHaveLength(1);
+		expect(all[0]?.email).toBe("a@x.com");
+	});
+
+	it("getConfirmedEmailsForScope finds matching subscribers", () => {
+		svc.upsertSubscription({
+			email: "a@x.com",
+			type: "materia",
+			scope: "IRPF",
+			confirmToken: "ct1",
+			unsubToken: "ut1",
+			confirmed: true,
+		});
+		svc.upsertSubscription({
+			email: "b@x.com",
+			type: "materia",
+			scope: "IRPF",
+			confirmToken: "ct2",
+			unsubToken: "ut2",
+			confirmed: true,
+		});
+		svc.upsertSubscription({
+			email: "c@x.com",
+			type: "materia",
+			scope: "Empleo",
+			confirmToken: "ct3",
+			unsubToken: "ut3",
+			confirmed: true,
+		});
+
+		const irpfEmails = svc.getConfirmedEmailsForScope("materia", "IRPF");
+		expect(irpfEmails.sort()).toEqual(["a@x.com", "b@x.com"]);
+	});
+
+	it("deleteSubscription requires matching token (cookie gate)", () => {
+		svc.upsertSubscription({
+			email: "alice@example.com",
+			type: "norma",
+			scope: "BOE-A-1978-31229",
+			confirmToken: "ctok",
+			unsubToken: "right-utok",
+			confirmed: true,
+		});
+		const rowsBefore = svc.getSubscriptionsByEmail("alice@example.com");
+		const id = rowsBefore[0]?.id ?? 0;
+
+		// Wrong token: no-op
+		expect(svc.deleteSubscription(id, "wrong-utok")).toBe(false);
+		expect(svc.getSubscriptionsByEmail("alice@example.com")).toHaveLength(1);
+
+		// Right token: deletes
+		expect(svc.deleteSubscription(id, "right-utok")).toBe(true);
+		expect(svc.getSubscriptionsByEmail("alice@example.com")).toHaveLength(0);
+	});
+
+	it("deleteSubscriptionsByEmail removes all rows for an email", () => {
+		for (const scope of ["IRPF", "Empleo", "Vivienda"]) {
+			svc.upsertSubscription({
+				email: "alice@example.com",
+				type: "materia",
+				scope,
+				confirmToken: `ct-${scope}`,
+				unsubToken: "ut",
+				confirmed: true,
+			});
+		}
+		expect(svc.getSubscriptionsByEmail("alice@example.com")).toHaveLength(3);
+		svc.deleteSubscriptionsByEmail("alice@example.com");
+		expect(svc.getSubscriptionsByEmail("alice@example.com")).toHaveLength(0);
+	});
+
+	it("getSubscriptionsByUnsubToken groups by per-email cookie value", () => {
+		const ut = "alice-utok";
+		svc.upsertSubscription({
+			email: "alice@example.com",
+			type: "materia",
+			scope: "IRPF",
+			confirmToken: "ct1",
+			unsubToken: ut,
+			confirmed: true,
+		});
+		svc.upsertSubscription({
+			email: "alice@example.com",
+			type: "norma",
+			scope: "BOE-A-1978-31229",
+			confirmToken: "ct2",
+			unsubToken: ut,
+			confirmed: true,
+		});
+
+		const rows = svc.getSubscriptionsByUnsubToken(ut);
+		expect(rows).toHaveLength(2);
+		expect(rows[0]?.email).toBe("alice@example.com");
+		expect(new Set(rows.map((r) => r.type))).toEqual(
+			new Set(["materia", "norma"]),
+		);
+	});
+});

--- a/packages/api/src/routes/alerts.ts
+++ b/packages/api/src/routes/alerts.ts
@@ -79,577 +79,581 @@ function isGetRateLimited(ip: string): boolean {
 // ── Routes ──────────────────────────────────────────────────────────────
 
 export function alertRoutes(_dbService?: DbService) {
-	return new Elysia({ prefix: "/v1" })
-		.get(
-			"/profiles",
-			() => {
-				return {
-					data: PROFILES.map((p) => ({
-						id: p.id,
-						name: p.name,
-						description: p.description,
-						icon: p.icon,
-					})),
-				};
-			},
-			{
-				detail: {
-					summary: "List subscriber profiles",
-					description:
-						"Returns available subscriber profiles for the alert wizard.",
-					tags: ["Alertas"],
-				},
-			},
-		)
-
-		.get(
-			"/situations",
-			() => {
-				return {
-					categories: SITUATION_CATEGORIES,
-					situations: SITUATIONS.map((s) => ({
-						id: s.id,
-						name: s.name,
-						category: s.category,
-						icon: s.icon,
-					})),
-				};
-			},
-			{
-				detail: {
-					summary: "List life situations",
-					description:
-						"Returns available life situation categories and options for the alert wizard.",
-					tags: ["Alertas"],
-				},
-			},
-		)
-
-		.post(
-			"/alerts/subscribe",
-			async ({ body, request, set }) => {
-				const resend = getResend();
-				const audienceId = getAudienceId();
-
-				if (!resend || !audienceId) {
-					set.status = 503;
+	return (
+		new Elysia({ prefix: "/v1" })
+			.get(
+				"/profiles",
+				() => {
 					return {
-						error:
-							"No pudimos procesar tu solicitud. Inténtalo de nuevo en unos minutos.",
+						data: PROFILES.map((p) => ({
+							id: p.id,
+							name: p.name,
+							description: p.description,
+							icon: p.icon,
+						})),
 					};
-				}
+				},
+				{
+					detail: {
+						summary: "List subscriber profiles",
+						description:
+							"Returns available subscriber profiles for the alert wizard.",
+						tags: ["Alertas"],
+					},
+				},
+			)
 
-				// Rate limit by IP
-				const ip = getClientIp(request);
-				if (isRateLimited(ip)) {
-					// Return generic 200 to avoid leaking rate-limit info
+			.get(
+				"/situations",
+				() => {
+					return {
+						categories: SITUATION_CATEGORIES,
+						situations: SITUATIONS.map((s) => ({
+							id: s.id,
+							name: s.name,
+							category: s.category,
+							icon: s.icon,
+						})),
+					};
+				},
+				{
+					detail: {
+						summary: "List life situations",
+						description:
+							"Returns available life situation categories and options for the alert wizard.",
+						tags: ["Alertas"],
+					},
+				},
+			)
+
+			.post(
+				"/alerts/subscribe",
+				async ({ body, request, set }) => {
+					const resend = getResend();
+					const audienceId = getAudienceId();
+
+					if (!resend || !audienceId) {
+						set.status = 503;
+						return {
+							error:
+								"No pudimos procesar tu solicitud. Inténtalo de nuevo en unos minutos.",
+						};
+					}
+
+					// Rate limit by IP
+					const ip = getClientIp(request);
+					if (isRateLimited(ip)) {
+						// Return generic 200 to avoid leaking rate-limit info
+						return {
+							ok: true,
+							message:
+								"Si tu email es válido, recibirás un enlace de confirmación",
+						};
+					}
+
+					// Accept materias (new) or situationIds (legacy)
+					const materias = body.materias ?? [];
+					const legacySituations = body.situationIds
+						? getSituationsByIds(body.situationIds)
+						: [];
+
+					if (materias.length === 0 && legacySituations.length === 0) {
+						set.status = 400;
+						return {
+							error: "Debes seleccionar al menos un tema o situación válida",
+						};
+					}
+
+					if (materias.length > MAX_MATERIAS) {
+						set.status = 400;
+						return {
+							error: `Máximo ${MAX_MATERIAS} temas permitidos`,
+						};
+					}
+
+					const email = body.email;
+					const jurisdiction = body.jurisdiction ?? "es";
+
+					try {
+						await resend.contacts.create({
+							audienceId,
+							email,
+							unsubscribed: true,
+							properties: {
+								...(materias.length > 0
+									? { materias: JSON.stringify(materias) }
+									: {
+											situation_ids: JSON.stringify(body.situationIds),
+										}),
+								jurisdiction,
+								consent_ts: new Date().toISOString(),
+								consent_ip: ip,
+							},
+						});
+					} catch (err: unknown) {
+						// Duplicate contact — silently continue (send confirmation anyway
+						// since they may not have confirmed the first time)
+						const isDuplicate =
+							err instanceof Error &&
+							(err.message?.includes("already exists") ||
+								err.message?.includes("duplicate"));
+						if (!isDuplicate) {
+							console.error("[alerts] Resend contacts.create failed:", err);
+							// Still return generic 200 to avoid email enumeration
+						}
+					}
+
+					// Mirror to unified subscriptions table. Same confirm token as the
+					// email link (HMAC of email) so a single click confirms every row.
+					const confirmToken = await generateHmac(email);
+					const items: Array<{
+						type: "materia" | "jurisdiccion";
+						scope: string;
+					}> = [
+						...materias.map((m: string) => ({
+							type: "materia" as const,
+							scope: m,
+						})),
+						{ type: "jurisdiccion" as const, scope: jurisdiction },
+					];
+					await mirrorToSubscriptions(
+						_dbService,
+						email,
+						items,
+						confirmToken,
+						false,
+					);
+
+					// Send confirmation email (best effort — always return generic 200)
+					const topicCount =
+						materias.length > 0 ? materias.length : legacySituations.length;
+					await sendConfirmationEmail(email, topicCount).catch((err) => {
+						console.error("[alerts] Failed to send confirmation email:", err);
+					});
+
 					return {
 						ok: true,
 						message:
 							"Si tu email es válido, recibirás un enlace de confirmación",
 					};
-				}
-
-				// Accept materias (new) or situationIds (legacy)
-				const materias = body.materias ?? [];
-				const legacySituations = body.situationIds
-					? getSituationsByIds(body.situationIds)
-					: [];
-
-				if (materias.length === 0 && legacySituations.length === 0) {
-					set.status = 400;
-					return {
-						error: "Debes seleccionar al menos un tema o situación válida",
-					};
-				}
-
-				if (materias.length > MAX_MATERIAS) {
-					set.status = 400;
-					return {
-						error: `Máximo ${MAX_MATERIAS} temas permitidos`,
-					};
-				}
-
-				const email = body.email;
-				const jurisdiction = body.jurisdiction ?? "es";
-
-				try {
-					await resend.contacts.create({
-						audienceId,
-						email,
-						unsubscribed: true,
-						properties: {
-							...(materias.length > 0
-								? { materias: JSON.stringify(materias) }
-								: {
-										situation_ids: JSON.stringify(body.situationIds),
-									}),
-							jurisdiction,
-							consent_ts: new Date().toISOString(),
-							consent_ip: ip,
-						},
-					});
-				} catch (err: unknown) {
-					// Duplicate contact — silently continue (send confirmation anyway
-					// since they may not have confirmed the first time)
-					const isDuplicate =
-						err instanceof Error &&
-						(err.message?.includes("already exists") ||
-							err.message?.includes("duplicate"));
-					if (!isDuplicate) {
-						console.error("[alerts] Resend contacts.create failed:", err);
-						// Still return generic 200 to avoid email enumeration
-					}
-				}
-
-				// Mirror to unified subscriptions table. Same confirm token as the
-				// email link (HMAC of email) so a single click confirms every row.
-				const confirmToken = await generateHmac(email);
-				const items: Array<{
-					type: "materia" | "jurisdiccion";
-					scope: string;
-				}> = [
-					...materias.map((m: string) => ({
-						type: "materia" as const,
-						scope: m,
-					})),
-					{ type: "jurisdiccion" as const, scope: jurisdiction },
-				];
-				await mirrorToSubscriptions(
-					_dbService,
-					email,
-					items,
-					confirmToken,
-					false,
-				);
-
-				// Send confirmation email (best effort — always return generic 200)
-				const topicCount =
-					materias.length > 0 ? materias.length : legacySituations.length;
-				await sendConfirmationEmail(email, topicCount).catch((err) => {
-					console.error("[alerts] Failed to send confirmation email:", err);
-				});
-
-				return {
-					ok: true,
-					message: "Si tu email es válido, recibirás un enlace de confirmación",
-				};
-			},
-			{
-				body: t.Object({
-					email: t.String({ format: "email" }),
-					situationIds: t.Optional(t.Array(t.String())),
-					materias: t.Optional(t.Array(t.String())),
-					jurisdiction: t.Optional(t.String()),
-				}),
-				detail: {
-					summary: "Subscribe to alerts",
-					description:
-						"Subscribe an email to legislative reform alerts. Triggers double opt-in confirmation email.",
-					tags: ["Alertas"],
 				},
-			},
-		)
+				{
+					body: t.Object({
+						email: t.String({ format: "email" }),
+						situationIds: t.Optional(t.Array(t.String())),
+						materias: t.Optional(t.Array(t.String())),
+						jurisdiction: t.Optional(t.String()),
+					}),
+					detail: {
+						summary: "Subscribe to alerts",
+						description:
+							"Subscribe an email to legislative reform alerts. Triggers double opt-in confirmation email.",
+						tags: ["Alertas"],
+					},
+				},
+			)
 
-		.get(
-			"/alerts/confirm",
-			async ({ query, set, request }) => {
-				const ip = getClientIp(request);
-				if (isGetRateLimited(ip)) {
-					set.status = 429;
-					return { error: "Demasiados intentos. Inténtalo más tarde." };
-				}
+			.get(
+				"/alerts/confirm",
+				async ({ query, set, request }) => {
+					const ip = getClientIp(request);
+					if (isGetRateLimited(ip)) {
+						set.status = 429;
+						return { error: "Demasiados intentos. Inténtalo más tarde." };
+					}
 
-				const { email, code } = query;
+					const { email, code } = query;
 
-				if (!email || !code) {
-					set.status = 400;
-					return { error: "Enlace no válido o expirado" };
-				}
+					if (!email || !code) {
+						set.status = 400;
+						return { error: "Enlace no válido o expirado" };
+					}
 
-				const valid = await verifyHmac(email, code);
-				if (!valid) {
-					set.status = 400;
-					return { error: "Enlace no válido o expirado" };
-				}
+					const valid = await verifyHmac(email, code);
+					if (!valid) {
+						set.status = 400;
+						return { error: "Enlace no válido o expirado" };
+					}
 
-				const resend = getResend();
-				const audienceId = getAudienceId();
+					const resend = getResend();
+					const audienceId = getAudienceId();
 
-				if (!resend || !audienceId) {
-					set.status = 503;
-					return {
-						error:
-							"No pudimos procesar tu solicitud. Inténtalo de nuevo en unos minutos.",
-					};
-				}
+					if (!resend || !audienceId) {
+						set.status = 503;
+						return {
+							error:
+								"No pudimos procesar tu solicitud. Inténtalo de nuevo en unos minutos.",
+						};
+					}
 
-				try {
-					// Update the contact to mark as subscribed
-					await resend.contacts.update({
-						audienceId,
-						id: email,
-						unsubscribed: false,
-					});
-				} catch (err) {
-					console.error("[alerts] Resend contacts.update failed:", err);
-					set.status = 503;
-					return {
-						error:
-							"No pudimos procesar tu solicitud. Inténtalo de nuevo en unos minutos.",
-					};
-				}
-
-				// Confirm all subscription rows for this email in the unified table.
-				if (_dbService) {
 					try {
-						_dbService.confirmSubscriptionsByToken(code);
+						// Update the contact to mark as subscribed
+						await resend.contacts.update({
+							audienceId,
+							id: email,
+							unsubscribed: false,
+						});
 					} catch (err) {
-						console.error("[alerts] Failed to confirm subscriptions:", err);
+						console.error("[alerts] Resend contacts.update failed:", err);
+						set.status = 503;
+						return {
+							error:
+								"No pudimos procesar tu solicitud. Inténtalo de nuevo en unos minutos.",
+						};
 					}
-				}
 
-				// Send welcome email (best effort)
-				await sendWelcomeEmail(email).catch((err) => {
-					console.error("[alerts] Failed to send welcome email:", err);
-				});
+					// Confirm all subscription rows for this email in the unified table.
+					if (_dbService) {
+						try {
+							_dbService.confirmSubscriptionsByToken(code);
+						} catch (err) {
+							console.error("[alerts] Failed to confirm subscriptions:", err);
+						}
+					}
 
-				// Cookie value the frontend will set on the confirmation page so
-				// returning users are recognized without typing their email again.
-				const lbToken = await unsubTokenForEmail(email);
-				return {
-					success: true,
-					message: "Suscripción confirmada",
-					token: lbToken,
-				};
-			},
-			{
-				query: t.Object({
-					email: t.String(),
-					code: t.String(),
-				}),
-				detail: {
-					summary: "Confirm alert subscription",
-					description:
-						"Confirms a subscription via HMAC-signed email link. Marks contact as subscribed in Resend and in subscriptions table. Returns the per-email cookie token.",
-					tags: ["Alertas"],
-				},
-			},
-		)
+					// Send welcome email (best effort)
+					await sendWelcomeEmail(email).catch((err) => {
+						console.error("[alerts] Failed to send welcome email:", err);
+					});
 
-		.post(
-			"/alerts/follow",
-			async ({ body, request, set }) => {
-				const dbService = _dbService;
-				if (!dbService) {
-					set.status = 503;
+					// Cookie value the frontend will set on the confirmation page so
+					// returning users are recognized without typing their email again.
+					const lbToken = await unsubTokenForEmail(email);
 					return {
-						error:
-							"No pudimos procesar tu solicitud. Inténtalo de nuevo en unos minutos.",
+						success: true,
+						message: "Suscripción confirmada",
+						token: lbToken,
 					};
-				}
+				},
+				{
+					query: t.Object({
+						email: t.String(),
+						code: t.String(),
+					}),
+					detail: {
+						summary: "Confirm alert subscription",
+						description:
+							"Confirms a subscription via HMAC-signed email link. Marks contact as subscribed in Resend and in subscriptions table. Returns the per-email cookie token.",
+						tags: ["Alertas"],
+					},
+				},
+			)
 
-				// Rate limit by IP
-				const ip = getClientIp(request);
-				if (isRateLimited(ip)) {
+			.post(
+				"/alerts/follow",
+				async ({ body, request, set }) => {
+					const dbService = _dbService;
+					if (!dbService) {
+						set.status = 503;
+						return {
+							error:
+								"No pudimos procesar tu solicitud. Inténtalo de nuevo en unos minutos.",
+						};
+					}
+
+					// Rate limit by IP
+					const ip = getClientIp(request);
+					if (isRateLimited(ip)) {
+						return {
+							ok: true,
+							message:
+								"Si tu email es válido, recibirás un enlace de confirmación",
+						};
+					}
+
+					const { email, normId } = body;
+
+					// Validate norm exists
+					const norm = dbService.getLaw(normId);
+					if (!norm) {
+						set.status = 400;
+						return { error: "No se encontró la ley indicada" };
+					}
+
+					// Generate a unique token for confirmation
+					const token = await generateHmac(`${email}:follow:${normId}`);
+
+					// Insert or update (upsert) — if already exists and confirmed, skip
+					try {
+						dbService.upsertNormFollow(email, normId, token);
+					} catch (err) {
+						console.error("[alerts] Failed to insert norm follow:", err);
+						set.status = 500;
+						return {
+							error:
+								"No pudimos procesar tu solicitud. Inténtalo de nuevo en unos minutos.",
+						};
+					}
+
+					// Mirror into unified subscriptions table.
+					await mirrorToSubscriptions(
+						dbService,
+						email,
+						[{ type: "norma", scope: normId }],
+						token,
+						false,
+					);
+
+					// Send confirmation email (best effort)
+					await sendFollowConfirmationEmail(
+						email,
+						norm.title,
+						normId,
+						token,
+					).catch((err) => {
+						console.error(
+							"[alerts] Failed to send follow confirmation email:",
+							err,
+						);
+					});
+
 					return {
 						ok: true,
 						message:
 							"Si tu email es válido, recibirás un enlace de confirmación",
 					};
-				}
-
-				const { email, normId } = body;
-
-				// Validate norm exists
-				const norm = dbService.getLaw(normId);
-				if (!norm) {
-					set.status = 400;
-					return { error: "No se encontró la ley indicada" };
-				}
-
-				// Generate a unique token for confirmation
-				const token = await generateHmac(`${email}:follow:${normId}`);
-
-				// Insert or update (upsert) — if already exists and confirmed, skip
-				try {
-					dbService.upsertNormFollow(email, normId, token);
-				} catch (err) {
-					console.error("[alerts] Failed to insert norm follow:", err);
-					set.status = 500;
-					return {
-						error:
-							"No pudimos procesar tu solicitud. Inténtalo de nuevo en unos minutos.",
-					};
-				}
-
-				// Mirror into unified subscriptions table.
-				await mirrorToSubscriptions(
-					dbService,
-					email,
-					[{ type: "norma", scope: normId }],
-					token,
-					false,
-				);
-
-				// Send confirmation email (best effort)
-				await sendFollowConfirmationEmail(
-					email,
-					norm.title,
-					normId,
-					token,
-				).catch((err) => {
-					console.error(
-						"[alerts] Failed to send follow confirmation email:",
-						err,
-					);
-				});
-
-				return {
-					ok: true,
-					message: "Si tu email es válido, recibirás un enlace de confirmación",
-				};
-			},
-			{
-				body: t.Object({
-					email: t.String({ format: "email" }),
-					normId: t.String({ minLength: 1 }),
-				}),
-				detail: {
-					summary: "Follow a specific law",
-					description:
-						"Subscribe to notifications for a specific law. Sends a confirmation email.",
-					tags: ["Alertas"],
 				},
-			},
-		)
+				{
+					body: t.Object({
+						email: t.String({ format: "email" }),
+						normId: t.String({ minLength: 1 }),
+					}),
+					detail: {
+						summary: "Follow a specific law",
+						description:
+							"Subscribe to notifications for a specific law. Sends a confirmation email.",
+						tags: ["Alertas"],
+					},
+				},
+			)
 
-		.get(
-			"/alerts/follow/confirm",
-			async ({ query, set, request }) => {
-				const ip = getClientIp(request);
-				if (isGetRateLimited(ip)) {
-					set.status = 429;
-					return { error: "Demasiados intentos. Inténtalo más tarde." };
-				}
-
-				const { token } = query;
-
-				if (!token) {
-					set.status = 400;
-					return { error: "Enlace no válido o expirado" };
-				}
-
-				const dbService = _dbService;
-				if (!dbService) {
-					set.status = 503;
-					return {
-						error:
-							"No pudimos procesar tu solicitud. Inténtalo de nuevo en unos minutos.",
-					};
-				}
-
-				const confirmed = dbService.confirmNormFollow(token);
-				if (!confirmed) {
-					set.status = 400;
-					return { error: "Enlace no válido o expirado" };
-				}
-
-				// Mirror confirmation into unified subscriptions table. Look up the
-				// email so we can return its cookie token to the confirmation page.
-				let lbToken: string | undefined;
-				try {
-					const row = dbService.getSubscriptionByConfirmToken(token);
-					dbService.confirmSubscriptionsByToken(token);
-					if (row?.email) {
-						lbToken = await unsubTokenForEmail(row.email);
+			.get(
+				"/alerts/follow/confirm",
+				async ({ query, set, request }) => {
+					const ip = getClientIp(request);
+					if (isGetRateLimited(ip)) {
+						set.status = 429;
+						return { error: "Demasiados intentos. Inténtalo más tarde." };
 					}
-				} catch (err) {
-					console.error(
-						"[alerts] Failed to confirm subscription mirror:",
-						err,
-					);
-				}
 
-				return {
-					success: true,
-					message: "Suscripción confirmada",
-					token: lbToken,
-				};
-			},
-			{
-				query: t.Object({
-					token: t.String(),
-				}),
-				detail: {
-					summary: "Confirm law follow",
-					description:
-						"Confirms a law-follow subscription via token from the confirmation email. Mirrors confirmation in unified subscriptions table.",
-					tags: ["Alertas"],
-				},
-			},
-		)
+					const { token } = query;
 
-		.get(
-			"/alerts/unsubscribe",
-			async ({ query, set, request }) => {
-				const ip = getClientIp(request);
-				if (isGetRateLimited(ip)) {
-					set.status = 429;
-					return { error: "Demasiados intentos. Inténtalo más tarde." };
-				}
+					if (!token) {
+						set.status = 400;
+						return { error: "Enlace no válido o expirado" };
+					}
 
-				const { email, code } = query;
+					const dbService = _dbService;
+					if (!dbService) {
+						set.status = 503;
+						return {
+							error:
+								"No pudimos procesar tu solicitud. Inténtalo de nuevo en unos minutos.",
+						};
+					}
 
-				if (!email || !code) {
-					set.status = 400;
-					return { error: "Enlace no válido o expirado" };
-				}
+					const confirmed = dbService.confirmNormFollow(token);
+					if (!confirmed) {
+						set.status = 400;
+						return { error: "Enlace no válido o expirado" };
+					}
 
-				const valid = await verifyHmac(email, code);
-				if (!valid) {
-					set.status = 400;
-					return { error: "Enlace no válido o expirado" };
-				}
-
-				const resend = getResend();
-				const audienceId = getAudienceId();
-
-				if (!resend || !audienceId) {
-					set.status = 503;
-					return {
-						error:
-							"No pudimos procesar tu solicitud. Inténtalo de nuevo en unos minutos.",
-					};
-				}
-
-				try {
-					await resend.contacts.remove({
-						audienceId,
-						email,
-					});
-				} catch (err) {
-					console.error("[alerts] Resend contacts.remove failed:", err);
-					// If the contact doesn't exist, that's fine — treat as success
-				}
-
-				// GDPR: also remove norm follow records and unified subscriptions
-				if (_dbService) {
+					// Mirror confirmation into unified subscriptions table. Look up the
+					// email so we can return its cookie token to the confirmation page.
+					let lbToken: string | undefined;
 					try {
-						_dbService.deleteNormFollowsByEmail(email);
+						const row = dbService.getSubscriptionByConfirmToken(token);
+						dbService.confirmSubscriptionsByToken(token);
+						if (row?.email) {
+							lbToken = await unsubTokenForEmail(row.email);
+						}
 					} catch (err) {
-						console.error("[alerts] Failed to delete norm_follows:", err);
+						console.error(
+							"[alerts] Failed to confirm subscription mirror:",
+							err,
+						);
 					}
+
+					return {
+						success: true,
+						message: "Suscripción confirmada",
+						token: lbToken,
+					};
+				},
+				{
+					query: t.Object({
+						token: t.String(),
+					}),
+					detail: {
+						summary: "Confirm law follow",
+						description:
+							"Confirms a law-follow subscription via token from the confirmation email. Mirrors confirmation in unified subscriptions table.",
+						tags: ["Alertas"],
+					},
+				},
+			)
+
+			.get(
+				"/alerts/unsubscribe",
+				async ({ query, set, request }) => {
+					const ip = getClientIp(request);
+					if (isGetRateLimited(ip)) {
+						set.status = 429;
+						return { error: "Demasiados intentos. Inténtalo más tarde." };
+					}
+
+					const { email, code } = query;
+
+					if (!email || !code) {
+						set.status = 400;
+						return { error: "Enlace no válido o expirado" };
+					}
+
+					const valid = await verifyHmac(email, code);
+					if (!valid) {
+						set.status = 400;
+						return { error: "Enlace no válido o expirado" };
+					}
+
+					const resend = getResend();
+					const audienceId = getAudienceId();
+
+					if (!resend || !audienceId) {
+						set.status = 503;
+						return {
+							error:
+								"No pudimos procesar tu solicitud. Inténtalo de nuevo en unos minutos.",
+						};
+					}
+
 					try {
-						_dbService.deleteSubscriptionsByEmail(email);
+						await resend.contacts.remove({
+							audienceId,
+							email,
+						});
 					} catch (err) {
-						console.error("[alerts] Failed to delete subscriptions:", err);
+						console.error("[alerts] Resend contacts.remove failed:", err);
+						// If the contact doesn't exist, that's fine — treat as success
 					}
-				}
 
-				return { success: true };
-			},
-			{
-				query: t.Object({
-					email: t.String(),
-					code: t.String(),
-				}),
-				detail: {
-					summary: "Unsubscribe from alerts",
-					description:
-						"Unsubscribes an email from all alerts. Removes contact from Resend and deletes law-follow records and unified subscriptions (GDPR).",
-					tags: ["Alertas"],
+					// GDPR: also remove norm follow records and unified subscriptions
+					if (_dbService) {
+						try {
+							_dbService.deleteNormFollowsByEmail(email);
+						} catch (err) {
+							console.error("[alerts] Failed to delete norm_follows:", err);
+						}
+						try {
+							_dbService.deleteSubscriptionsByEmail(email);
+						} catch (err) {
+							console.error("[alerts] Failed to delete subscriptions:", err);
+						}
+					}
+
+					return { success: true };
 				},
-			},
-		)
-
-		// ── /v1/alerts/me ─────────────────────────────────────────────────
-		// Reads the user's confirmed subscriptions by unsubscribe token (cookie).
-		// No email leak: caller must already possess the per-email token.
-
-		.get(
-			"/alerts/me",
-			({ query, set, request }) => {
-				const ip = getClientIp(request);
-				if (isGetRateLimited(ip)) {
-					set.status = 429;
-					return { error: "Demasiados intentos. Inténtalo más tarde." };
-				}
-
-				const dbService = _dbService;
-				if (!dbService) {
-					set.status = 503;
-					return { error: "Servicio temporalmente no disponible." };
-				}
-
-				const rows = dbService.getSubscriptionsByUnsubToken(query.token);
-				if (rows.length === 0) {
-					return { email: null, items: [] };
-				}
-
-				return {
-					email: rows[0]?.email ?? null,
-					items: rows.map((r) => ({
-						id: r.id,
-						type: r.type,
-						scope: r.scope,
-						confirmed: r.confirmed === 1,
-					})),
-				};
-			},
-			{
-				query: t.Object({
-					token: t.String({ minLength: 16 }),
-				}),
-				detail: {
-					summary: "List my subscriptions (cookie-authenticated)",
-					description:
-						"Returns the subscriptions belonging to the email associated with the given unsub token. The token is set as cookie `lb_token` on confirmation.",
-					tags: ["Alertas"],
+				{
+					query: t.Object({
+						email: t.String(),
+						code: t.String(),
+					}),
+					detail: {
+						summary: "Unsubscribe from alerts",
+						description:
+							"Unsubscribes an email from all alerts. Removes contact from Resend and deletes law-follow records and unified subscriptions (GDPR).",
+						tags: ["Alertas"],
+					},
 				},
-			},
-		)
+			)
 
-		.delete(
-			"/alerts/me",
-			({ query, set, request }) => {
-				const ip = getClientIp(request);
-				if (isRateLimited(ip)) {
-					set.status = 429;
-					return { error: "Demasiados intentos. Inténtalo más tarde." };
-				}
+			// ── /v1/alerts/me ─────────────────────────────────────────────────
+			// Reads the user's confirmed subscriptions by unsubscribe token (cookie).
+			// No email leak: caller must already possess the per-email token.
 
-				const dbService = _dbService;
-				if (!dbService) {
-					set.status = 503;
-					return { error: "Servicio temporalmente no disponible." };
-				}
+			.get(
+				"/alerts/me",
+				({ query, set, request }) => {
+					const ip = getClientIp(request);
+					if (isGetRateLimited(ip)) {
+						set.status = 429;
+						return { error: "Demasiados intentos. Inténtalo más tarde." };
+					}
 
-				const id = Number.parseInt(query.id, 10);
-				if (!Number.isFinite(id) || id <= 0) {
-					set.status = 400;
-					return { error: "Identificador inválido." };
-				}
+					const dbService = _dbService;
+					if (!dbService) {
+						set.status = 503;
+						return { error: "Servicio temporalmente no disponible." };
+					}
 
-				const ok = dbService.deleteSubscription(id, query.token);
-				if (!ok) {
-					set.status = 404;
-					return { error: "Suscripción no encontrada." };
-				}
+					const rows = dbService.getSubscriptionsByUnsubToken(query.token);
+					if (rows.length === 0) {
+						return { email: null, items: [] };
+					}
 
-				return { success: true };
-			},
-			{
-				query: t.Object({
-					id: t.String({ minLength: 1 }),
-					token: t.String({ minLength: 16 }),
-				}),
-				detail: {
-					summary: "Delete a single subscription",
-					description:
-						"Removes one subscription row by id, gated by the per-email unsub token (cookie).",
-					tags: ["Alertas"],
+					return {
+						email: rows[0]?.email ?? null,
+						items: rows.map((r) => ({
+							id: r.id,
+							type: r.type,
+							scope: r.scope,
+							confirmed: r.confirmed === 1,
+						})),
+					};
 				},
-			},
-		);
+				{
+					query: t.Object({
+						token: t.String({ minLength: 16 }),
+					}),
+					detail: {
+						summary: "List my subscriptions (cookie-authenticated)",
+						description:
+							"Returns the subscriptions belonging to the email associated with the given unsub token. The token is set as cookie `lb_token` on confirmation.",
+						tags: ["Alertas"],
+					},
+				},
+			)
+
+			.delete(
+				"/alerts/me",
+				({ query, set, request }) => {
+					const ip = getClientIp(request);
+					if (isRateLimited(ip)) {
+						set.status = 429;
+						return { error: "Demasiados intentos. Inténtalo más tarde." };
+					}
+
+					const dbService = _dbService;
+					if (!dbService) {
+						set.status = 503;
+						return { error: "Servicio temporalmente no disponible." };
+					}
+
+					const id = Number.parseInt(query.id, 10);
+					if (!Number.isFinite(id) || id <= 0) {
+						set.status = 400;
+						return { error: "Identificador inválido." };
+					}
+
+					const ok = dbService.deleteSubscription(id, query.token);
+					if (!ok) {
+						set.status = 404;
+						return { error: "Suscripción no encontrada." };
+					}
+
+					return { success: true };
+				},
+				{
+					query: t.Object({
+						id: t.String({ minLength: 1 }),
+						token: t.String({ minLength: 16 }),
+					}),
+					detail: {
+						summary: "Delete a single subscription",
+						description:
+							"Removes one subscription row by id, gated by the per-email unsub token (cookie).",
+						tags: ["Alertas"],
+					},
+				},
+			)
+	);
 }

--- a/packages/api/src/routes/alerts.ts
+++ b/packages/api/src/routes/alerts.ts
@@ -66,7 +66,7 @@ async function mirrorToSubscriptions(
 
 const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000; // 1 hour
 const postLimiter = createRateLimiter(3, RATE_LIMIT_WINDOW_MS); // 3/hour for POST
-const getLimiter = createRateLimiter(10, RATE_LIMIT_WINDOW_MS); // 10/hour for GET
+const getLimiter = createRateLimiter(60, RATE_LIMIT_WINDOW_MS); // 60/hour for GET (one /alerts/me lookup per leyes/[id] visit)
 
 function isRateLimited(ip: string): boolean {
 	return postLimiter.isLimited(ip);

--- a/packages/api/src/routes/alerts.ts
+++ b/packages/api/src/routes/alerts.ts
@@ -26,6 +26,44 @@ import { createRateLimiter, getClientIp } from "../services/rate-limiter.ts";
 
 const MAX_MATERIAS = 60;
 
+// Per-email unsubscribe token. Deterministic per email so all subscriptions
+// share one cookie value for the user. Used by /alerts/me and as the
+// `lb_token` cookie set after confirmation.
+async function unsubTokenForEmail(email: string): Promise<string> {
+	return generateHmac(`${email}:unsub`);
+}
+
+// Mirrors a set of (type, scope) pairs into the unified subscriptions table.
+// Idempotent: upsert preserves prior `confirmed=1` state. Best effort — never
+// throws into the request handler.
+async function mirrorToSubscriptions(
+	dbService: DbService | undefined,
+	email: string,
+	items: Array<{
+		type: "materia" | "jurisdiccion" | "norma";
+		scope: string;
+	}>,
+	confirmToken: string,
+	confirmed: boolean,
+): Promise<void> {
+	if (!dbService || items.length === 0) return;
+	try {
+		const unsubToken = await unsubTokenForEmail(email);
+		for (const item of items) {
+			dbService.upsertSubscription({
+				email,
+				type: item.type,
+				scope: item.scope,
+				confirmToken,
+				unsubToken,
+				confirmed,
+			});
+		}
+	} catch (err) {
+		console.error("[alerts] Failed to mirror to subscriptions:", err);
+	}
+}
+
 const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000; // 1 hour
 const postLimiter = createRateLimiter(3, RATE_LIMIT_WINDOW_MS); // 3/hour for POST
 const getLimiter = createRateLimiter(10, RATE_LIMIT_WINDOW_MS); // 10/hour for GET
@@ -164,6 +202,27 @@ export function alertRoutes(_dbService?: DbService) {
 					}
 				}
 
+				// Mirror to unified subscriptions table. Same confirm token as the
+				// email link (HMAC of email) so a single click confirms every row.
+				const confirmToken = await generateHmac(email);
+				const items: Array<{
+					type: "materia" | "jurisdiccion";
+					scope: string;
+				}> = [
+					...materias.map((m: string) => ({
+						type: "materia" as const,
+						scope: m,
+					})),
+					{ type: "jurisdiccion" as const, scope: jurisdiction },
+				];
+				await mirrorToSubscriptions(
+					_dbService,
+					email,
+					items,
+					confirmToken,
+					false,
+				);
+
 				// Send confirmation email (best effort — always return generic 200)
 				const topicCount =
 					materias.length > 0 ? materias.length : legacySituations.length;
@@ -241,12 +300,28 @@ export function alertRoutes(_dbService?: DbService) {
 					};
 				}
 
+				// Confirm all subscription rows for this email in the unified table.
+				if (_dbService) {
+					try {
+						_dbService.confirmSubscriptionsByToken(code);
+					} catch (err) {
+						console.error("[alerts] Failed to confirm subscriptions:", err);
+					}
+				}
+
 				// Send welcome email (best effort)
 				await sendWelcomeEmail(email).catch((err) => {
 					console.error("[alerts] Failed to send welcome email:", err);
 				});
 
-				return { success: true, message: "Suscripción confirmada" };
+				// Cookie value the frontend will set on the confirmation page so
+				// returning users are recognized without typing their email again.
+				const lbToken = await unsubTokenForEmail(email);
+				return {
+					success: true,
+					message: "Suscripción confirmada",
+					token: lbToken,
+				};
 			},
 			{
 				query: t.Object({
@@ -256,7 +331,7 @@ export function alertRoutes(_dbService?: DbService) {
 				detail: {
 					summary: "Confirm alert subscription",
 					description:
-						"Confirms a subscription via HMAC-signed email link. Marks contact as subscribed in Resend.",
+						"Confirms a subscription via HMAC-signed email link. Marks contact as subscribed in Resend and in subscriptions table. Returns the per-email cookie token.",
 					tags: ["Alertas"],
 				},
 			},
@@ -307,6 +382,15 @@ export function alertRoutes(_dbService?: DbService) {
 							"No pudimos procesar tu solicitud. Inténtalo de nuevo en unos minutos.",
 					};
 				}
+
+				// Mirror into unified subscriptions table.
+				await mirrorToSubscriptions(
+					dbService,
+					email,
+					[{ type: "norma", scope: normId }],
+					token,
+					false,
+				);
 
 				// Send confirmation email (best effort)
 				await sendFollowConfirmationEmail(
@@ -371,7 +455,27 @@ export function alertRoutes(_dbService?: DbService) {
 					return { error: "Enlace no válido o expirado" };
 				}
 
-				return { success: true, message: "Suscripción confirmada" };
+				// Mirror confirmation into unified subscriptions table. Look up the
+				// email so we can return its cookie token to the confirmation page.
+				let lbToken: string | undefined;
+				try {
+					const row = dbService.getSubscriptionByConfirmToken(token);
+					dbService.confirmSubscriptionsByToken(token);
+					if (row?.email) {
+						lbToken = await unsubTokenForEmail(row.email);
+					}
+				} catch (err) {
+					console.error(
+						"[alerts] Failed to confirm subscription mirror:",
+						err,
+					);
+				}
+
+				return {
+					success: true,
+					message: "Suscripción confirmada",
+					token: lbToken,
+				};
 			},
 			{
 				query: t.Object({
@@ -380,7 +484,7 @@ export function alertRoutes(_dbService?: DbService) {
 				detail: {
 					summary: "Confirm law follow",
 					description:
-						"Confirms a law-follow subscription via token from the confirmation email.",
+						"Confirms a law-follow subscription via token from the confirmation email. Mirrors confirmation in unified subscriptions table.",
 					tags: ["Alertas"],
 				},
 			},
@@ -429,12 +533,17 @@ export function alertRoutes(_dbService?: DbService) {
 					// If the contact doesn't exist, that's fine — treat as success
 				}
 
-				// GDPR: also remove norm follow records for this email
+				// GDPR: also remove norm follow records and unified subscriptions
 				if (_dbService) {
 					try {
 						_dbService.deleteNormFollowsByEmail(email);
 					} catch (err) {
 						console.error("[alerts] Failed to delete norm_follows:", err);
+					}
+					try {
+						_dbService.deleteSubscriptionsByEmail(email);
+					} catch (err) {
+						console.error("[alerts] Failed to delete subscriptions:", err);
 					}
 				}
 
@@ -448,7 +557,97 @@ export function alertRoutes(_dbService?: DbService) {
 				detail: {
 					summary: "Unsubscribe from alerts",
 					description:
-						"Unsubscribes an email from all alerts. Removes contact from Resend and deletes law-follow records (GDPR).",
+						"Unsubscribes an email from all alerts. Removes contact from Resend and deletes law-follow records and unified subscriptions (GDPR).",
+					tags: ["Alertas"],
+				},
+			},
+		)
+
+		// ── /v1/alerts/me ─────────────────────────────────────────────────
+		// Reads the user's confirmed subscriptions by unsubscribe token (cookie).
+		// No email leak: caller must already possess the per-email token.
+
+		.get(
+			"/alerts/me",
+			({ query, set, request }) => {
+				const ip = getClientIp(request);
+				if (isGetRateLimited(ip)) {
+					set.status = 429;
+					return { error: "Demasiados intentos. Inténtalo más tarde." };
+				}
+
+				const dbService = _dbService;
+				if (!dbService) {
+					set.status = 503;
+					return { error: "Servicio temporalmente no disponible." };
+				}
+
+				const rows = dbService.getSubscriptionsByUnsubToken(query.token);
+				if (rows.length === 0) {
+					return { email: null, items: [] };
+				}
+
+				return {
+					email: rows[0]?.email ?? null,
+					items: rows.map((r) => ({
+						id: r.id,
+						type: r.type,
+						scope: r.scope,
+						confirmed: r.confirmed === 1,
+					})),
+				};
+			},
+			{
+				query: t.Object({
+					token: t.String({ minLength: 16 }),
+				}),
+				detail: {
+					summary: "List my subscriptions (cookie-authenticated)",
+					description:
+						"Returns the subscriptions belonging to the email associated with the given unsub token. The token is set as cookie `lb_token` on confirmation.",
+					tags: ["Alertas"],
+				},
+			},
+		)
+
+		.delete(
+			"/alerts/me",
+			({ query, set, request }) => {
+				const ip = getClientIp(request);
+				if (isRateLimited(ip)) {
+					set.status = 429;
+					return { error: "Demasiados intentos. Inténtalo más tarde." };
+				}
+
+				const dbService = _dbService;
+				if (!dbService) {
+					set.status = 503;
+					return { error: "Servicio temporalmente no disponible." };
+				}
+
+				const id = Number.parseInt(query.id, 10);
+				if (!Number.isFinite(id) || id <= 0) {
+					set.status = 400;
+					return { error: "Identificador inválido." };
+				}
+
+				const ok = dbService.deleteSubscription(id, query.token);
+				if (!ok) {
+					set.status = 404;
+					return { error: "Suscripción no encontrada." };
+				}
+
+				return { success: true };
+			},
+			{
+				query: t.Object({
+					id: t.String({ minLength: 1 }),
+					token: t.String({ minLength: 16 }),
+				}),
+				detail: {
+					summary: "Delete a single subscription",
+					description:
+						"Removes one subscription row by id, gated by the per-email unsub token (cookie).",
 					tags: ["Alertas"],
 				},
 			},

--- a/packages/api/src/scripts/migrate-to-subscriptions.ts
+++ b/packages/api/src/scripts/migrate-to-subscriptions.ts
@@ -1,0 +1,182 @@
+/**
+ * One-shot migration: backfill the unified `subscriptions` table from the two
+ * legacy stores it replaces — Resend Audiences (materias + jurisdiccion) and
+ * the local `norm_follows` table.
+ *
+ * Idempotent. Re-running is safe: upsertSubscription preserves prior
+ * `confirmed=1` state and rewrites tokens deterministically.
+ *
+ * Usage:
+ *   bun run packages/api/src/scripts/migrate-to-subscriptions.ts
+ *   bun run packages/api/src/scripts/migrate-to-subscriptions.ts --dry-run
+ *
+ * Run once on production after deploying the schema migration. Subsequent
+ * runs are no-ops unless new rows exist in either source.
+ */
+
+import { Database } from "bun:sqlite";
+import { createSchema } from "@leyabierta/pipeline";
+import { Resend } from "resend";
+import { DbService } from "../services/db.ts";
+import { generateHmac } from "../services/email.ts";
+
+const DB_PATH = process.env.DB_PATH ?? "./data/leyabierta.db";
+const RESEND_API_KEY = process.env.RESEND_API_KEY ?? "";
+const RESEND_AUDIENCE_ID = process.env.RESEND_AUDIENCE_ID ?? "";
+
+const args = process.argv.slice(2);
+const dryRun = args.includes("--dry-run");
+
+if (!RESEND_API_KEY || !RESEND_AUDIENCE_ID) {
+	console.error(
+		"RESEND_API_KEY and RESEND_AUDIENCE_ID must be set. Aborting.",
+	);
+	process.exit(1);
+}
+
+const db = new Database(DB_PATH);
+db.exec("PRAGMA journal_mode = WAL");
+db.exec("PRAGMA foreign_keys = ON");
+createSchema(db);
+const dbService = new DbService(db);
+
+interface ResendContact {
+	id: string;
+	email: string;
+	unsubscribed: boolean;
+	properties?: Record<string, string>;
+}
+
+async function unsubTokenForEmail(email: string): Promise<string> {
+	return generateHmac(`${email}:unsub`);
+}
+
+async function migrateResendContacts(): Promise<{
+	contacts: number;
+	rows: number;
+}> {
+	const resend = new Resend(RESEND_API_KEY);
+	let contacts: ResendContact[] = [];
+	try {
+		const response = await resend.contacts.list({
+			audienceId: RESEND_AUDIENCE_ID,
+		});
+		contacts = response.data?.data ?? [];
+	} catch (err) {
+		console.error("Failed to fetch contacts from Resend:", err);
+		return { contacts: 0, rows: 0 };
+	}
+
+	let rowsWritten = 0;
+	for (const c of contacts) {
+		const props = c.properties ?? {};
+		let materias: string[] = [];
+		try {
+			materias = JSON.parse(props.materias ?? "[]");
+		} catch {
+			// no materias on this contact
+		}
+		const jurisdiction = props.jurisdiction ?? "es";
+
+		// confirmed=1 only when Resend says the contact is subscribed
+		// (unsubscribed=false). Pending double-opt-in contacts stay confirmed=0.
+		const confirmed = !c.unsubscribed;
+		const confirmToken = await generateHmac(c.email);
+		const unsubToken = await unsubTokenForEmail(c.email);
+
+		const items: Array<{ type: "materia" | "jurisdiccion"; scope: string }> = [
+			...materias.map((m: string) => ({
+				type: "materia" as const,
+				scope: m,
+			})),
+			{ type: "jurisdiccion" as const, scope: jurisdiction },
+		];
+
+		if (dryRun) {
+			console.log(
+				`[dry] ${c.email} → ${items.length} rows (confirmed=${confirmed})`,
+			);
+			rowsWritten += items.length;
+			continue;
+		}
+
+		for (const item of items) {
+			dbService.upsertSubscription({
+				email: c.email,
+				type: item.type,
+				scope: item.scope,
+				confirmToken,
+				unsubToken,
+				confirmed,
+			});
+			rowsWritten++;
+		}
+	}
+
+	return { contacts: contacts.length, rows: rowsWritten };
+}
+
+async function migrateNormFollows(): Promise<{
+	rows: number;
+}> {
+	const rows = db
+		.query<
+			{ email: string; norm_id: string; confirmed: number; token: string },
+			[]
+		>(
+			`SELECT email, norm_id, confirmed, token FROM norm_follows`,
+		)
+		.all();
+
+	let written = 0;
+	for (const r of rows) {
+		const unsubToken = await unsubTokenForEmail(r.email);
+		const confirmed = r.confirmed === 1;
+
+		if (dryRun) {
+			console.log(
+				`[dry] follow ${r.email} → ${r.norm_id} (confirmed=${confirmed})`,
+			);
+			written++;
+			continue;
+		}
+
+		dbService.upsertSubscription({
+			email: r.email,
+			type: "norma",
+			scope: r.norm_id,
+			confirmToken: r.token,
+			unsubToken,
+			confirmed,
+		});
+		written++;
+	}
+
+	return { rows: written };
+}
+
+console.log(
+	`Migrating to unified subscriptions table${dryRun ? " (dry run)" : ""}…`,
+);
+
+const resendResult = await migrateResendContacts();
+console.log(
+	`Resend Audiences: ${resendResult.contacts} contacts → ${resendResult.rows} subscription rows`,
+);
+
+const followsResult = await migrateNormFollows();
+console.log(`norm_follows: ${followsResult.rows} subscription rows`);
+
+const total = resendResult.rows + followsResult.rows;
+console.log(`Total rows ${dryRun ? "would be " : ""}written: ${total}`);
+
+if (!dryRun) {
+	const after = db
+		.query<{ c: number }, []>(
+			"SELECT COUNT(*) AS c FROM subscriptions WHERE confirmed = 1",
+		)
+		.get();
+	console.log(`Confirmed rows in subscriptions now: ${after?.c ?? 0}`);
+}
+
+db.close();

--- a/packages/api/src/scripts/migrate-to-subscriptions.ts
+++ b/packages/api/src/scripts/migrate-to-subscriptions.ts
@@ -28,9 +28,7 @@ const args = process.argv.slice(2);
 const dryRun = args.includes("--dry-run");
 
 if (!RESEND_API_KEY || !RESEND_AUDIENCE_ID) {
-	console.error(
-		"RESEND_API_KEY and RESEND_AUDIENCE_ID must be set. Aborting.",
-	);
+	console.error("RESEND_API_KEY and RESEND_AUDIENCE_ID must be set. Aborting.");
 	process.exit(1);
 }
 
@@ -123,9 +121,7 @@ async function migrateNormFollows(): Promise<{
 		.query<
 			{ email: string; norm_id: string; confirmed: number; token: string },
 			[]
-		>(
-			`SELECT email, norm_id, confirmed, token FROM norm_follows`,
-		)
+		>(`SELECT email, norm_id, confirmed, token FROM norm_follows`)
 		.all();
 
 	let written = 0;

--- a/packages/api/src/scripts/send-notifications.ts
+++ b/packages/api/src/scripts/send-notifications.ts
@@ -16,7 +16,6 @@
 
 import { Database } from "bun:sqlite";
 import { createSchema } from "@leyabierta/pipeline";
-import { Resend } from "resend";
 import { DbService } from "../services/db.ts";
 import {
 	buildUnsubscribeUrl,
@@ -29,7 +28,6 @@ import {
 const DB_PATH = process.env.DB_PATH ?? "./data/leyabierta.db";
 const SITE_URL = process.env.SITE_URL ?? "https://leyabierta.es";
 const RESEND_API_KEY = process.env.RESEND_API_KEY ?? "";
-const RESEND_AUDIENCE_ID = process.env.RESEND_AUDIENCE_ID ?? "";
 const MAX_REFORMS_PER_EMAIL = 10;
 
 const args = process.argv.slice(2);
@@ -373,73 +371,83 @@ if (previewMode) {
 
 // ── Send mode ───────────────────────────────────────────────────────────
 
-if (!RESEND_API_KEY || !RESEND_AUDIENCE_ID) {
-	console.error("RESEND_API_KEY and RESEND_AUDIENCE_ID must be set.");
+if (!RESEND_API_KEY) {
+	console.error("RESEND_API_KEY must be set.");
 	db.close();
 	process.exit(1);
 }
 
-const resend = new Resend(RESEND_API_KEY);
-
-interface ResendContact {
-	id: string;
-	email: string;
-	unsubscribed: boolean;
-	properties?: Record<string, string>;
-}
-
-let contacts: ResendContact[] = [];
-try {
-	const response = await resend.contacts.list({
-		audienceId: RESEND_AUDIENCE_ID,
-	});
-	contacts = (response.data?.data ?? []).filter(
-		(c: ResendContact) => !c.unsubscribed,
-	);
-} catch (err) {
-	console.error("Failed to fetch contacts from Resend:", err);
-	db.close();
-	process.exit(1);
-}
-
-console.log(`Found ${contacts.length} subscribed contacts.`);
+// Source of truth: unified `subscriptions` table. Resend Audiences is no
+// longer read here. The migration script (migrate-to-subscriptions.ts)
+// backfills from Resend + norm_follows; from this point onward `subscriptions`
+// is what determines who gets what.
 
 interface ContactInfo {
 	email: string;
 	materias: string[];
 	jurisdiction: string;
+	followedNormIds: string[];
 }
 
-const contactInfos: ContactInfo[] = [];
-let legacySkipped = 0;
+const allSubs = dbService.getAllConfirmedSubscriptions();
+console.log(`Found ${allSubs.length} confirmed subscription rows.`);
 
-for (const c of contacts) {
-	const props = c.properties ?? {};
-	let materias: string[] = [];
-	try {
-		materias = JSON.parse(props.materias ?? "[]");
-	} catch {
-		// ignore
+const byEmail = new Map<string, ContactInfo>();
+for (const s of allSubs) {
+	const info = byEmail.get(s.email) ?? {
+		email: s.email,
+		materias: [],
+		jurisdiction: "es",
+		followedNormIds: [],
+	};
+	if (s.type === "materia") info.materias.push(s.scope);
+	else if (s.type === "jurisdiccion") info.jurisdiction = s.scope;
+	else if (s.type === "norma") info.followedNormIds.push(s.scope);
+	byEmail.set(s.email, info);
+}
+
+const contactInfos = [...byEmail.values()].filter(
+	(c) => c.materias.length > 0 || c.followedNormIds.length > 0,
+);
+
+console.log(`Processing ${contactInfos.length} unique recipients.`);
+
+// ── Reform lookup helpers ───────────────────────────────────────────────
+
+const reformByKey = new Map<string, ReformItem>(
+	pending
+		.map((p): [string, ReformItem | undefined] => {
+			// Pending rows already have summaries — fetch the full ReformItem via
+			// the materias query, joined to summaries. We simulate by grabbing
+			// data from the existing reform record.
+			const all = dbService.getRecentReformsByMaterias(
+				materiasMap.get(p.norm_id) ?? [],
+				"es",
+				"1900-01-01",
+			);
+			const row = all.find(
+				(r) => r.id === p.norm_id && r.date === p.reform_date,
+			);
+			return [`${p.norm_id}::${p.reform_date}`, row];
+		})
+		.filter((entry): entry is [string, ReformItem] => entry[1] != null),
+);
+
+function getReformsByNormIds(normIds: string[]): ReformItem[] {
+	const result: ReformItem[] = [];
+	for (const id of normIds) {
+		for (const p of pending) {
+			if (p.norm_id !== id) continue;
+			const r = reformByKey.get(`${p.norm_id}::${p.reform_date}`);
+			if (r?.headline && r?.summary) result.push(r);
+		}
 	}
-	if (materias.length === 0) {
-		legacySkipped++;
-		continue;
-	}
-	contactInfos.push({
-		email: c.email,
-		materias,
-		jurisdiction: props.jurisdiction ?? "es",
-	});
+	return result;
 }
-
-if (legacySkipped > 0) {
-	console.log(`Skipped ${legacySkipped} legacy contacts without materias.`);
-}
-console.log(`Processing ${contactInfos.length} contacts with materias.`);
 
 // ── Send per subscriber ─────────────────────────────────────────────────
 
-const reformCache = new Map<string, ReformItem[]>();
+const materiaCache = new Map<string, ReformItem[]>();
 
 function getCacheKey(materias: string[], jurisdiction: string): string {
 	return `${jurisdiction}::${[...materias].sort().join("|")}`;
@@ -449,12 +457,35 @@ let sent = 0;
 let skipped = 0;
 
 for (const contact of contactInfos) {
-	const cacheKey = getCacheKey(contact.materias, contact.jurisdiction);
-	let reforms = reformCache.get(cacheKey);
-	if (!reforms) {
-		reforms = getMatchingReforms(contact.materias, contact.jurisdiction);
-		reformCache.set(cacheKey, reforms);
+	// Materias + jurisdiccion matches (cached across recipients).
+	let materiaMatches: ReformItem[] = [];
+	if (contact.materias.length > 0) {
+		const cacheKey = getCacheKey(contact.materias, contact.jurisdiction);
+		const cached = materiaCache.get(cacheKey);
+		if (cached) {
+			materiaMatches = cached;
+		} else {
+			materiaMatches = getMatchingReforms(
+				contact.materias,
+				contact.jurisdiction,
+			);
+			materiaCache.set(cacheKey, materiaMatches);
+		}
 	}
+
+	// Followed-law matches (always per-recipient — typically a small set).
+	const followMatches = getReformsByNormIds(contact.followedNormIds);
+
+	// Merge and deduplicate by (id, date).
+	const seen = new Set<string>();
+	const merged: ReformItem[] = [];
+	for (const r of [...materiaMatches, ...followMatches]) {
+		const k = `${r.id}::${r.date}`;
+		if (seen.has(k)) continue;
+		seen.add(k);
+		merged.push(r);
+	}
+	const reforms = merged.slice(0, MAX_REFORMS_PER_EMAIL);
 
 	if (reforms.length === 0) {
 		skipped++;
@@ -478,7 +509,7 @@ for (const contact of contactInfos) {
 
 	if (dryRun) {
 		console.log(
-			`[dry-run] ${maskEmail(contact.email)}: ${reforms.length} reforms, subject: "${subject}"`,
+			`[dry-run] ${maskEmail(contact.email)}: ${reforms.length} reforms (${materiaMatches.length} by materia, ${followMatches.length} by follow), subject: "${subject}"`,
 		);
 		sent++;
 		continue;

--- a/packages/api/src/scripts/send-notifications.ts
+++ b/packages/api/src/scripts/send-notifications.ts
@@ -146,23 +146,27 @@ function reformUrl(r: ReformItem): string {
 
 function getMatchingReforms(
 	materias: string[],
-	jurisdiction: string,
+	jurisdictions: string[],
 ): ReformItem[] {
-	// Query by materia+jurisdiction, then filter to only pending (un-notified) reforms
-	const all = dbService.getRecentReformsByMaterias(
-		materias,
-		jurisdiction,
-		"1900-01-01",
+	// Query by materia+jurisdiction (one call per jurisdiction the user follows),
+	// then filter to only pending (un-notified) reforms.
+	const all = jurisdictions.flatMap((j) =>
+		dbService.getRecentReformsByMaterias(materias, j, "1900-01-01"),
 	);
 
 	const matches = all.filter(
 		(r) => pendingKeys.has(`${r.id}::${r.date}`) && r.headline && r.summary,
 	);
 
-	// Deduplicate by headline
+	// Deduplicate by (id, date) first (multiple jurisdictions may surface the
+	// same reform), then by headline.
+	const idSeen = new Set<string>();
 	const seen = new Set<string>();
 	const deduped: ReformItem[] = [];
 	for (const r of matches) {
+		const idKey = `${r.id}::${r.date}`;
+		if (idSeen.has(idKey)) continue;
+		idSeen.add(idKey);
 		const key = r.headline ?? r.title;
 		if (seen.has(key)) continue;
 		seen.add(key);
@@ -347,7 +351,7 @@ if (previewMode) {
 		`Preview: ${previewMaterias.length} materias, jurisdiction=${previewJurisdiction}`,
 	);
 
-	const reforms = getMatchingReforms(previewMaterias, previewJurisdiction);
+	const reforms = getMatchingReforms(previewMaterias, [previewJurisdiction]);
 	if (reforms.length === 0) {
 		console.log("No un-notified reforms match. Nothing to preview.");
 		db.close();
@@ -385,7 +389,7 @@ if (!RESEND_API_KEY) {
 interface ContactInfo {
 	email: string;
 	materias: string[];
-	jurisdiction: string;
+	jurisdictions: string[];
 	followedNormIds: string[];
 }
 
@@ -397,13 +401,18 @@ for (const s of allSubs) {
 	const info = byEmail.get(s.email) ?? {
 		email: s.email,
 		materias: [],
-		jurisdiction: "es",
+		jurisdictions: [],
 		followedNormIds: [],
 	};
 	if (s.type === "materia") info.materias.push(s.scope);
-	else if (s.type === "jurisdiccion") info.jurisdiction = s.scope;
+	else if (s.type === "jurisdiccion") info.jurisdictions.push(s.scope);
 	else if (s.type === "norma") info.followedNormIds.push(s.scope);
 	byEmail.set(s.email, info);
+}
+
+// Default to state-level ("es") when a recipient hasn't picked any jurisdiction.
+for (const info of byEmail.values()) {
+	if (info.jurisdictions.length === 0) info.jurisdictions.push("es");
 }
 
 const contactInfos = [...byEmail.values()].filter(
@@ -458,8 +467,8 @@ function getReformsByNormIds(normIds: string[]): ReformItem[] {
 
 const materiaCache = new Map<string, ReformItem[]>();
 
-function getCacheKey(materias: string[], jurisdiction: string): string {
-	return `${jurisdiction}::${[...materias].sort().join("|")}`;
+function getCacheKey(materias: string[], jurisdictions: string[]): string {
+	return `${[...jurisdictions].sort().join(",")}::${[...materias].sort().join("|")}`;
 }
 
 let sent = 0;
@@ -469,14 +478,14 @@ for (const contact of contactInfos) {
 	// Materias + jurisdiccion matches (cached across recipients).
 	let materiaMatches: ReformItem[] = [];
 	if (contact.materias.length > 0) {
-		const cacheKey = getCacheKey(contact.materias, contact.jurisdiction);
+		const cacheKey = getCacheKey(contact.materias, contact.jurisdictions);
 		const cached = materiaCache.get(cacheKey);
 		if (cached) {
 			materiaMatches = cached;
 		} else {
 			materiaMatches = getMatchingReforms(
 				contact.materias,
-				contact.jurisdiction,
+				contact.jurisdictions,
 			);
 			materiaCache.set(cacheKey, materiaMatches);
 		}
@@ -485,10 +494,12 @@ for (const contact of contactInfos) {
 	// Followed-law matches (always per-recipient — typically a small set).
 	const followMatches = getReformsByNormIds(contact.followedNormIds);
 
-	// Merge and deduplicate by (id, date).
+	// Merge and deduplicate by (id, date). Followed laws first: an explicit
+	// follow is a stronger signal than a materia match, so when MAX_REFORMS_PER_EMAIL
+	// caps the list we keep the user-curated picks ahead of broad-topic hits.
 	const seen = new Set<string>();
 	const merged: ReformItem[] = [];
-	for (const r of [...materiaMatches, ...followMatches]) {
+	for (const r of [...followMatches, ...materiaMatches]) {
 		const k = `${r.id}::${r.date}`;
 		if (seen.has(k)) continue;
 		seen.add(k);

--- a/packages/api/src/scripts/send-notifications.ts
+++ b/packages/api/src/scripts/send-notifications.ts
@@ -282,7 +282,7 @@ function buildMultiReformHtml(
 	const cards = reforms.map(buildReformCard).join("\n");
 	const overflow =
 		overflowCount > 0
-			? `<tr><td style="padding:4px 0 12px;font-size:13px;color:#576b80;font-family:Arial,Helvetica,sans-serif;">y ${overflowCount} m\u00E1s en <a href="${SITE_URL}/mis-cambios" style="color:#2b5797;">leyabierta.es/mis-cambios</a></td></tr>`
+			? `<tr><td style="padding:4px 0 12px;font-size:13px;color:#576b80;font-family:Arial,Helvetica,sans-serif;">y ${overflowCount} m\u00E1s en <a href="${SITE_URL}/cambios/para-mi/" style="color:#2b5797;">leyabierta.es/cambios/para-mi</a></td></tr>`
 			: "";
 
 	return `<!DOCTYPE html>
@@ -313,7 +313,7 @@ function buildMultiReformHtml(
   </table>
   <table width="100%" cellpadding="0" cellspacing="0" border="0" style="background:#ffffff;">
     <tr><td style="padding:24px 28px;text-align:center;">
-      <a href="${SITE_URL}/mis-cambios" style="display:inline-block;padding:12px 28px;background:#1a365d;color:#ffffff;text-decoration:none;border-radius:6px;font-size:14px;font-weight:600;">Ver todos tus cambios</a>
+      <a href="${SITE_URL}/cambios/para-mi/" style="display:inline-block;padding:12px 28px;background:#1a365d;color:#ffffff;text-decoration:none;border-radius:6px;font-size:14px;font-weight:600;">Ver todos tus cambios</a>
     </td></tr>
   </table>
   <table width="100%" cellpadding="0" cellspacing="0" border="0" style="background:#ffffff;border-radius:0 0 8px 8px;">
@@ -414,21 +414,30 @@ console.log(`Processing ${contactInfos.length} unique recipients.`);
 
 // ── Reform lookup helpers ───────────────────────────────────────────────
 
+// Build reformByKey directly from `pending`, which already carries
+// headline/summary/reform_type/importance from getUnnotifiedReforms.
+// Fetching by jurisdiction would silently drop autonomic-community laws,
+// and per-row CTE queries are wasteful when we have the data in hand.
 const reformByKey = new Map<string, ReformItem>(
 	pending
 		.map((p): [string, ReformItem | undefined] => {
-			// Pending rows already have summaries — fetch the full ReformItem via
-			// the materias query, joined to summaries. We simulate by grabbing
-			// data from the existing reform record.
-			const all = dbService.getRecentReformsByMaterias(
-				materiasMap.get(p.norm_id) ?? [],
-				"es",
-				"1900-01-01",
-			);
-			const row = all.find(
-				(r) => r.id === p.norm_id && r.date === p.reform_date,
-			);
-			return [`${p.norm_id}::${p.reform_date}`, row];
+			const norm = dbService.getLaw(p.norm_id);
+			if (!norm) return [`${p.norm_id}::${p.reform_date}`, undefined];
+			return [
+				`${p.norm_id}::${p.reform_date}`,
+				{
+					id: p.norm_id,
+					title: norm.title,
+					rank: norm.rank,
+					status: norm.status,
+					date: p.reform_date,
+					source_id: p.source_id,
+					headline: p.headline,
+					summary: p.summary,
+					reform_type: p.reform_type,
+					importance: p.importance,
+				},
+			];
 		})
 		.filter((entry): entry is [string, ReformItem] => entry[1] != null),
 );

--- a/packages/api/src/services/db.ts
+++ b/packages/api/src/services/db.ts
@@ -950,6 +950,22 @@ export class DbService {
 		return result.changes;
 	}
 
+	getSubscriptionByConfirmToken(token: string): {
+		email: string;
+		type: string;
+		scope: string;
+	} | null {
+		const row = this.db
+			.query(
+				`SELECT email, type, scope FROM subscriptions
+				 WHERE confirm_token = ? LIMIT 1`,
+			)
+			.get(token) as
+			| { email: string; type: string; scope: string }
+			| null;
+		return row;
+	}
+
 	getSubscriptionsByUnsubToken(token: string): Array<{
 		id: number;
 		email: string;

--- a/packages/api/src/services/db.ts
+++ b/packages/api/src/services/db.ts
@@ -960,9 +960,7 @@ export class DbService {
 				`SELECT email, type, scope FROM subscriptions
 				 WHERE confirm_token = ? LIMIT 1`,
 			)
-			.get(token) as
-			| { email: string; type: string; scope: string }
-			| null;
+			.get(token) as { email: string; type: string; scope: string } | null;
 		return row;
 	}
 
@@ -1046,9 +1044,7 @@ export class DbService {
 		scope: string;
 	}> {
 		return this.db
-			.query(
-				`SELECT email, type, scope FROM subscriptions WHERE confirmed = 1`,
-			)
+			.query(`SELECT email, type, scope FROM subscriptions WHERE confirmed = 1`)
 			.all() as Array<{ email: string; type: string; scope: string }>;
 	}
 

--- a/packages/api/src/services/db.ts
+++ b/packages/api/src/services/db.ts
@@ -899,6 +899,143 @@ export class DbService {
 		return result.changes > 0;
 	}
 
+	// ── Subscriptions (unified) ──
+	//
+	// Single source of truth for all email subscriptions. Replaces the split
+	// between Resend Audiences (materias + jurisdiccion) and norm_follows.
+	// `type` is one of: materia | jurisdiccion | norma | query.
+
+	upsertSubscription(args: {
+		email: string;
+		type: "materia" | "jurisdiccion" | "norma" | "query";
+		scope: string;
+		confirmToken: string;
+		unsubToken: string;
+		confirmed?: boolean;
+	}): void {
+		const confirmedFlag = args.confirmed ? 1 : 0;
+		const confirmedAt = args.confirmed ? new Date().toISOString() : null;
+		this.db
+			.query(
+				`INSERT INTO subscriptions
+					(email, type, scope, confirmed, confirm_token, unsub_token, confirmed_at)
+				 VALUES (?, ?, ?, ?, ?, ?, ?)
+				 ON CONFLICT(email, type, scope) DO UPDATE SET
+					confirm_token = excluded.confirm_token,
+					unsub_token   = CASE WHEN subscriptions.confirmed = 1
+						THEN subscriptions.unsub_token ELSE excluded.unsub_token END,
+					confirmed     = CASE WHEN subscriptions.confirmed = 1
+						THEN 1 ELSE excluded.confirmed END,
+					confirmed_at  = COALESCE(subscriptions.confirmed_at, excluded.confirmed_at)`,
+			)
+			.run(
+				args.email,
+				args.type,
+				args.scope,
+				confirmedFlag,
+				args.confirmToken,
+				args.unsubToken,
+				confirmedAt,
+			);
+	}
+
+	confirmSubscriptionsByToken(token: string): number {
+		const result = this.db
+			.query(
+				`UPDATE subscriptions
+				 SET confirmed = 1, confirmed_at = datetime('now')
+				 WHERE confirm_token = ? AND confirmed = 0`,
+			)
+			.run(token);
+		return result.changes;
+	}
+
+	getSubscriptionsByUnsubToken(token: string): Array<{
+		id: number;
+		email: string;
+		type: string;
+		scope: string;
+		confirmed: number;
+	}> {
+		return this.db
+			.query(
+				`SELECT id, email, type, scope, confirmed
+				 FROM subscriptions WHERE unsub_token = ?`,
+			)
+			.all(token) as Array<{
+			id: number;
+			email: string;
+			type: string;
+			scope: string;
+			confirmed: number;
+		}>;
+	}
+
+	getSubscriptionsByEmail(email: string): Array<{
+		id: number;
+		type: string;
+		scope: string;
+		confirmed: number;
+		created_at: string;
+	}> {
+		return this.db
+			.query(
+				`SELECT id, type, scope, confirmed, created_at
+				 FROM subscriptions WHERE email = ? ORDER BY created_at DESC`,
+			)
+			.all(email) as Array<{
+			id: number;
+			type: string;
+			scope: string;
+			confirmed: number;
+			created_at: string;
+		}>;
+	}
+
+	deleteSubscription(id: number, unsubToken: string): boolean {
+		const result = this.db
+			.query("DELETE FROM subscriptions WHERE id = ? AND unsub_token = ?")
+			.run(id, unsubToken);
+		return result.changes > 0;
+	}
+
+	deleteSubscriptionsByEmail(email: string): void {
+		this.db.query("DELETE FROM subscriptions WHERE email = ?").run(email);
+	}
+
+	deleteSubscriptionsByUnsubToken(token: string): number {
+		const result = this.db
+			.query("DELETE FROM subscriptions WHERE unsub_token = ?")
+			.run(token);
+		return result.changes;
+	}
+
+	// Returns confirmed emails subscribed to a given (type, scope) tuple.
+	// Used by the notification cron to find recipients per match dimension.
+	getConfirmedEmailsForScope(type: string, scope: string): string[] {
+		const rows = this.db
+			.query(
+				`SELECT DISTINCT email FROM subscriptions
+				 WHERE type = ? AND scope = ? AND confirmed = 1`,
+			)
+			.all(type, scope) as Array<{ email: string }>;
+		return rows.map((r) => r.email);
+	}
+
+	// All confirmed subscriptions grouped by email. Used by the cron to build
+	// per-recipient match sets in a single pass.
+	getAllConfirmedSubscriptions(): Array<{
+		email: string;
+		type: string;
+		scope: string;
+	}> {
+		return this.db
+			.query(
+				`SELECT email, type, scope FROM subscriptions WHERE confirmed = 1`,
+			)
+			.all() as Array<{ email: string; type: string; scope: string }>;
+	}
+
 	getRecentReformsByMaterias(
 		materias: string[],
 		jurisdiction: string,

--- a/packages/pipeline/src/db/schema.ts
+++ b/packages/pipeline/src/db/schema.ts
@@ -130,6 +130,8 @@ const SCHEMA_SQL = /* sql */ `
   );
 
   -- Norm follows (users following specific laws for change notifications)
+  -- DEPRECATED: superseded by subscriptions(type='norma'). Kept for one release
+  -- so the migration script can backfill. Drop in release N+1.
   CREATE TABLE IF NOT EXISTS norm_follows (
     email       TEXT NOT NULL,
     norm_id     TEXT NOT NULL REFERENCES norms(id),
@@ -141,6 +143,32 @@ const SCHEMA_SQL = /* sql */ `
 
   CREATE INDEX IF NOT EXISTS idx_norm_follows_norm ON norm_follows(norm_id);
   CREATE INDEX IF NOT EXISTS idx_norm_follows_token ON norm_follows(token);
+
+  -- Unified subscriptions table.
+  -- One row per (email, type, scope) tuple. Replaces both Resend Audiences
+  -- (materias + jurisdiccion) and norm_follows (norma-specific subscriptions).
+  -- 'query' type is reserved for saved searches (future).
+  CREATE TABLE IF NOT EXISTS subscriptions (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    email         TEXT NOT NULL,
+    type          TEXT NOT NULL CHECK(type IN ('materia','jurisdiccion','norma','query')),
+    scope         TEXT NOT NULL,
+    confirmed     INTEGER NOT NULL DEFAULT 0,
+    confirm_token TEXT NOT NULL,
+    unsub_token   TEXT NOT NULL,
+    created_at    TEXT NOT NULL DEFAULT (datetime('now')),
+    confirmed_at  TEXT,
+    UNIQUE(email, type, scope)
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_subscriptions_email
+    ON subscriptions(email);
+  CREATE INDEX IF NOT EXISTS idx_subscriptions_type_scope
+    ON subscriptions(type, scope);
+  CREATE INDEX IF NOT EXISTS idx_subscriptions_confirm_token
+    ON subscriptions(confirm_token);
+  CREATE INDEX IF NOT EXISTS idx_subscriptions_unsub_token
+    ON subscriptions(unsub_token);
 
   -- AI-generated reform summaries (separate from factual reforms table)
   CREATE TABLE IF NOT EXISTS reform_summaries (

--- a/packages/web/src/pages/alertas/confirmar.astro
+++ b/packages/web/src/pages/alertas/confirmar.astro
@@ -64,9 +64,18 @@ import Base from "../../layouts/Base.astro";
 			var params = new URLSearchParams(window.location.search);
 			var email = params.get("email");
 			var code = params.get("code");
+			var token = params.get("token");
 			var el = document.getElementById("confirm-content");
 
-			if (!email || !code) {
+			// Two valid shapes:
+			//   ?email=...&code=...   → POST /subscribe confirmation flow
+			//   ?token=...            → POST /follow confirmation flow
+			var url;
+			if (email && code) {
+				url = API + "/v1/alerts/confirm?email=" + encodeURIComponent(email) + "&code=" + encodeURIComponent(code);
+			} else if (token) {
+				url = API + "/v1/alerts/follow/confirm?token=" + encodeURIComponent(token);
+			} else {
 				el.innerHTML =
 					'<div class="confirm-icon error">&#10007;</div>' +
 					'<h1>Enlace no válido</h1>' +
@@ -75,10 +84,24 @@ import Base from "../../layouts/Base.astro";
 				return;
 			}
 
-			fetch(API + "/v1/alerts/confirm?email=" + encodeURIComponent(email) + "&code=" + encodeURIComponent(code))
+			function setLbCookie(value) {
+				if (!value) return;
+				// 1 year, root path. Not httpOnly because no real auth — this is a
+				// convenience cookie that lets returning users see their subscriptions.
+				var expires = new Date();
+				expires.setFullYear(expires.getFullYear() + 1);
+				document.cookie =
+					"lb_token=" + encodeURIComponent(value) +
+					"; expires=" + expires.toUTCString() +
+					"; path=/; SameSite=Lax";
+			}
+
+			fetch(url)
 				.then(function (r) { return r.json(); })
 				.then(function (data) {
-					if (data.ok) {
+					var ok = data && (data.success === true || data.ok === true);
+					if (ok) {
+						setLbCookie(data.token);
 						if (window.la) {
 							window.la.track("digest_subscribe_success", { source: "email_confirm" });
 						}
@@ -86,7 +109,7 @@ import Base from "../../layouts/Base.astro";
 							'<div class="confirm-icon success">&#10003;</div>' +
 							'<h1>Suscripción confirmada</h1>' +
 							'<p>Tu alerta legislativa está activa. Recibirás una notificación cuando se publiquen cambios que te afecten.</p>' +
-							'<a href="/cambios/mias/" class="btn btn-primary">Ver mis cambios</a>';
+							'<a href="/cambios/para-mi/" class="btn btn-primary">Ver mis cambios</a>';
 					} else {
 						el.innerHTML =
 							'<div class="confirm-icon error">&#10007;</div>' +

--- a/packages/web/src/pages/alertas/seguir/confirmar.astro
+++ b/packages/web/src/pages/alertas/seguir/confirmar.astro
@@ -1,0 +1,23 @@
+---
+// Backwards-compatible target for confirmation links sent before the
+// unified subscription flow landed. Forwards the token to the unified
+// /alertas/confirmar page so the same client-side logic runs (cookie set,
+// success UI, redirect to /cambios/para-mi).
+---
+<!doctype html>
+<html lang="es">
+	<head>
+		<meta charset="utf-8" />
+		<title>Confirmando suscripción…</title>
+		<meta http-equiv="refresh" content="0;url=/alertas/confirmar/" />
+		<script is:inline>
+			(function () {
+				var qs = window.location.search || "";
+				window.location.replace("/alertas/confirmar/" + qs);
+			})();
+		</script>
+	</head>
+	<body>
+		<p>Redirigiendo…</p>
+	</body>
+</html>

--- a/packages/web/src/pages/cambios/para-mi/index.astro
+++ b/packages/web/src/pages/cambios/para-mi/index.astro
@@ -435,6 +435,27 @@ import Base from "../../../layouts/Base.astro";
 				perfil = JSON.parse(localStorage.getItem("leyabierta_perfil") || "null");
 			} catch (e) {}
 
+			// Cookie-based recognition: if the user has confirmed an email
+			// before, lb_token is set. We fetch their subscriptions to pre-fill
+			// the email form and skip re-asking for it.
+			function readLbToken() {
+				var match = document.cookie.match(/(?:^|; )lb_token=([^;]+)/);
+				return match ? decodeURIComponent(match[1]) : null;
+			}
+			window.__lbToken = readLbToken();
+			if (window.__lbToken) {
+				fetch(API + "/v1/alerts/me?token=" + encodeURIComponent(window.__lbToken))
+					.then(function (r) { return r.json(); })
+					.then(function (data) {
+						window.__lbMe = data;
+						if (data && data.email) {
+							var emailInput = document.getElementById("alert-email");
+							if (emailInput && !emailInput.value) emailInput.value = data.email;
+						}
+					})
+					.catch(function () {});
+			}
+
 			var answersObj = perfil ? (perfil.answers || {}) : {};
 			if (!perfil || !answersObj.workStatus) {
 				window.location.href = "/mi-situacion/";

--- a/packages/web/src/pages/leyes/[id].astro
+++ b/packages/web/src/pages/leyes/[id].astro
@@ -941,6 +941,21 @@ const seoDescription = [
 			var form = document.getElementById('follow-form');
 			if (!form) return;
 
+			// Pre-fill email from /alerts/me if the user has a known cookie.
+			// One-click follow for returning users — they don't retype email.
+			var lbCookie = document.cookie.match(/(?:^|; )lb_token=([^;]+)/);
+			if (lbCookie) {
+				fetch(apiBase + '/v1/alerts/me?token=' + encodeURIComponent(decodeURIComponent(lbCookie[1])))
+					.then(function (r) { return r.json(); })
+					.then(function (data) {
+						if (data && data.email) {
+							var emailInput = form.querySelector('input[name="email"]');
+							if (emailInput && !emailInput.value) emailInput.value = data.email;
+						}
+					})
+					.catch(function () {});
+			}
+
 			form.addEventListener('submit', function(e) {
 				e.preventDefault();
 				var emailInput = form.querySelector('input[name="email"]');


### PR DESCRIPTION
## Resumen

Unifica el sistema de suscripciones por email en una sola tabla `subscriptions` que reemplaza el almacén dividido entre **Resend Audiences** (materias + jurisdicción) y **`norm_follows`** (suscripciones por ley individual). Una fila por `(email, type, scope)` con `type ∈ {materia, jurisdiccion, norma, query}`.

Doc de decisión: `decisions/2026-05-07-unified-subscriptions.md` (Obsidian, privado).

## Por qué este PR

Antes había tres síntomas y un problema de fondo:

1. El input "Seguir esta ley" en `/leyes/[id]` capturaba emails y los guardaba en `norm_follows`, pero **el cron nunca leía esa tabla**. Datos al vacío.
2. La personalización del wizard `/mi-situacion` vivía en `localStorage`, no en backend. Cambias de dispositivo, pierdes todo.
3. Dos almacenes de suscripciones (Resend SaaS + SQLite local) sin diálogo entre ellos.

El problema de fondo: no había modelo unificado de "suscripción". Este PR lo introduce.

## Cambios

### Backend

- **`subscriptions` table** (schema.ts): tabla nueva con `type/scope`, tokens HMAC determinísticos por email, índices por email/type/scope/token.
- **`DbService`**: 9 métodos nuevos (`upsertSubscription`, `confirmSubscriptionsByToken`, `getSubscriptionByConfirmToken`, `getSubscriptionsByEmail`, `getSubscriptionsByUnsubToken`, `deleteSubscription`, `deleteSubscriptionsByEmail`, `deleteSubscriptionsByUnsubToken`, `getConfirmedEmailsForScope`, `getAllConfirmedSubscriptions`). Upsert preserva `confirmed=1` previo: re-suscribirse no degrada estado.
- **`alerts.ts`**: dual-write durante este PR. `/subscribe`, `/follow`, `/confirm`, `/follow/confirm`, `/unsubscribe` siguen escribiendo a Resend/`norm_follows` Y mirroran a `subscriptions`. Confirmación devuelve el `lb_token` (HMAC determinístico por email) para que el frontend lo guarde en cookie.
- **Endpoints nuevos**: `GET /v1/alerts/me?token=` (lista subs por token-cookie), `DELETE /v1/alerts/me?id=&token=` (quita una sub).
- **`send-notifications.ts`**: corte limpio. Lee solo de `subscriptions` (no más `resend.contacts.list()`). Por destinatario: union de matches `materia × jurisdiccion` + matches `norma` (leyes seguidas). Dedupe por `(norm_id, date)`, cap a `MAX_REFORMS_PER_EMAIL`.
- **`scripts/migrate-to-subscriptions.ts`**: backfill idempotente. Lee Resend Audiences (`materias`, `jurisdiction`, `unsubscribed`) y `norm_follows` (`email`, `norm_id`, `confirmed`, `token`), inserta en `subscriptions` con tokens determinísticos. Reejecutable: upsert preserva `confirmed=1`.

### Frontend

- **`/alertas/confirmar`**: maneja ambos flujos (`?email=&code=` y `?token=`). Setea cookie `lb_token` (1 año, SameSite=Lax) en éxito. Arregla check `data.ok` que era stale (la API devuelve `success: true`) y redirect roto a `/cambios/mias/` (la ruta real es `/cambios/para-mi/`).
- **`/alertas/seguir/confirmar`**: nuevo, redirect compatible con emails antiguos en cola.
- **`/cambios/para-mi`**: si hay cookie, llama `/v1/alerts/me`, pre-rellena el form de email. localStorage path intacto.
- **`/leyes/[id]`**: el form "Seguir esta ley" pre-rellena email para usuarios con cookie. Un click para usuarios conocidos.

### Tests

- `subscriptions.test.ts`: 9 tests cubren idempotencia de upsert, preservación de `confirmed=1`, confirm-by-token, cookie-gated delete, agrupación por unsub_token, y confirmed-only read del cron.
- `bun test`: 506/506 pasan, sin regresiones.

## Despliegue (orden importante)

1. Mergear → schema migration corre en deploy (es `CREATE TABLE IF NOT EXISTS`, idempotente).
2. **Una vez** post-deploy, ejecutar migración manual desde KonarServer:
   ```
   bun run packages/api/src/scripts/migrate-to-subscriptions.ts
   ```
   Backfilea Resend Audiences + `norm_follows` → `subscriptions`. Idempotente: re-correr no daña.
3. Cron `send-notifications.ts` ya leerá de `subscriptions` desde el siguiente run.

**Rollback**: revert del PR. Resend Audiences y `norm_follows` quedan intactos (la migración solo copia, nunca borra). Cero downtime.

## Fuera de scope (defer)

- `type='query'` (búsquedas guardadas tipo "teletrabajo"). Schema lo soporta; cron lo ignora.
- Magic link / login real.
- Mini-análisis IA personalizado por envío.
- Drop de `norm_follows` table y desconexión total de Resend Audiences SaaS. Esperar 1 release tras este merge.

## Test plan

- [ ] Schema migration aplica limpio en BD existente (probar con copia de prod).
- [ ] `migrate-to-subscriptions.ts --dry-run` lista contactos esperados sin escribir.
- [ ] `migrate-to-subscriptions.ts` real produce N rows = (contactos Resend × (1 + |materias|)) + (rows en `norm_follows`).
- [ ] Re-correr el script no añade filas (idempotente).
- [ ] Suscripción nueva por wizard → fila en `subscriptions` con `confirmed=0`.
- [ ] Click en email de confirmación → fila pasa a `confirmed=1`, cookie `lb_token` seteada en navegador.
- [ ] `/cambios/para-mi` con cookie → email pre-rellenado en form.
- [ ] `/leyes/[id]` con cookie → email pre-rellenado en form de "Seguir esta ley".
- [ ] Cron `send-notifications.ts --dry-run` reporta destinatarios desde `subscriptions` (no Resend).
- [ ] Cron real envía 1 email por destinatario con materia+follow merged.
- [ ] Unsubscribe (vía `/alertas/cancelar`) borra fila de Resend, `norm_follows`, y `subscriptions`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)