### PR TITLE
chore(rag): remove dead OpenRouter/Cohere code paths and legacy EMBEDDING_MODELS entries

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,7 +36,7 @@ OPENROUTER_API_KEY=sk-or-xxxxxxxxxxxx
 
 # === RAG NaN stack (Phase 5/6 — qwen3 via api.nan.builders, prod default) ===
 #
-# Required. Used by:
+# Required. Single api.nan.builders token used by:
 #   - Embeddings: qwen3-embedding (4096 dims), the prod default
 #   - Query analyzer: qwen3.6 (replaces gemini-2.5-flash-lite, +4 pp R@1)
 #   - Reranker: qwen3.6 LLM rerank (replaces cohere/rerank-4-pro, +18 pp R@1)
@@ -44,7 +44,10 @@ OPENROUTER_API_KEY=sk-or-xxxxxxxxxxxx
 #
 # Combined Phase 5+6 A/B result on 50 citizen queries × 9.7k norms:
 #   +30 pp R@1 retrieval, +1.65 pts overall synthesis quality, $0 cost.
-HERMES_API_KEY=
+NAN_API_KEY=
+# Legacy name — accepted as fallback during the rename. Will be removed in a
+# follow-up release. Set NAN_API_KEY instead.
+# HERMES_API_KEY=
 
 # Optional override: low-confidence early-return threshold for retrieval.
 # Default 0.40 (effectively off — bestScore is not informative about

--- a/packages/api/src/scripts/ab-thinking-on-off.ts
+++ b/packages/api/src/scripts/ab-thinking-on-off.ts
@@ -17,7 +17,7 @@ import { mkdirSync, writeFileSync } from "node:fs";
 
 const DB_PATH = "data/leyabierta.db";
 const HERMES_BASE_URL = "https://api.nan.builders/v1";
-const HERMES_API_KEY = process.env.HERMES_API_KEY ?? "";
+const NAN_API_KEY = process.env.NAN_API_KEY ?? process.env.HERMES_API_KEY ?? "";
 
 const args = process.argv.slice(2);
 const N = args.includes("--n")
