### PR TITLE
debug(api): diagnostic probes for silent shutdown restarts

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -86,9 +86,12 @@ let isShuttingDown = false;
 
 function shutdown(signal: string) {
 	isShuttingDown = true;
-	console.log(`${signal} received, shutting down gracefully...`);
-	// Wait 30s for in-flight requests + fire-and-forget LLM calls to complete
+	// stderr is line-buffered in Bun; stdout may not flush before process.exit
+	process.stderr.write(
+		`[shutdown] ${signal} received at ${new Date().toISOString()} — draining for 30s\n`,
+	);
 	setTimeout(async () => {
+		process.stderr.write("[shutdown] drain complete, exiting\n");
 		await flushTraces();
 		db.close();
 		process.exit(0);
@@ -97,6 +100,15 @@ function shutdown(signal: string) {
 
 process.on("SIGTERM", () => shutdown("SIGTERM"));
 process.on("SIGINT", () => shutdown("SIGINT"));
+process.on("SIGHUP", () => shutdown("SIGHUP"));
+process.on("uncaughtException", (err) => {
+	process.stderr.write(`[fatal] uncaughtException: ${err?.stack ?? err}\n`);
+});
+process.on("unhandledRejection", (reason) => {
+	process.stderr.write(
+		`[fatal] unhandledRejection: ${reason instanceof Error ? reason.stack : String(reason)}\n`,
+	);
+});
 
 const app = new Elysia()
 	.use(cors({ origin: CORS_ORIGINS }))


### PR DESCRIPTION
## Summary

The prod API container (`code-api-1`) restarts ~15×/day with `ExitCode 0`. Each restart leaves a ~33s gap between the last request log and the new `"Ley Abierta API running"` line — exactly matching the 30s graceful shutdown timer in `shutdown()`. So the SIGTERM handler **is** firing, but the `console.log("${signal} received...")` never appears in docker logs. We can't tell who/what is signalling the process.

This PR adds non-invasive diagnostic probes so the next restart leaves a fingerprint:

- Replace `console.log` in the shutdown handler with `process.stderr.write` (stderr is line-buffered in Bun; stdout is fully buffered when piped, which is the likely reason the message is being swallowed).
- Log signal name + ISO timestamp on entry, and a second line after the 30s drain.
- Add a `SIGHUP` handler in case watchtower or another supervisor uses it.
- Add `uncaughtException` / `unhandledRejection` sinks in case the runtime is exiting from an async error rather than an external signal.

Zero behavior changes for clients. Drops one `console.log`, gains five probes — all to stderr.

## What we already know it's NOT

- Not OOM (mem 408 MB / 4 GB limit, no OOMKilled flag)
- Not watchtower (logs show `Updated=0` on every poll)
- Not the daily pipeline cron (runs at 08:30, restarts happen any hour)
- Not traefik (it routes, doesn't kill)
- Not a `docker stop` (no lifecycle events captured in `docker events`)

## Test plan

- [ ] Merge, let watchtower pull the new image
- [ ] Wait for the next restart (typically <2h based on current cadence)
- [ ] `ssh KonarServer docker logs code-api-1 2>&1 | grep -E "shutdown|fatal"` — should reveal either the signal source (`[shutdown] SIGTERM received at ...`) or an async error (`[fatal] unhandledRejection: ...`)
- [ ] Use that to write the actual fix in a follow-up PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)