### PR TITLE
chore(nan): drop HERMES_API_KEY compat fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,9 +45,6 @@ OPENROUTER_API_KEY=sk-or-xxxxxxxxxxxx
 # Combined Phase 5+6 A/B result on 50 citizen queries × 9.7k norms:
 #   +30 pp R@1 retrieval, +1.65 pts overall synthesis quality, $0 cost.
 NAN_API_KEY=
-# Legacy name — accepted as fallback during the rename. Will be removed in a
-# follow-up release. Set NAN_API_KEY instead.
-# HERMES_API_KEY=
 
 # Optional override: low-confidence early-return threshold for retrieval.
 # Default 0.40 (effectively off — bestScore is not informative about

--- a/packages/api/src/scripts/ab-thinking-on-off.ts
+++ b/packages/api/src/scripts/ab-thinking-on-off.ts
@@ -17,7 +17,7 @@ import { mkdirSync, writeFileSync } from "node:fs";
 
 const DB_PATH = "data/leyabierta.db";
 const HERMES_BASE_URL = "https://api.nan.builders/v1";
-const NAN_API_KEY = process.env.NAN_API_KEY ?? process.env.HERMES_API_KEY ?? "";
+const NAN_API_KEY = process.env.NAN_API_KEY ?? "";
 
 const args = process.argv.slice(2);
 const N = args.includes("--n")

--- a/packages/api/src/scripts/backfill-citizen-summaries.ts
+++ b/packages/api/src/scripts/backfill-citizen-summaries.ts
@@ -50,9 +50,9 @@ const SOLO_THRESHOLD_CHARS = Number(process.env.QWEN_SOLO_THRESHOLD ?? 5000);
 const CHECKPOINT_INTERVAL = 100; // checkpoint every N articles
 const REQUEST_TIMEOUT_MS = 180_000; // 3 minutes per individual request
 const HERMES_BASE_URL = "https://api.nan.builders/v1";
-const NAN_API_KEY = process.env.NAN_API_KEY ?? process.env.HERMES_API_KEY;
+const NAN_API_KEY = process.env.NAN_API_KEY;
 if (!NAN_API_KEY) {
-	console.error("Error: NAN_API_KEY (or HERMES_API_KEY) env var is required");
+	console.error("Error: NAN_API_KEY env var is required");
 	process.exit(1);
 }
 

--- a/packages/api/src/scripts/compare-citizen-models.ts
+++ b/packages/api/src/scripts/compare-citizen-models.ts
@@ -24,7 +24,7 @@ import { mkdirSync, writeFileSync } from "node:fs";
 
 const DB_PATH = "data/leyabierta.db";
 const HERMES_BASE_URL = "https://api.nan.builders/v1";
-const NAN_API_KEY = process.env.NAN_API_KEY ?? process.env.HERMES_API_KEY ?? "";
+const NAN_API_KEY = process.env.NAN_API_KEY ?? "";
 const OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY;
 if (!OPENROUTER_API_KEY) {
 	console.error("OPENROUTER_API_KEY not set");

--- a/packages/api/src/services/nan-api-key.ts
+++ b/packages/api/src/services/nan-api-key.ts
@@ -1,34 +1,12 @@
 /**
  * Resolve the api.nan.builders API key from the environment.
  *
- * Reads `NAN_API_KEY` (correct name — the provider is nan.builders) with a
- * fallback to `HERMES_API_KEY` (legacy name used during the OpenRouter → NaN
- * migration; predates the rename). The fallback emits a one-time deprecation
- * warning so we can drop it in a follow-up PR once every deployment has set
- * `NAN_API_KEY`.
- *
- * Returns `undefined` if neither is set — callers decide whether that's a hard
- * error (runtime / embed jobs) or acceptable (dry-run tooling).
+ * Reads `NAN_API_KEY`. Returns `undefined` if unset — callers decide whether
+ * that's a hard error (runtime / embed jobs) or acceptable (dry-run tooling).
  */
 
-let warnedAboutHermes = false;
-
 export function getNanApiKey(): string | undefined {
-	const nan = process.env.NAN_API_KEY;
-	if (nan) return nan;
-
-	const hermes = process.env.HERMES_API_KEY;
-	if (hermes) {
-		if (!warnedAboutHermes) {
-			warnedAboutHermes = true;
-			console.warn(
-				"[nan] using HERMES_API_KEY for nan.builders auth — rename to NAN_API_KEY (HERMES_API_KEY fallback will be removed)",
-			);
-		}
-		return hermes;
-	}
-
-	return undefined;
+	return process.env.NAN_API_KEY;
 }
 
 /**
@@ -38,9 +16,7 @@ export function getNanApiKey(): string | undefined {
 export function requireNanApiKey(): string {
 	const key = getNanApiKey();
 	if (!key) {
-		throw new Error(
-			"NAN_API_KEY not set (HERMES_API_KEY fallback also unset); required for api.nan.builders calls",
-		);
+		throw new Error("NAN_API_KEY not set; required for api.nan.builders calls");
 	}
 	return key;
 }


### PR DESCRIPTION
## Summary

- Removes the `HERMES_API_KEY` fallback from `getNanApiKey()` (and the `warnedAboutHermes` flag) — prod has been on `NAN_API_KEY` only since #95.
- Strips the `?? process.env.HERMES_API_KEY` chain from all three scripts (`ab-thinking-on-off`, `compare-citizen-models`, `backfill-citizen-summaries`).
- Cleans up `.env.example`: removes the commented `HERMES_API_KEY` line and its legacy-name note.

## Test plan

- [ ] `bunx biome check .` passes (2 pre-existing warnings in `biome.json`, unrelated to this PR)
- [ ] All 573 tests pass (`bun test`)
- [ ] Verify `NAN_API_KEY` is set in prod `.env` before merging (already confirmed — no `HERMES_API_KEY` in `.env.prod`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)