### PR TITLE
feat(api): preload vector index at startup to close OOM cold-start window

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -22,7 +22,9 @@ import { DbService } from "./services/db.ts";
 import { GitService } from "./services/git.ts";
 import { HybridSearcherImpl } from "./services/hybrid-search.ts";
 import { RagPipeline } from "./services/rag/pipeline.ts";
+import { EMBEDDING_MODEL_KEY } from "./services/rag/retrieval.ts";
 import { flushTraces } from "./services/rag/tracing.ts";
+import { getSharedVectorIndex } from "./services/rag/vector-index-singleton.ts";
 import { createRateLimiter, getClientIp } from "./services/rate-limiter.ts";
 
 const DB_PATH = process.env.DB_PATH ?? "./data/leyabierta.db";
@@ -315,8 +317,34 @@ app
 				tags: ["Sistema"],
 			},
 		},
-	)
-	.listen(PORT);
+	);
+
+// ── Vector index preload ─────────────────────────────────────────────
+// Block startup on the vector index load so the port isn't bound until
+// the ~1.9 GB int8 SharedArrayBuffer is fully populated. Eliminates the
+// cold-start OOM window where 6 concurrent requests hit lazy-load
+// simultaneously and pushed anon-rss past the cgroup cap (#99/#100/#101).
+// Trade: ~30s delay before the new container accepts traffic. Acceptable
+// — during that window traefik returns 502, which is the *same* failure
+// mode as the OOM restart, but without killing the container.
+// Gate: only preload when the API key is present (same gate as ragPipeline
+// / hybridSearcher) and RAG_PRELOAD is not explicitly disabled.
+if (OPENROUTER_API_KEY && process.env.RAG_PRELOAD !== "false") {
+	const t0 = performance.now();
+	console.log("[preload] loading vector index…");
+	try {
+		await getSharedVectorIndex(db, EMBEDDING_MODEL_KEY, RAG_DATA_DIR);
+		const ms = Math.round(performance.now() - t0);
+		console.log(`[preload] vector index ready in ${ms}ms`);
+	} catch (err) {
+		// Non-fatal: fall back to lazy loading on first request.
+		process.stderr.write(
+			`[preload] vector index failed to load: ${err instanceof Error ? err.message : err}\n`,
+		);
+	}
+}
+
+app.listen(PORT);
 
 console.log(`Ley Abierta API running on http://localhost:${PORT}`);
 console.log(`Swagger docs: http://localhost:${PORT}/swagger`);


### PR DESCRIPTION
## Summary

- Calls `getSharedVectorIndex(db, EMBEDDING_MODEL_KEY, RAG_DATA_DIR)` before `app.listen()` so the ~1.9 GB int8 SharedArrayBuffer is fully allocated before the first request arrives
- Eliminates the thundering-herd OOM window identified in #99 / #100 / #101, where 6 concurrent cold requests triggered parallel SAB allocation and pushed peak heap past the 4 GB cgroup limit
- Gated on `OPENROUTER_API_KEY` being present (same gate as `ragPipeline` / `hybridSearcher`) and `RAG_PRELOAD !== "false"` for an escape hatch
- Non-fatal: preload failures are logged to stderr but never crash the process — falls back to lazy loading transparently
- Logs `[preload] loading vector index…` and `[preload] vector index ready in <N>ms` for visibility in `docker logs`

## Test plan

- [ ] All 685 existing tests pass (verified locally by pre-push hook)
- [ ] `packages/api/src/__tests__/vector-pool-smoke.test.ts` and `vector-simd-parity.test.ts` pass — these touch the singleton directly
- [ ] Smoke-test in staging: `docker logs` shows `[preload] vector index ready in ~30000ms` at startup, no OOM on first burst of `/v1/laws?q=` requests
- [ ] Set `RAG_PRELOAD=false` in env and verify the preload lines do not appear (escape hatch works)
- [ ] Remove `OPENROUTER_API_KEY` and verify startup proceeds without error (gate works)

Follows up on #99, #100, #101.

🤖 Generated with [Claude Code](https://claude.com/claude-code)