### PR TITLE
fix(docker): pin Bun to 1.3.13 — Deploy workflow lockfile mismatch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ── Build stage: compile the SIMD .so so gcc never reaches the runtime image ──
-FROM oven/bun:1-slim AS simd-builder
+FROM oven/bun:1.3.13-slim AS simd-builder
 
 WORKDIR /build
 
@@ -10,7 +10,7 @@ COPY packages/api/src/services/rag/vector-simd.c .
 RUN gcc -O3 -mavx2 -mfma -shared -fPIC -o vector-simd.linux-amd64.so vector-simd.c
 
 # ── Runtime stage: slim, no compiler toolchain ──
-FROM oven/bun:1-slim
+FROM oven/bun:1.3.13-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary

Deploy workflow on `e82d662` (#90 squash-merge to main) failed building the API image:

```
error: lockfile had changes, but lockfile is frozen
note: try re-running without --frozen-lockfile and commit the updated lockfile
```

The Dockerfile pulled `oven/bun:1-slim` which on the GHA runner resolved to Bun **1.3.11**. The `bun.lock` regenerated locally (and validated by lefthook + CI Lint) was written by Bun **1.3.13**, which adds a top-level `configVersion: 0` field. 1.3.11 cannot parse the new field, sees the lockfile as "changed" and aborts under `--frozen-lockfile`.

## Fix

Pin both Dockerfile stages to `oven/bun:1.3.13-slim`. Matches the version dev + CI use, so the same lockfile passes everywhere.

## Test plan

- [ ] Deploy workflow goes green on this branch
- [ ] After merge, prod `code-api-1` updates to commit with NaN stack (`HERMES_API_KEY` is already set in `.env.prod`)
- [ ] Smoke: `/v1/ask` with "vecino ruido" → top-1 LPH 1960 art. 7

🤖 Generated with [Claude Code](https://claude.com/claude-code)