### PR TITLE
refactor(rag): rename HERMES_API_KEY → NAN_API_KEY with compat fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,7 +36,7 @@ OPENROUTER_API_KEY=sk-or-xxxxxxxxxxxx
 
 # === RAG NaN stack (Phase 5/6 — qwen3 via api.nan.builders, prod default) ===
 #
-# Required. Used by:
+# Required. Single api.nan.builders token used by:
 #   - Embeddings: qwen3-embedding (4096 dims), the prod default
 #   - Query analyzer: qwen3.6 (replaces gemini-2.5-flash-lite, +4 pp R@1)
 #   - Reranker: qwen3.6 LLM rerank (replaces cohere/rerank-4-pro, +18 pp R@1)
@@ -44,7 +44,10 @@ OPENROUTER_API_KEY=sk-or-xxxxxxxxxxxx
 #
 # Combined Phase 5+6 A/B result on 50 citizen queries × 9.7k norms:
 #   +30 pp R@1 retrieval, +1.65 pts overall synthesis quality, $0 cost.
-HERMES_API_KEY=
+NAN_API_KEY=
+# Legacy name — accepted as fallback during the rename. Will be removed in a
+# follow-up release. Set NAN_API_KEY instead.
+# HERMES_API_KEY=
 
 # Optional override: low-confidence early-return threshold for retrieval.
 # Default 0.40 (effectively off — bestScore is not informative about

--- a/packages/api/src/scripts/ab-thinking-on-off.ts
+++ b/packages/api/src/scripts/ab-thinking-on-off.ts
@@ -17,7 +17,7 @@ import { mkdirSync, writeFileSync } from "node:fs";
 
 const DB_PATH = "data/leyabierta.db";
 const HERMES_BASE_URL = "https://api.nan.builders/v1";
-const HERMES_API_KEY = process.env.HERMES_API_KEY ?? "";
+const NAN_API_KEY = process.env.NAN_API_KEY ?? process.env.HERMES_API_KEY ?? "";
 
 const args = process.argv.slice(2);
 const N = args.includes("--n")
