### PR TITLE
debug(api): file-backed exit probes

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -6,6 +6,7 @@
 
 import { Database } from "bun:sqlite";
 import { timingSafeEqual } from "node:crypto";
+import { appendFileSync } from "node:fs";
 import { join } from "node:path";
 import { cors } from "@elysiajs/cors";
 import { createSchema } from "@leyabierta/pipeline";
@@ -108,6 +109,27 @@ process.on("unhandledRejection", (reason) => {
 	process.stderr.write(
 		`[fatal] unhandledRejection: ${reason instanceof Error ? reason.stack : String(reason)}\n`,
 	);
+});
+
+// Persistent exit probes. The shutdown / fatal stderr writes above never
+// surfaced in `docker logs`, so we also tap `exit` (fires for every exit
+// path, including process.exit and natural event loop drain) and
+// `beforeExit` (fires only when the loop drains naturally with no pending
+// work — would indicate the HTTP server died silently). Each write goes to
+// a file mounted on the persistent volume so it survives container restarts.
+const EXIT_LOG = `${RAG_DATA_DIR}/api-exits.log`;
+function probeWrite(line: string) {
+	try {
+		appendFileSync(EXIT_LOG, `${new Date().toISOString()} ${line}\n`);
+	} catch {}
+}
+probeWrite(`[boot] pid=${process.pid} startedAt=${new Date().toISOString()}`);
+process.on("beforeExit", (code) => {
+	probeWrite(`[beforeExit] code=${code} — event loop drained naturally`);
+	process.stderr.write(`[beforeExit] code=${code}\n`);
+});
+process.on("exit", (code) => {
+	probeWrite(`[exit] code=${code}`);
 });
 
 const app = new Elysia()


### PR DESCRIPTION
Follow-up to #99 (c7dd029).

The stderr probes added in the previous PR **never surfaced** in `docker logs`, even though the container kept exiting and being restarted. ExitCode is consistently 0, no OOM, and yet `SIGTERM`/`uncaughtException`/`unhandledRejection` handlers all stay silent.

Working hypothesis: exit is bypassing every JS-level hook — either an internal `process.exit(0)` from native code, or the runtime tearing down stdio before our handler can flush.

This PR adds file-backed probes:
- `process.on("exit", ...)` — fires for **every** exit path (process.exit, natural loop drain, signal handler). Writes the exit code to `/data/api-exits.log`.
- `process.on("beforeExit", ...)` — fires only when the event loop drains naturally. Would tell us if the HTTP server died and left nothing keeping the loop alive.
- `[boot]` line on startup so each death has a matching birth in the same file.

Why a file: the persistent volume survives container restarts, so we can read the full history regardless of `docker logs` reliability.

## Test plan
- [ ] Merge, watchtower pulls
- [ ] Wait for next restart (or send load to provoke one — see Alex's follow-up testing)
- [ ] `ssh KonarServer docker exec code-api-1 tail -20 /data/api-exits.log`
- [ ] Read exit codes and timing → narrow root cause

🤖 Generated with [Claude Code](https://claude.com/claude-code)