### PR TITLE
infra(api): raise memory cap 4G → 8G to stop OOM restarts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,13 @@ services:
     deploy:
       resources:
         limits:
-          memory: 4G
+          # 4G triggered cgroup OOM under concurrent /v1/laws?q= and /v1/ask
+          # load: vectors.bin (~8 GB virtual via mmap) pushed anon-rss past
+          # the cap and the kernel SIGKILL'd PID 1, restarting the container.
+          # Docker did not report it as OOMKilled (only PID 1 died, not the
+          # cgroup as a whole). Bump to 8G until the embedding loader is
+          # changed to keep RSS bounded under fan-out (see #100 follow-ups).
+          memory: 8G
           cpus: "4.0"
 
   watchtower:


### PR DESCRIPTION
## Root cause (confirmed via reproduction)

After two diagnostic PRs (#99 stderr probes, #100 file-backed exit probes), I finally caught the kill:

```
kernel: bun invoked oom-killer
kernel: Memory cgroup out of memory: Killed process (bun)
  total-vm: 78 GB    ← mmap of vectors.bin
  anon-rss: 4.18 GB  ← over the 4 G cgroup cap
```

The kernel SIGKILL'd PID 1 (bun). No JS-level handler ever fires under SIGKILL — explains why neither the SIGTERM handler nor `process.on("exit")` left any trace.

**Why we missed it twice**: `docker inspect` shows `State.OOMKilled=true` only when the *whole cgroup* is OOM-killed. Here just PID 1 died, the container was restarted by `restart: unless-stopped`, and `OOMKilled` stayed `false`. Combined with `ExitCode: 0` (Docker doesn't always preserve the previous instance's exit code) the signature looked like a clean exit, sending us looking for graceful-shutdown bugs.

## Reproduction

Locally provoked the kill in 30 requests at concurrency 6:

```
seq 30 | xargs -P 6 -I{} curl -sS "https://api.leyabierta.es/v1/laws?q=vivienda&_cb={}"
→ 30× 502 → kernel oom-kill → container restart → ~30s recovery
```

In normal traffic this happens ~1×/day on traffic spikes that fan out concurrent hybrid-search or RAG queries.

## This PR

One-line change: `memory: 4G` → `memory: 8G` for the api service. Host has plenty of free RAM. Stop-gap only — see follow-ups below.

## Follow-ups (not in this PR)

1. **Bound RSS in the embedding loader.** `embeddings.ts` already reads `vectors.bin` in 1 GB chunks, but under concurrent fan-out multiple chunks stay resident. Need `madvise(MADV_RANDOM)` or smaller per-query working set.
2. **Smarter exit signature.** Add a probe that inspects `/proc/self/status` `VmPeak`/`VmRSS` periodically and logs when it crosses 80% of the cgroup cap, so a future OOM is obvious from the application logs (not just kernel ring buffer).

## Test plan

- [ ] Merge
- [ ] Watchtower pulls the new image (compose file changes don't auto-apply — needs `docker compose up -d` on the server). Will do that manually after merge.
- [ ] Rerun the reproduction burst. Expect: zero 502s, container stays up.
- [ ] Watch `/data/api-exits.log` for 24 h. Expect: no new `[boot]` lines (no restarts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)