@@ -167,7 +167,7 @@ async function callQwen(a: Article, thinking: boolean): Promise<Result> {
 			method: "POST",
 			signal: ctrl.signal,
 			headers: {
-				Authorization: `Bearer ${HERMES_API_KEY}`,
+				Authorization: `Bearer ${NAN_API_KEY}`,
 				"Content-Type": "application/json",
 			},
 			body: JSON.stringify(body),

--- a/packages/api/src/scripts/backfill-citizen-summaries.ts
+++ b/packages/api/src/scripts/backfill-citizen-summaries.ts
@@ -50,9 +50,9 @@ const SOLO_THRESHOLD_CHARS = Number(process.env.QWEN_SOLO_THRESHOLD ?? 5000);
 const CHECKPOINT_INTERVAL = 100; // checkpoint every N articles
 const REQUEST_TIMEOUT_MS = 180_000; // 3 minutes per individual request
 const HERMES_BASE_URL = "https://api.nan.builders/v1";
-const HERMES_API_KEY = process.env.HERMES_API_KEY;
-if (!HERMES_API_KEY) {
-	console.error("Error: HERMES_API_KEY env var is required");
+const NAN_API_KEY = process.env.NAN_API_KEY ?? process.env.HERMES_API_KEY;
+if (!NAN_API_KEY) {
+	console.error("Error: NAN_API_KEY (or HERMES_API_KEY) env var is required");
 	process.exit(1);
 }
 
@@ -324,7 +324,7 @@ async function callQwenBatch(
 			method: "POST",
 			signal: controller.signal,
 			headers: {
-				Authorization: `Bearer ${HERMES_API_KEY}`,
+				Authorization: `Bearer ${NAN_API_KEY}`,
 				"Content-Type": "application/json",
 			},
 			body: JSON.stringify({

--- a/packages/api/src/scripts/compare-citizen-models.ts
+++ b/packages/api/src/scripts/compare-citizen-models.ts
@@ -24,7 +24,7 @@ import { mkdirSync, writeFileSync } from "node:fs";
 
 const DB_PATH = "data/leyabierta.db";
 const HERMES_BASE_URL = "https://api.nan.builders/v1";
-const HERMES_API_KEY = process.env.HERMES_API_KEY ?? "";
+const NAN_API_KEY = process.env.NAN_API_KEY ?? process.env.HERMES_API_KEY ?? "";
 const OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY;
 if (!OPENROUTER_API_KEY) {
 	console.error("OPENROUTER_API_KEY not set");
@@ -324,7 +324,7 @@ async function callWithRetry(
 const callQwen = (a: Article) =>
 	callWithRetry(
 		`${HERMES_BASE_URL}/chat/completions`,
-		`Bearer ${HERMES_API_KEY}`,
+		`Bearer ${NAN_API_KEY}`,
 		{
 			model: "qwen3.6",
 			messages: [

--- a/packages/api/src/services/nan-api-key.ts
+++ b/packages/api/src/services/nan-api-key.ts
@@ -1,0 +1,46 @@
+/**
+ * Resolve the api.nan.builders API key from the environment.
+ *
+ * Reads `NAN_API_KEY` (correct name — the provider is nan.builders) with a
+ * fallback to `HERMES_API_KEY` (legacy name used during the OpenRouter → NaN
+ * migration; predates the rename). The fallback emits a one-time deprecation
+ * warning so we can drop it in a follow-up PR once every deployment has set
+ * `NAN_API_KEY`.
+ *
+ * Returns `undefined` if neither is set — callers decide whether that's a hard
+ * error (runtime / embed jobs) or acceptable (dry-run tooling).
+ */
+
+let warnedAboutHermes = false;
+
+export function getNanApiKey(): string | undefined {
+	const nan = process.env.NAN_API_KEY;
+	if (nan) return nan;
+
+	const hermes = process.env.HERMES_API_KEY;
+	if (hermes) {
+		if (!warnedAboutHermes) {
+			warnedAboutHermes = true;
+			console.warn(
+				"[nan] using HERMES_API_KEY for nan.builders auth — rename to NAN_API_KEY (HERMES_API_KEY fallback will be removed)",
+			);
+		}
+		return hermes;
+	}
+
+	return undefined;
+}
+
+/**
+ * Same as `getNanApiKey()` but throws when missing. Use from code paths where
+ * a missing key is unrecoverable (the runtime RAG pipeline, embed-corpus jobs).
+ */
+export function requireNanApiKey(): string {
+	const key = getNanApiKey();
+	if (!key) {
+		throw new Error(
+			"NAN_API_KEY not set (HERMES_API_KEY fallback also unset); required for api.nan.builders calls",
+		);
+	}
+	return key;
+}

--- a/packages/api/src/services/rag/analyzer.ts
+++ b/packages/api/src/services/rag/analyzer.ts
@@ -16,6 +16,7 @@
 
 import type { Database } from "bun:sqlite";
 import { callNan } from "../nan.ts";
+import { getNanApiKey } from "../nan-api-key.ts";
 import { JURISDICTION_NAMES } from "./jurisdiction.ts";
 
 /**
@@ -253,12 +254,10 @@ export async function analyzeQuery(
 }> {
 	const llmFn = (overrides.llmFn ?? callNan) as AnalyzerLlmFn;
 	const model = overrides.model ?? ANALYZER_MODEL;
-	// Default path uses NaN qwen3.6 → read HERMES_API_KEY. If the caller
+	// Default path uses NaN qwen3.6 → read from getNanApiKey(). If the caller
 	// supplied a custom llmFn (e.g. callOpenRouter for legacy A/B harnesses),
 	// respect whatever key they passed.
-	const effectiveKey = overrides.llmFn
-		? apiKey
-		: (process.env.HERMES_API_KEY ?? apiKey);
+	const effectiveKey = overrides.llmFn ? apiKey : (getNanApiKey() ?? apiKey);
 	try {
 		const result = await llmFn<{
 			keywords: string[];

--- a/packages/api/src/services/rag/embeddings.ts
+++ b/packages/api/src/services/rag/embeddings.ts
@@ -5,6 +5,8 @@
  * Supports brute-force cosine similarity search (sufficient for ~13K articles).
  */
 
+import { getNanApiKey } from "../nan-api-key.ts";
+
 const OPENROUTER_EMBEDDINGS_URL = "https://openrouter.ai/api/v1/embeddings";
 const NAN_EMBEDDINGS_URL = "https://api.nan.builders/v1/embeddings";
 const BATCH_SIZE = 50; // articles per API call
@@ -120,15 +122,14 @@ export async function fetchWithRetry(
 		);
 	}
 
-	// Pick endpoint + auth per provider. NaN reads HERMES_API_KEY from env so
-	// callers don't have to thread a separate key.
+	// Pick endpoint + auth per provider. NaN reads from getNanApiKey() so the
+	// callers don't have to thread a separate key; everyone else uses the apiKey arg.
 	const url =
 		provider === "nan" ? NAN_EMBEDDINGS_URL : OPENROUTER_EMBEDDINGS_URL;
-	const effectiveKey =
-		provider === "nan" ? (process.env.HERMES_API_KEY ?? "") : apiKey;
+	const effectiveKey = provider === "nan" ? (getNanApiKey() ?? "") : apiKey;
 	if (provider === "nan" && !effectiveKey) {
 		throw new Error(
-			"HERMES_API_KEY not set; required for NaN embedding provider",
+			"NAN_API_KEY not set (HERMES_API_KEY fallback also unset); required for NaN embedding provider",
 		);
 	}
 

--- a/packages/api/src/services/rag/reranker.ts
+++ b/packages/api/src/services/rag/reranker.ts
@@ -9,6 +9,7 @@
  * corresponding key.
  */
 
+import { getNanApiKey } from "../nan-api-key.ts";
 import { qwenLLMRerank } from "./qwen-llm-rerank.ts";
 
 const COHERE_RERANK_URL = "https://api.cohere.com/v2/rerank";
@@ -84,14 +85,14 @@ export async function rerank(
 		);
 	}
 
-	// Default: qwen3.6 LLM rerank via NaN. Read HERMES_API_KEY from the env
-	// when the caller didn't pass one — same pattern as embeddings/analyzer.
-	const nanKey = config.nanApiKey ?? process.env.HERMES_API_KEY;
+	// Default: qwen3.6 LLM rerank via NaN. Resolve via getNanApiKey() when the
+	// caller didn't pass one — same pattern as embeddings/analyzer.
+	const nanKey = config.nanApiKey ?? getNanApiKey();
 	if (nanKey) {
 		return rerankWithNanLLM(query, candidates, topK, nanKey);
 	}
 
-	// Last-resort fallbacks if HERMES_API_KEY is genuinely missing.
+	// Last-resort fallbacks if NAN_API_KEY is genuinely missing.
 	if (config.cohereApiKey) {
 		return rerankWithCohere(query, candidates, topK, config.cohereApiKey);
 	}

--- a/packages/api/src/services/rag/synthesis.ts
+++ b/packages/api/src/services/rag/synthesis.ts
@@ -13,6 +13,7 @@
 
 import type { Database } from "bun:sqlite";
 import { callNan, callNanStream } from "../nan.ts";
+import { getNanApiKey } from "../nan-api-key.ts";
 import {
 	describeNormScope,
 	isModifierNorm,
@@ -261,11 +262,11 @@ export async function synthesizeAnswer(opts: {
 	const { question, evidenceText, systemPrompt } = opts;
 	const llmFn = (opts.llmFn ?? callNan) as SynthesisLlmFn;
 	const model = opts.model ?? SYNTHESIS_MODEL;
-	// NaN models read HERMES_API_KEY; pass it (or whatever the caller gave) to
+	// NaN models read NAN_API_KEY (legacy HERMES_API_KEY fallback); pass it (or whatever the caller gave) to
 	// the llmFn. The synthesis path used to require an OpenRouter key; with
 	// qwen3.6 NaN as the default the prod caller's `apiKey` is ignored unless
 	// they swap llmFn back to callOpenRouter for legacy testing.
-	const apiKey = process.env.HERMES_API_KEY ?? opts.apiKey;
+	const apiKey = getNanApiKey() ?? opts.apiKey;
 	const result = await llmFn<{
 		answer: string;
 		citations: Array<{ norm_id: string; article_title: string }>;
@@ -341,7 +342,7 @@ export function synthesizeStream(opts: {
 	systemPrompt: string;
 }) {
 	const { question, evidenceText, systemPrompt } = opts;
-	const apiKey = process.env.HERMES_API_KEY ?? opts.apiKey;
+	const apiKey = getNanApiKey() ?? opts.apiKey;
 	return callNanStream(apiKey, {
 		model: SYNTHESIS_MODEL,
 		messages: [
@@ -431,7 +432,7 @@ export function generateMissingSummaries(opts: {
 	insertSummaryStmt: ReturnType<Database["prepare"]>;
 }) {
 	const { citations, articles, insertSummaryStmt } = opts;
-	const apiKey = process.env.HERMES_API_KEY ?? opts.apiKey;
+	const apiKey = getNanApiKey() ?? opts.apiKey;
 	const missing = citations.filter((c) => !c.citizenSummary);
 	if (missing.length === 0) return;
 
@@ -504,7 +505,7 @@ export async function generatePostSynthExtras(opts: {
 	answer: string;
 }): Promise<{ tldr: string; nextQuestions: string[] }> {
 	const { question, answer } = opts;
-	const apiKey = process.env.HERMES_API_KEY ?? opts.apiKey;
+	const apiKey = getNanApiKey() ?? opts.apiKey;
 	try {
 		const result = await callNan<{
 			tldr: string;
@@ -565,7 +566,7 @@ export async function generateDeclinedSuggestions(opts: {
 	question: string;
 }): Promise<string[]> {
 	const { question } = opts;
-	const apiKey = process.env.HERMES_API_KEY ?? opts.apiKey;
+	const apiKey = getNanApiKey() ?? opts.apiKey;
 	try {
 		const result = await callNan<{ suggested_questions: string[] }>(apiKey, {
 			model: SYNTHESIS_MODEL,


### PR DESCRIPTION
## Why

The runtime authenticates to **api.nan.builders** via an env var literally named after a different project (Hermes). Mid-migration rename that never reached the env layer. Every onboarding / ops conversation starts with "wait, is HERMES the same as NAN?" — I had it wrong earlier today in this same session.

## What

New tiny resolver \`packages/api/src/services/nan-api-key.ts\`:
- \`getNanApiKey()\` reads \`NAN_API_KEY\` first, falls back to \`HERMES_API_KEY\`, emits a **one-time** deprecation warning when the fallback fires so the rename surfaces in logs without spamming.
- \`requireNanApiKey()\` for hot paths where missing is unrecoverable.

All seven runtime/script call sites swapped:
- \`packages/api/src/services/rag/{embeddings,analyzer,reranker,synthesis}.ts\`
- \`packages/api/src/scripts/{ab-thinking-on-off,compare-citizen-models,backfill-citizen-summaries}.ts\`

\`.env.example\`: \`NAN_API_KEY=\` is now canonical, \`HERMES_API_KEY=\` documented as deprecated.

## Deploy plan

1. **Merge + deploy** — fallback covers it, prod keeps working unchanged. Expect one deprecation warning per process start in the API logs.
2. SSH KonarServer, \`echo "NAN_API_KEY=\$VALUE" >> /opt/leyabierta/code/.env.prod\`, \`docker compose up -d --force-recreate api\`.
3. Delete \`HERMES_API_KEY=\` line from \`.env.prod\`, recreate again. Warning should stop.
4. Follow-up PR (after a few days): drop the fallback path from \`getNanApiKey()\`.

## Test plan

- [x] biome clean for all touched files.
- [x] Verified no tsgo regressions in touched files (existing tsgo errors in scripts are pre-existing).
- [ ] CI Lint + Build green.
- [ ] Post-deploy: \`docker logs code-api-1 | grep "using HERMES_API_KEY"\` shows the deprecation warning once (then continues working).

🤖 Generated with [Claude Code](https://claude.com/claude-code)