### PR TITLE
fix(docker): add packages/eval/package.json to build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends git adduser ca-
 # Copy workspace config + package files for dependency install
 COPY package.json bun.lock ./
 COPY packages/api/package.json packages/api/
+COPY packages/eval/package.json packages/eval/
 COPY packages/pipeline/package.json packages/pipeline/
 COPY packages/web/package.json packages/web/
 


### PR DESCRIPTION
## Summary

Follow-up to #91. After pinning Bun to 1.3.13 the Deploy still failed on `5af5952` (#91 merge) with:

\`\`\`
error: lockfile had changes, but lockfile is frozen
\`\`\`

Root cause: the Dockerfile copies `packages/api`, `packages/pipeline`, `packages/web` package.json files but never `packages/eval`, which was added as a new workspace in #90 (e82d662). `bun.lock` references `@leyabierta/eval` but bun finds no package.json at that workspace path → treats lockfile as drifted.

## Fix

One-line: add the missing `COPY packages/eval/package.json packages/eval/`.

## Test plan

- [ ] Deploy goes green on main
- [ ] `code-api-1` on Konar advances past `8e38068` to the latest SHA
- [ ] Smoke: `/v1/ask` works with NaN stack + HERMES_API_KEY already in `.env.prod`

🤖 Generated with [Claude Code](https://claude.com/claude-code)