@@ -167,7 +167,7 @@ async function callQwen(a: Article, thinking: boolean): Promise<Result> {
 			method: "POST",
 			signal: ctrl.signal,
 			headers: {
-				Authorization: `Bearer ${HERMES_API_KEY}`,
+				Authorization: `Bearer ${NAN_API_KEY}`,
 				"Content-Type": "application/json",
 			},
 			body: JSON.stringify(body),

--- a/packages/api/src/scripts/backfill-citizen-summaries.ts
+++ b/packages/api/src/scripts/backfill-citizen-summaries.ts
@@ -50,9 +50,9 @@ const SOLO_THRESHOLD_CHARS = Number(process.env.QWEN_SOLO_THRESHOLD ?? 5000);
 const CHECKPOINT_INTERVAL = 100; // checkpoint every N articles
 const REQUEST_TIMEOUT_MS = 180_000; // 3 minutes per individual request
 const HERMES_BASE_URL = "https://api.nan.builders/v1";
-const HERMES_API_KEY = process.env.HERMES_API_KEY;
-if (!HERMES_API_KEY) {
-	console.error("Error: HERMES_API_KEY env var is required");
+const NAN_API_KEY = process.env.NAN_API_KEY ?? process.env.HERMES_API_KEY;
+if (!NAN_API_KEY) {
+	console.error("Error: NAN_API_KEY (or HERMES_API_KEY) env var is required");
 	process.exit(1);
 }
 
@@ -324,7 +324,7 @@ async function callQwenBatch(
 			method: "POST",
 			signal: controller.signal,
 			headers: {
-				Authorization: `Bearer ${HERMES_API_KEY}`,
+				Authorization: `Bearer ${NAN_API_KEY}`,
 				"Content-Type": "application/json",
 			},
 			body: JSON.stringify({

--- a/packages/api/src/scripts/compare-citizen-models.ts
+++ b/packages/api/src/scripts/compare-citizen-models.ts
@@ -24,7 +24,7 @@ import { mkdirSync, writeFileSync } from "node:fs";
 
 const DB_PATH = "data/leyabierta.db";
 const HERMES_BASE_URL = "https://api.nan.builders/v1";
-const HERMES_API_KEY = process.env.HERMES_API_KEY ?? "";
+const NAN_API_KEY = process.env.NAN_API_KEY ?? process.env.HERMES_API_KEY ?? "";
 const OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY;
 if (!OPENROUTER_API_KEY) {
 	console.error("OPENROUTER_API_KEY not set");
@@ -324,7 +324,7 @@ async function callWithRetry(
 const callQwen = (a: Article) =>
 	callWithRetry(
 		`${HERMES_BASE_URL}/chat/completions`,
-		`Bearer ${HERMES_API_KEY}`,
+		`Bearer ${NAN_API_KEY}`,
 		{
 			model: "qwen3.6",
 			messages: [

--- a/packages/api/src/services/nan-api-key.ts
+++ b/packages/api/src/services/nan-api-key.ts
@@ -1,0 +1,46 @@
+/**
+ * Resolve the api.nan.builders API key from the environment.
+ *
+ * Reads `NAN_API_KEY` (correct name — the provider is nan.builders) with a
+ * fallback to `HERMES_API_KEY` (legacy name used during the OpenRouter → NaN
+ * migration; predates the rename). The fallback emits a one-time deprecation
+ * warning so we can drop it in a follow-up PR once every deployment has set
+ * `NAN_API_KEY`.
+ *
+ * Returns `undefined` if neither is set — callers decide whether that's a hard
+ * error (runtime / embed jobs) or acceptable (dry-run tooling).
+ */
+
+let warnedAboutHermes = false;
+
+export function getNanApiKey(): string | undefined {
+	const nan = process.env.NAN_API_KEY;
+	if (nan) return nan;
+
+	const hermes = process.env.HERMES_API_KEY;
+	if (hermes) {
+		if (!warnedAboutHermes) {
+			warnedAboutHermes = true;
+			console.warn(
+				"[nan] using HERMES_API_KEY for nan.builders auth — rename to NAN_API_KEY (HERMES_API_KEY fallback will be removed)",
+			);
+		}
+		return hermes;
+	}
+
+	return undefined;
+}
+
+/**
+ * Same as `getNanApiKey()` but throws when missing. Use from code paths where
+ * a missing key is unrecoverable (the runtime RAG pipeline, embed-corpus jobs).
+ */
+export function requireNanApiKey(): string {
+	const key = getNanApiKey();
+	if (!key) {
+		throw new Error(
+			"NAN_API_KEY not set (HERMES_API_KEY fallback also unset); required for api.nan.builders calls",
+		);
+	}
+	return key;
+}

--- a/packages/api/src/services/rag/analyzer.ts
+++ b/packages/api/src/services/rag/analyzer.ts
@@ -16,6 +16,7 @@
 
 import type { Database } from "bun:sqlite";
 import { callNan } from "../nan.ts";
+import { getNanApiKey } from "../nan-api-key.ts";
 import { JURISDICTION_NAMES } from "./jurisdiction.ts";
 
 /**
@@ -253,12 +254,10 @@ export async function analyzeQuery(
 }> {
 	const llmFn = (overrides.llmFn ?? callNan) as AnalyzerLlmFn;
 	const model = overrides.model ?? ANALYZER_MODEL;
-	// Default path uses NaN qwen3.6 → read HERMES_API_KEY. If the caller
+	// Default path uses NaN qwen3.6 → read from getNanApiKey(). If the caller
 	// supplied a custom llmFn (e.g. callOpenRouter for legacy A/B harnesses),
 	// respect whatever key they passed.
-	const effectiveKey = overrides.llmFn
-		? apiKey
-		: (process.env.HERMES_API_KEY ?? apiKey);
+	const effectiveKey = overrides.llmFn ? apiKey : (getNanApiKey() ?? apiKey);
 	try {
 		const result = await llmFn<{
 			keywords: string[];

--- a/packages/api/src/services/rag/analyzer.ts
+++ b/packages/api/src/services/rag/analyzer.ts
@@ -227,9 +227,9 @@ export function normalizePeriodicTitle(title: string): string | null {
 // ── Query analysis ──
 
 /**
- * LLM call signature shared by callOpenRouter and callNan. The harness can
- * inject a NaN-backed function via `analyzerLlmFn` to swap providers without
- * touching the prompt or parsing logic.
+ * LLM call signature. The harness can inject an alternative function via
+ * `llmFn` to swap providers without touching the prompt or parsing logic.
+ * Used by research/ab/ scripts.
  */
 export type AnalyzerLlmFn = <T>(
 	apiKey: string,
@@ -255,8 +255,8 @@ export async function analyzeQuery(
 	const llmFn = (overrides.llmFn ?? callNan) as AnalyzerLlmFn;
 	const model = overrides.model ?? ANALYZER_MODEL;
 	// Default path uses NaN qwen3.6 → read from getNanApiKey(). If the caller
-	// supplied a custom llmFn (e.g. callOpenRouter for legacy A/B harnesses),
-	// respect whatever key they passed.
+	// supplied a custom llmFn (e.g. research/ab/ harnesses), respect whatever
+	// key they passed.
 	const effectiveKey = overrides.llmFn ? apiKey : (getNanApiKey() ?? apiKey);
 	try {
 		const result = await llmFn<{

--- a/packages/api/src/services/rag/embeddings.ts
+++ b/packages/api/src/services/rag/embeddings.ts
@@ -1,74 +1,30 @@
 /**
  * Embedding generation and vector search for RAG.
  *
- * Generates embeddings via OpenRouter API and stores them as a binary file.
- * Supports brute-force cosine similarity search (sufficient for ~13K articles).
+ * Generates embeddings via api.nan.builders (qwen3-embedding) and stores
+ * them as a binary file. Supports brute-force cosine similarity search
+ * (sufficient for ~13K articles).
  */
 
 import { getNanApiKey } from "../nan-api-key.ts";
 
-const OPENROUTER_EMBEDDINGS_URL = "https://openrouter.ai/api/v1/embeddings";
 const NAN_EMBEDDINGS_URL = "https://api.nan.builders/v1/embeddings";
 const BATCH_SIZE = 50; // articles per API call
 const BACKOFF_MS = 1000;
 
-export type EmbeddingProvider = "openrouter" | "nan" | "local";
+export type EmbeddingProvider = "nan" | "local";
 
 export interface EmbeddingModel {
 	id: string;
 	dimensions: number;
-	/**
-	 * Where the embedding API lives. Defaults to OpenRouter for backwards
-	 * compat. NaN models hit api.nan.builders (free, no auth via OpenRouter)
-	 * and read HERMES_API_KEY from the environment instead of the apiKey arg.
-	 */
 	provider?: EmbeddingProvider;
 }
 
 export const EMBEDDING_MODELS: Record<string, EmbeddingModel> = {
-	"openai-small": {
-		id: "openai/text-embedding-3-small",
-		dimensions: 1536,
-		provider: "openrouter",
-	},
-	"openai-large": {
-		id: "openai/text-embedding-3-large",
-		dimensions: 3072,
-		provider: "openrouter",
-	},
-	qwen3: {
-		id: "qwen/qwen3-embedding-8b",
-		dimensions: 4096,
-		provider: "openrouter",
-	},
-	"qwen3-local-q8": {
-		id: "qwen3-embedding-8b-q8_0-local",
-		dimensions: 4096,
-		provider: "local",
-	},
 	"qwen3-nan": {
 		id: "qwen3-embedding",
 		dimensions: 4096,
 		provider: "nan",
-	},
-	"qwen3-nan-summary": {
-		// Same Qwen3-Embedding-8B as qwen3-nan, but the corpus side embeds
-		// citizen summaries (plain Spanish) instead of raw legal text. Used by
-		// Phase 4 multi-vector retrieval as a "vocabulary bridge" between
-		// citizen queries and ancient legalese.
-		id: "qwen3-embedding",
-		dimensions: 4096,
-		provider: "nan",
-	},
-	"embgemma-local": {
-		id: "embeddinggemma-300m-bf16-local",
-		dimensions: 768,
-		provider: "local",
-	},
-	"gemini-embedding-2": {
-		id: "google/gemini-embedding-2-preview",
-		dimensions: 3072,
-		provider: "openrouter",
 	},
 };
 
@@ -111,7 +67,7 @@ export async function fetchWithRetry(
 	apiKey: string,
 	modelId: string,
 	input: string | string[],
-	provider: EmbeddingProvider = "openrouter",
+	provider: EmbeddingProvider = "nan",
 ): Promise<Response> {
 	const maxRetries = 3;
 	let attempts = 0;
@@ -122,12 +78,9 @@ export async function fetchWithRetry(
 		);
 	}
 
-	// Pick endpoint + auth per provider. NaN reads from getNanApiKey() so the
-	// callers don't have to thread a separate key; everyone else uses the apiKey arg.
-	const url =
-		provider === "nan" ? NAN_EMBEDDINGS_URL : OPENROUTER_EMBEDDINGS_URL;
-	const effectiveKey = provider === "nan" ? (getNanApiKey() ?? "") : apiKey;
-	if (provider === "nan" && !effectiveKey) {
+	// NaN reads from getNanApiKey() so callers don't have to thread a separate key.
+	const effectiveKey = getNanApiKey() ?? apiKey;
+	if (!effectiveKey) {
 		throw new Error(
 			"NAN_API_KEY not set (HERMES_API_KEY fallback also unset); required for NaN embedding provider",
 		);
@@ -136,21 +89,16 @@ export async function fetchWithRetry(
 	while (true) {
 		let response: Response;
 		try {
-			const headers: Record<string, string> = {
-				Authorization: `Bearer ${effectiveKey}`,
-				"Content-Type": "application/json",
-			};
-			if (provider === "openrouter") {
-				headers["HTTP-Referer"] = "https://leyabierta.es";
-				headers["X-Title"] = "Ley Abierta RAG";
-			}
-			response = await fetch(url, {
+			response = await fetch(NAN_EMBEDDINGS_URL, {
 				method: "POST",
-				headers,
+				headers: {
+					Authorization: `Bearer ${effectiveKey}`,
+					"Content-Type": "application/json",
+				},
 				body: JSON.stringify({
 					model: modelId,
 					input,
-					...(provider === "nan" ? { encoding_format: "float" } : {}),
+					encoding_format: "float",
 				}),
 			});
 
@@ -165,10 +113,12 @@ export async function fetchWithRetry(
 			}
 
 			// Cloudflare 5xx (NaN) is transient — retry like 429.
-			if (provider === "nan" && response.status >= 500) {
+			if (response.status >= 500) {
 				attempts++;
 				if (attempts > maxRetries) {
-					throw new Error(`NaN ${response.status} after ${attempts} retries`);
+					throw new Error(
+						`NaN API ${response.status} after ${attempts} retries`,
+					);
 				}
 				const delay = BACKOFF_MS * attempts * 2;
 				await new Promise((r) => setTimeout(r, delay));
@@ -223,15 +173,9 @@ export async function generateEmbeddings(
 
 	for (let i = 0; i < articles.length; i += BATCH_SIZE) {
 		const batch = articles.slice(i, i + BATCH_SIZE);
-		const texts = batch.map((a) => {
-			// Gemini Embedding 2 supports 8,192 tokens (~24K chars).
-			// Truncate to 24000 chars to stay safely within limit while using
-			// most of the available context window (previously 2000 chars / 6%).
-			const content = a.text.slice(0, 24000);
-			return content;
-		});
+		const texts = batch.map((a) => a.text.slice(0, 24000));
 
-		// biome-ignore lint/suspicious/noExplicitAny: OpenRouter API response shape
+		// biome-ignore lint/suspicious/noExplicitAny: API response shape
 		let data: any = null;
 		for (let attempt = 0; attempt < 5; attempt++) {
 			if (attempt > 0) {
@@ -1084,17 +1028,10 @@ export async function embedQuery(
 	const model = EMBEDDING_MODELS[modelKey];
 	if (!model) throw new Error(`Unknown model: ${modelKey}`);
 
-	// Gemini Embedding 2 requires inline task prefixes for asymmetric retrieval.
-	// See: https://ai.google.dev/gemini-api/docs/embeddings
-	const prefixedQuery =
-		modelKey === "gemini-embedding-2"
-			? `task: question answering | query: ${query}`
-			: query;
-
 	const response = await fetchWithRetry(
 		apiKey,
 		model.id,
-		prefixedQuery,
+		query,
 		model.provider,
 	);
 	// biome-ignore lint/suspicious/noExplicitAny: API response shape

--- a/packages/api/src/services/rag/embeddings.ts
+++ b/packages/api/src/services/rag/embeddings.ts
@@ -5,6 +5,8 @@
  * Supports brute-force cosine similarity search (sufficient for ~13K articles).
  */
 
+import { getNanApiKey } from "../nan-api-key.ts";
+
 const OPENROUTER_EMBEDDINGS_URL = "https://openrouter.ai/api/v1/embeddings";
 const NAN_EMBEDDINGS_URL = "https://api.nan.builders/v1/embeddings";
 const BATCH_SIZE = 50; // articles per API call
@@ -120,15 +122,14 @@ export async function fetchWithRetry(
 		);
 	}
 
-	// Pick endpoint + auth per provider. NaN reads HERMES_API_KEY from env so
-	// callers don't have to thread a separate key.
+	// Pick endpoint + auth per provider. NaN reads from getNanApiKey() so the
+	// callers don't have to thread a separate key; everyone else uses the apiKey arg.
 	const url =
 		provider === "nan" ? NAN_EMBEDDINGS_URL : OPENROUTER_EMBEDDINGS_URL;
-	const effectiveKey =
-		provider === "nan" ? (process.env.HERMES_API_KEY ?? "") : apiKey;
+	const effectiveKey = provider === "nan" ? (getNanApiKey() ?? "") : apiKey;
 	if (provider === "nan" && !effectiveKey) {
 		throw new Error(
-			"HERMES_API_KEY not set; required for NaN embedding provider",
+			"NAN_API_KEY not set (HERMES_API_KEY fallback also unset); required for NaN embedding provider",
 		);
 	}
 

--- a/packages/api/src/services/rag/pipeline.ts
+++ b/packages/api/src/services/rag/pipeline.ts
@@ -90,7 +90,6 @@ const DECLINE_LOW_CONFIDENCE =
 // ── Pipeline ──
 
 export class RagPipeline {
-	private cohereApiKey: string | null;
 	private embeddedNormIds: string[] | null = null;
 
 	private insertSummaryStmt: ReturnType<Database["prepare"]>;
@@ -101,8 +100,6 @@ export class RagPipeline {
 		private apiKey: string,
 		private dataDir: string = "./data",
 	) {
-		this.cohereApiKey = process.env.COHERE_API_KEY ?? null;
-
 		// Initialize article-level BM25 index for hybrid search
 		ensureBlocksFts(this.db);
 		// Vocab table powers the OR-fallback token pruning in bm25ArticleSearch.
@@ -216,7 +213,6 @@ export class RagPipeline {
 		const retrieval = await runRetrievalCore({
 			db: this.db,
 			apiKey: this.apiKey,
-			cohereApiKey: this.cohereApiKey,
 			question: request.question,
 			requestJurisdiction: request.jurisdiction,
 			embeddedNormIds: this.getEmbeddedNormIdsCached(),
@@ -450,7 +446,6 @@ export class RagPipeline {
 			const retrievalPromise = runRetrievalCore({
 				db: this.db,
 				apiKey: this.apiKey,
-				cohereApiKey: this.cohereApiKey,
 				question: request.question,
 				requestJurisdiction: request.jurisdiction,
 				embeddedNormIds: this.getEmbeddedNormIdsCached(),
@@ -746,7 +741,6 @@ export class RagPipeline {
 		const retrieval = await runRetrievalCore({
 			db: this.db,
 			apiKey: this.apiKey,
-			cohereApiKey: this.cohereApiKey,
 			question: request.question,
 			requestJurisdiction: request.jurisdiction,
 			embeddedNormIds: this.getEmbeddedNormIdsCached(),
@@ -834,7 +828,6 @@ export class RagPipeline {
 			const retrieval = await runRetrievalCore({
 				db: this.db,
 				apiKey: this.apiKey,
-				cohereApiKey: this.cohereApiKey,
 				question: request.question,
 				requestJurisdiction: request.jurisdiction,
 				embeddedNormIds: this.getEmbeddedNormIdsCached(),

--- a/packages/api/src/services/rag/reranker.ts
+++ b/packages/api/src/services/rag/reranker.ts
@@ -1,21 +1,12 @@
 /**
  * Reranker — rescores candidate articles by relevance to the query.
  *
- * Default backend: qwen3.6 LLM rerank via NaN. Phase 5 A/B showed +18 pp R@1
+ * Backend: qwen3.6 LLM rerank via NaN. Phase 5 A/B showed +18 pp R@1
  * over cohere/rerank-4-pro on this Spanish-legal corpus, with $0 cost.
- *
- * Cohere and OpenRouter backends remain available as opt-in fallbacks for
- * comparison testing only — set `preferredBackend` and provide the
- * corresponding key.
  */
 
 import { getNanApiKey } from "../nan-api-key.ts";
 import { qwenLLMRerank } from "./qwen-llm-rerank.ts";
-
-const COHERE_RERANK_URL = "https://api.cohere.com/v2/rerank";
-const OPENROUTER_RERANK_URL = "https://openrouter.ai/api/v1/rerank";
-const COHERE_MODEL = "rerank-v3.5";
-const OPENROUTER_RERANK_MODEL = "cohere/rerank-4-pro";
 
 export interface RerankerCandidate {
 	key: string; // "normId:blockId"
@@ -30,13 +21,7 @@ export interface RerankerResult {
 }
 
 interface RerankerConfig {
-	cohereApiKey?: string;
-	openrouterApiKey?: string;
-	openrouterModel?: string;
-	/** When set, use the NaN qwen3.6 LLM reranker instead of OpenRouter/Cohere. */
 	nanApiKey?: string;
-	/** Force a specific backend regardless of credentials present. */
-	preferredBackend?: "cohere" | "openrouter" | "nan-llm";
 }
 
 /**
@@ -72,19 +57,6 @@ export async function rerank(
 		};
 	}
 
-	// Opt-in legacy backends for comparison/A-B only.
-	if (config.preferredBackend === "cohere" && config.cohereApiKey) {
-		return rerankWithCohere(query, candidates, topK, config.cohereApiKey);
-	}
-	if (config.preferredBackend === "openrouter" && config.openrouterApiKey) {
-		return rerankViaOpenRouter(
-			query,
-			candidates,
-			topK,
-			config.openrouterApiKey,
-		);
-	}
-
 	// Default: qwen3.6 LLM rerank via NaN. Resolve via getNanApiKey() when the
 	// caller didn't pass one — same pattern as embeddings/analyzer.
 	const nanKey = config.nanApiKey ?? getNanApiKey();
@@ -92,20 +64,7 @@ export async function rerank(
 		return rerankWithNanLLM(query, candidates, topK, nanKey);
 	}
 
-	// Last-resort fallbacks if NAN_API_KEY is genuinely missing.
-	if (config.cohereApiKey) {
-		return rerankWithCohere(query, candidates, topK, config.cohereApiKey);
-	}
-	if (config.openrouterApiKey) {
-		return rerankViaOpenRouter(
-			query,
-			candidates,
-			topK,
-			config.openrouterApiKey,
-		);
-	}
-
-	// No keys → passthrough (preserves order from RRF).
+	// No key → passthrough (preserves order from RRF).
 	return {
 		results: candidates.slice(0, topK).map((c, i) => ({
 			key: c.key,
@@ -126,221 +85,4 @@ async function rerankWithNanLLM(
 	nanApiKey: string,
 ): Promise<{ results: RerankerResult[]; backend: string; cost: number }> {
 	return qwenLLMRerank(nanApiKey, query, candidates, topK);
-}
-
-// ── Cohere Rerank ──
-
-async function rerankWithCohere(
-	query: string,
-	candidates: RerankerCandidate[],
-	topK: number,
-	apiKey: string,
-): Promise<{ results: RerankerResult[]; backend: string; cost: number }> {
-	const documents = candidates.map((c) => ({
-		text: `${c.title}\n\n${c.text.slice(0, 1500)}`,
-	}));
-
-	const response = await fetch(COHERE_RERANK_URL, {
-		method: "POST",
-		headers: {
-			Authorization: `Bearer ${apiKey}`,
-			"Content-Type": "application/json",
-		},
-		body: JSON.stringify({
-			model: COHERE_MODEL,
-			query,
-			documents,
-			top_n: topK,
-		}),
-	});
-
-	if (!response.ok) {
-		const err = await response.text();
-		console.warn(
-			`Cohere Rerank error ${response.status}: ${err.slice(0, 200)}`,
-		);
-		// Graceful fallback: return candidates in original order
-		return {
-			results: candidates.slice(0, topK).map((c, i) => ({
-				key: c.key,
-				relevanceScore: 1 - i * 0.01,
-				rank: i + 1,
-			})),
-			backend: "cohere-rerank-failed",
-			cost: 0,
-		};
-	}
-
-	const data = (await response.json()) as {
-		results: Array<{ index: number; relevance_score: number }>;
-	};
-
-	const results: RerankerResult[] = data.results
-		.filter((r) => r.index >= 0 && r.index < candidates.length)
-		.map((r, rank) => ({
-			key: candidates[r.index]!.key,
-			relevanceScore: r.relevance_score,
-			rank: rank + 1,
-		}));
-
-	// Cohere costs ~$0.001 per 1000 search units (1 search unit = 1 doc × 1 query)
-	const cost = (candidates.length / 1000) * 0.001;
-
-	return { results, backend: "cohere-rerank-v3.5", cost };
-}
-
-// ── OpenRouter Rerank (Cohere rerank-4-pro via OpenRouter) ──
-
-async function rerankViaOpenRouter(
-	query: string,
-	candidates: RerankerCandidate[],
-	topK: number,
-	apiKey: string,
-): Promise<{ results: RerankerResult[]; backend: string; cost: number }> {
-	const documents = candidates.map(
-		(c) => `${c.title}\n\n${c.text.slice(0, 1500)}`,
-	);
-
-	const response = await fetch(OPENROUTER_RERANK_URL, {
-		method: "POST",
-		headers: {
-			Authorization: `Bearer ${apiKey}`,
-			"Content-Type": "application/json",
-			"HTTP-Referer": "https://leyabierta.es",
-			"X-Title": "Ley Abierta RAG",
-		},
-		body: JSON.stringify({
-			model: OPENROUTER_RERANK_MODEL,
-			query,
-			documents,
-			top_n: topK,
-		}),
-	});
-
-	if (!response.ok) {
-		const err = await response.text();
-		console.warn(
-			`OpenRouter rerank error ${response.status}: ${err.slice(0, 200)}`,
-		);
-		// Fall back to passthrough instead of crashing
-		return {
-			results: candidates.slice(0, topK).map((c, i) => ({
-				key: c.key,
-				relevanceScore: 1 - i * 0.01,
-				rank: i + 1,
-			})),
-			backend: "openrouter-rerank-failed",
-			cost: 0,
-		};
-	}
-
-	const data = (await response.json()) as {
-		results: Array<{ index: number; relevance_score: number }>;
-		usage?: { cost?: number };
-	};
-
-	const results: RerankerResult[] = data.results
-		.filter((r) => r.index >= 0 && r.index < candidates.length)
-		.map((r, rank) => ({
-			key: candidates[r.index]!.key,
-			relevanceScore: r.relevance_score,
-			rank: rank + 1,
-		}));
-
-	const cost = data.usage?.cost ?? 0;
-	return { results, backend: "openrouter-rerank-4-pro", cost };
-}
-
-// ── LLM-based reranker (kept as fallback, not actively used) ──
-// biome-ignore lint/correctness/noUnusedVariables: kept as documented fallback
-async function rerankWithLLM(
-	query: string,
-	candidates: RerankerCandidate[],
-	topK: number,
-	apiKey: string,
-	model: string,
-): Promise<{ results: RerankerResult[]; backend: string; cost: number }> {
-	// Build a numbered list of candidate snippets
-	const snippets = candidates
-		.map((c, i) => `[${i}] ${c.title}\n${c.text.slice(0, 300)}`)
-		.join("\n\n");
-
-	const response = await fetch(
-		"https://openrouter.ai/api/v1/chat/completions",
-		{
-			method: "POST",
-			headers: {
-				Authorization: `Bearer ${apiKey}`,
-				"Content-Type": "application/json",
-				"HTTP-Referer": "https://leyabierta.es",
-				"X-Title": "Ley Abierta RAG Reranker",
-			},
-			body: JSON.stringify({
-				model,
-				temperature: 0,
-				max_tokens: 300,
-				response_format: { type: "json_object" },
-				messages: [
-					{
-						role: "system",
-						content: `Eres un reranker de documentos legales. Dada una pregunta y una lista de artículos legislativos numerados, devuelve los ${topK} más relevantes ordenados por relevancia descendente.
-
-Responde SOLO con JSON: {"ranking": [{"index": N, "score": 0.0-1.0}, ...]}
-- "index" es el número del artículo en la lista
-- "score" es la relevancia (1.0 = perfectamente relevante, 0.0 = irrelevante)
-- Devuelve exactamente ${topK} resultados (o menos si hay menos candidatos relevantes)`,
-					},
-					{
-						role: "user",
-						content: `PREGUNTA: ${query}\n\nARTÍCULOS:\n${snippets}`,
-					},
-				],
-			}),
-		},
-	);
-
-	if (!response.ok) {
-		const err = await response.text();
-		throw new Error(
-			`LLM reranker error ${response.status}: ${err.slice(0, 200)}`,
-		);
-	}
-
-	const data = (await response.json()) as {
-		usage?: { cost?: number };
-		choices?: Array<{ message?: { content?: string } }>;
-	};
-	const usage = data.usage ?? {};
-	const cost = usage.cost ?? 0;
-
-	let ranking: Array<{ index: number; score: number }>;
-	try {
-		const content = data.choices?.[0]?.message?.content ?? "{}";
-		const parsed = JSON.parse(content) as {
-			ranking?: Array<{ index: number; score: number }>;
-		};
-		ranking = parsed.ranking ?? [];
-	} catch {
-		// If LLM fails to produce valid JSON, return candidates as-is
-		return {
-			results: candidates.slice(0, topK).map((c, i) => ({
-				key: c.key,
-				relevanceScore: 1 - i * 0.01,
-				rank: i + 1,
-			})),
-			backend: `llm-reranker-${model}-failed`,
-			cost,
-		};
-	}
-
-	const results: RerankerResult[] = ranking
-		.filter((r) => r.index >= 0 && r.index < candidates.length)
-		.slice(0, topK)
-		.map((r, rank) => ({
-			key: candidates[r.index]!.key,
-			relevanceScore: r.score,
-			rank: rank + 1,
-		}));
-
-	return { results, backend: `llm-reranker-${model}`, cost };
 }

--- a/packages/api/src/services/rag/reranker.ts
+++ b/packages/api/src/services/rag/reranker.ts
@@ -9,6 +9,7 @@
  * corresponding key.
  */
 
+import { getNanApiKey } from "../nan-api-key.ts";
 import { qwenLLMRerank } from "./qwen-llm-rerank.ts";
 
 const COHERE_RERANK_URL = "https://api.cohere.com/v2/rerank";
@@ -84,14 +85,14 @@ export async function rerank(
 		);
 	}
 
-	// Default: qwen3.6 LLM rerank via NaN. Read HERMES_API_KEY from the env
-	// when the caller didn't pass one — same pattern as embeddings/analyzer.
-	const nanKey = config.nanApiKey ?? process.env.HERMES_API_KEY;
+	// Default: qwen3.6 LLM rerank via NaN. Resolve via getNanApiKey() when the
+	// caller didn't pass one — same pattern as embeddings/analyzer.
+	const nanKey = config.nanApiKey ?? getNanApiKey();
 	if (nanKey) {
 		return rerankWithNanLLM(query, candidates, topK, nanKey);
 	}
 
-	// Last-resort fallbacks if HERMES_API_KEY is genuinely missing.
+	// Last-resort fallbacks if NAN_API_KEY is genuinely missing.
 	if (config.cohereApiKey) {
 		return rerankWithCohere(query, candidates, topK, config.cohereApiKey);
 	}

--- a/packages/api/src/services/rag/retrieval.ts
+++ b/packages/api/src/services/rag/retrieval.ts
@@ -551,9 +551,8 @@ export type ProgressEventPayload =
 export type RunRetrievalCoreOpts = {
 	db: Database;
 	apiKey: string;
-	cohereApiKey: string | null;
 	question: string;
-	/** Override the embedding model key (default: EMBEDDING_MODEL_KEY = "gemini-embedding-2"). */
+	/** Override the embedding model key (default: EMBEDDING_MODEL_KEY = "qwen3-nan"). */
 	embeddingModelKey?: string;
 	/** Override the query embedding function (default: embedQuery). */
 	embedQueryFn?: EmbedQueryFn;
@@ -571,28 +570,22 @@ export type RunRetrievalCoreOpts = {
 	} | null;
 	trace?: RagTrace;
 	/**
-	 * Override the analyzer LLM. When set, replaces the default OpenRouter
-	 * gemini-2.5-flash-lite with the provided model + llmFn. Used by A/B
-	 * harnesses to swap to NaN qwen3.6.
+	 * Override the analyzer LLM. Used by research/ab/ harnesses to test
+	 * alternative models or providers.
 	 */
 	analyzerOverrides?: {
-		apiKey?: string; // override apiKey for analyzer (e.g. NaN key vs OpenRouter)
+		apiKey?: string;
 		model?: string;
 		llmFn?: import("./analyzer.ts").AnalyzerLlmFn;
 	};
-	/**
-	 * Override the reranker config. When set, replaces the default Cohere/
-	 * OpenRouter reranker selection. Set `nanApiKey` + `preferredBackend:"nan-llm"`
-	 * to force the qwen3.6 NaN LLM rerank.
-	 */
+	/** Override the reranker config (e.g. pass a specific nanApiKey). */
 	rerankerOverrides?: {
 		nanApiKey?: string;
-		preferredBackend?: "cohere" | "openrouter" | "nan-llm";
 	};
 	/**
 	 * Optional progress callback. Fired at phase boundaries inside the
 	 * retrieval pipeline (`retrieving` before vector/BM25 fan-out, `ranking`
-	 * before the Cohere/LLM rerank). The streaming route consumes these to
+	 * before the LLM rerank). The streaming route consumes these to
 	 * surface SSE `progress` events; non-streaming callers can omit.
 	 */
 	onProgress?: (payload: ProgressEventPayload) => void;
@@ -613,7 +606,6 @@ export async function runRetrievalCore(
 	const {
 		db,
 		apiKey,
-		cohereApiKey,
 		question,
 		embeddingModelKey = EMBEDDING_MODEL_KEY,
 		embedQueryFn = embedQuery,
@@ -947,7 +939,7 @@ export async function runRetrievalCore(
 	const rerankSpan = trace?.span("rerank", "tool", {
 		inputCandidates: allFusedArticles.length,
 		topK: TOP_K,
-		backend: cohereApiKey ? "cohere" : "llm",
+		backend: "nan-llm",
 	});
 	const rerankStart = Date.now();
 	let articles: RetrievedArticle[];
@@ -968,10 +960,7 @@ export async function runRetrievalCore(
 			text: a.text,
 		}));
 		const reranked = await rerank(question, candidates, TOP_K, {
-			cohereApiKey: cohereApiKey ?? undefined,
-			openrouterApiKey: apiKey,
 			nanApiKey: rerankerOverrides?.nanApiKey,
-			preferredBackend: rerankerOverrides?.preferredBackend,
 		});
 		rerankerBackend = reranked.backend;
 		const rerankedKeys = new Set(reranked.results.map((r) => r.key));

--- a/packages/api/src/services/rag/synthesis.ts
+++ b/packages/api/src/services/rag/synthesis.ts
@@ -13,6 +13,7 @@
 
 import type { Database } from "bun:sqlite";
 import { callNan, callNanStream } from "../nan.ts";
+import { getNanApiKey } from "../nan-api-key.ts";
 import {
 	describeNormScope,
 	isModifierNorm,
@@ -261,11 +262,11 @@ export async function synthesizeAnswer(opts: {
 	const { question, evidenceText, systemPrompt } = opts;
 	const llmFn = (opts.llmFn ?? callNan) as SynthesisLlmFn;
 	const model = opts.model ?? SYNTHESIS_MODEL;
-	// NaN models read HERMES_API_KEY; pass it (or whatever the caller gave) to
+	// NaN models read NAN_API_KEY (legacy HERMES_API_KEY fallback); pass it (or whatever the caller gave) to
 	// the llmFn. The synthesis path used to require an OpenRouter key; with
 	// qwen3.6 NaN as the default the prod caller's `apiKey` is ignored unless
 	// they swap llmFn back to callOpenRouter for legacy testing.
-	const apiKey = process.env.HERMES_API_KEY ?? opts.apiKey;
+	const apiKey = getNanApiKey() ?? opts.apiKey;
 	const result = await llmFn<{
 		answer: string;
 		citations: Array<{ norm_id: string; article_title: string }>;
@@ -341,7 +342,7 @@ export function synthesizeStream(opts: {
 	systemPrompt: string;
 }) {
 	const { question, evidenceText, systemPrompt } = opts;
-	const apiKey = process.env.HERMES_API_KEY ?? opts.apiKey;
+	const apiKey = getNanApiKey() ?? opts.apiKey;
 	return callNanStream(apiKey, {
 		model: SYNTHESIS_MODEL,
 		messages: [
@@ -431,7 +432,7 @@ export function generateMissingSummaries(opts: {
 	insertSummaryStmt: ReturnType<Database["prepare"]>;
 }) {
 	const { citations, articles, insertSummaryStmt } = opts;
-	const apiKey = process.env.HERMES_API_KEY ?? opts.apiKey;
+	const apiKey = getNanApiKey() ?? opts.apiKey;
 	const missing = citations.filter((c) => !c.citizenSummary);
 	if (missing.length === 0) return;
 
@@ -504,7 +505,7 @@ export async function generatePostSynthExtras(opts: {
 	answer: string;
 }): Promise<{ tldr: string; nextQuestions: string[] }> {
 	const { question, answer } = opts;
-	const apiKey = process.env.HERMES_API_KEY ?? opts.apiKey;
+	const apiKey = getNanApiKey() ?? opts.apiKey;
 	try {
 		const result = await callNan<{
 			tldr: string;
@@ -565,7 +566,7 @@ export async function generateDeclinedSuggestions(opts: {
 	question: string;
 }): Promise<string[]> {
 	const { question } = opts;
-	const apiKey = process.env.HERMES_API_KEY ?? opts.apiKey;
+	const apiKey = getNanApiKey() ?? opts.apiKey;
 	try {
 		const result = await callNan<{ suggested_questions: string[] }>(apiKey, {
 			model: SYNTHESIS_MODEL,

--- a/packages/api/src/services/rag/synthesis.ts
+++ b/packages/api/src/services/rag/synthesis.ts
@@ -42,8 +42,7 @@ import {
  * Trade-off: latency 13s avg vs 2.5s. Acceptable for Ley Abierta SSE because
  * first-token-time is what users perceive (token streaming masks the total).
  *
- * To override per call, pass `model` to `synthesizeAnswer`. To switch globally
- * back to OpenRouter, set `LEGACY_SYNTHESIS_MODEL` env var (Phase 7+ tracking).
+ * To override per call, pass `model` to `synthesizeAnswer`.
  */
 export const SYNTHESIS_MODEL = "qwen3.6";
 export const MAX_EVIDENCE_TOKENS = 8000;
@@ -256,16 +255,14 @@ export async function synthesizeAnswer(opts: {
 	systemPrompt: string;
 	/** Override the synthesis model id (default: SYNTHESIS_MODEL). */
 	model?: string;
-	/** Override the LLM transport (default: callOpenRouter; pass callNan for NaN). */
+	/** Override the LLM transport (default: callNan). Used by research/ab/ scripts. */
 	llmFn?: SynthesisLlmFn;
 }): Promise<SynthesisResult> {
 	const { question, evidenceText, systemPrompt } = opts;
 	const llmFn = (opts.llmFn ?? callNan) as SynthesisLlmFn;
 	const model = opts.model ?? SYNTHESIS_MODEL;
 	// NaN models read NAN_API_KEY (legacy HERMES_API_KEY fallback); pass it (or whatever the caller gave) to
-	// the llmFn. The synthesis path used to require an OpenRouter key; with
-	// qwen3.6 NaN as the default the prod caller's `apiKey` is ignored unless
-	// they swap llmFn back to callOpenRouter for legacy testing.
+	// the llmFn. The prod caller's `apiKey` is used as a fallback when NAN_API_KEY is unset.
 	const apiKey = getNanApiKey() ?? opts.apiKey;
 	const result = await llmFn<{
 		answer: string;


### PR DESCRIPTION
## Summary

- **embeddings.ts**: drop `EmbeddingProvider "openrouter"`, remove `OPENROUTER_EMBEDDINGS_URL` const, delete 7 legacy `EMBEDDING_MODELS` entries (`openai-small`, `openai-large`, `qwen3[openrouter]`, `qwen3-local-q8`, `qwen3-nan-summary`, `embgemma-local`, `gemini-embedding-2`), simplify `fetchWithRetry` to NaN-only path (no `HTTP-Referer`/`X-Title` headers), remove Gemini task-prefix logic from `embedQuery`.
- **reranker.ts**: delete `rerankWithCohere`, `rerankViaOpenRouter`, `rerankWithLLM` functions and their URL/model consts; strip `cohereApiKey`, `openrouterApiKey`, `preferredBackend` from `RerankerConfig`; remove all fallback dispatch branches.
- **retrieval.ts**: remove `cohereApiKey` from `RunRetrievalCoreOpts`, drop `openrouter/cohere/preferredBackend` from `rerankerOverrides` type, simplify rerank call.
- **pipeline.ts**: remove `cohereApiKey` field + `COHERE_API_KEY` env read; strip from all 4 `runRetrievalCore` call sites.
- **analyzer.ts, synthesis.ts**: update stale comments referencing OpenRouter/callOpenRouter.

The `llmFn` and `analyzerOverrides` override paths are kept — `research/ab/` scripts still use them.

## Test plan

- [x] `bunx biome check --write .` — no errors
- [x] `bunx tsgo --noEmit` — no new errors in touched files
- [x] `bun test` — 573 pass, 0 fail (pre-push hook passed)
- [x] `grep` confirms no references to deleted `EMBEDDING_MODELS` keys in `packages/api/src/` or `packages/web/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)