### PR TITLE
feat(api): in-process RSS pressure probe vs cgroup cap

### DIFF
--- a/packages/api/src/__tests__/mem-probe.test.ts
+++ b/packages/api/src/__tests__/mem-probe.test.ts
@@ -1,0 +1,23 @@
+/**
+ * Smoke test for the RSS memory pressure probe.
+ *
+ * Verifies that startMemProbe is exported and callable without crashing (the
+ * timer itself is unref'd, so running it in a test is harmless on Linux but
+ * we don't depend on /proc being present in CI — the function must handle
+ * both cases without throwing).
+ */
+
+import { describe, expect, test } from "bun:test";
+import { startMemProbe } from "../services/mem-probe.ts";
+
+describe("mem-probe", () => {
+	test("startMemProbe is exported and is a function", () => {
+		expect(typeof startMemProbe).toBe("function");
+	});
+
+	test("startMemProbe does not throw on any platform", () => {
+		// On Linux it may start a timer (unref'd — won't block test exit).
+		// On macOS/Windows it logs once and returns.
+		expect(() => startMemProbe()).not.toThrow();
+	});
+});

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -21,6 +21,7 @@ import { CitizenSummaryService } from "./services/citizen-summary.ts";
 import { DbService } from "./services/db.ts";
 import { GitService } from "./services/git.ts";
 import { HybridSearcherImpl } from "./services/hybrid-search.ts";
+import { startMemProbe } from "./services/mem-probe.ts";
 import { RagPipeline } from "./services/rag/pipeline.ts";
 import { flushTraces } from "./services/rag/tracing.ts";
 import { createRateLimiter, getClientIp } from "./services/rate-limiter.ts";
@@ -131,6 +132,9 @@ process.on("beforeExit", (code) => {
 process.on("exit", (code) => {
 	probeWrite(`[exit] code=${code}`);
 });
+
+// RSS vs cgroup-cap pressure probe — logs to stderr every 30s when busy.
+startMemProbe();
 
 const app = new Elysia()
 	.use(cors({ origin: CORS_ORIGINS }))

--- a/packages/api/src/services/mem-probe.ts
+++ b/packages/api/src/services/mem-probe.ts
@@ -1,0 +1,121 @@
+/**
+ * RSS pressure probe vs cgroup memory cap.
+ *
+ * Reads /proc/self/status every 30 seconds and compares VmRSS against the
+ * cgroup memory limit. Logs a structured JSON line to stderr so we know
+ * before the kernel OOM-kills the process.
+ *
+ * macOS / non-Linux: logs once and disables itself — production observability
+ * only, dev doesn't need it.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+
+/** One reading emitted to stderr. */
+export interface MemProbeReading {
+	probe: "mem";
+	level: "info" | "warn" | "critical";
+	rss_mb: number;
+	cap_mb: number;
+	ratio: number;
+	vm_peak_gb: number;
+}
+
+/** Returns null if the file does not exist or the key is missing. */
+function readProcStatusKb(key: string): number | null {
+	try {
+		const text = readFileSync("/proc/self/status", "utf8");
+		const match = new RegExp(`^${key}:\\s+(\\d+)\\s+kB`, "m").exec(text);
+		return match ? Number(match[1]) : null;
+	} catch {
+		return null;
+	}
+}
+
+/** Reads the cgroup v2 limit first, falls back to v1. Returns bytes or null. */
+function readCgroupLimitBytes(): number | null {
+	const v2Path = "/sys/fs/cgroup/memory.max";
+	const v1Path = "/sys/fs/cgroup/memory/memory.limit_in_bytes";
+	for (const p of [v2Path, v1Path]) {
+		try {
+			const raw = readFileSync(p, "utf8").trim();
+			// cgroup v2 may return "max" when there is no limit
+			if (raw === "max" || raw === "") continue;
+			const n = Number(raw);
+			if (Number.isFinite(n) && n > 0) return n;
+		} catch {
+			/* not found */
+		}
+	}
+	return null;
+}
+
+function levelFor(ratio: number): MemProbeReading["level"] {
+	if (ratio >= 0.85) return "critical";
+	if (ratio >= 0.7) return "warn";
+	return "info";
+}
+
+/**
+ * Starts the in-process RSS pressure probe.
+ *
+ * - Runs every 30 seconds via setInterval (unref'd so it doesn't block exit).
+ * - Suppresses output when idle (ratio < 0.3 for 5 consecutive readings).
+ * - No-ops silently on macOS/non-Linux.
+ */
+export function startMemProbe(): void {
+	// Guard: /proc/self/status must exist (Linux only)
+	if (!existsSync("/proc/self/status")) {
+		process.stderr.write("[mem-probe] rss probe disabled (non-Linux)\n");
+		return;
+	}
+
+	const cgroupLimitBytes = readCgroupLimitBytes();
+	if (cgroupLimitBytes === null) {
+		process.stderr.write(
+			"[mem-probe] cgroup memory limit not readable — probe disabled\n",
+		);
+		return;
+	}
+
+	const capMb = cgroupLimitBytes / (1024 * 1024);
+
+	// Consecutive idle-reading counter (ratio < 0.3)
+	let idleStreak = 0;
+	const IDLE_THRESHOLD = 0.3;
+	const IDLE_SKIP_AFTER = 5; // suppress after 5 consecutive idle readings
+
+	const timer = setInterval(() => {
+		const rssKb = readProcStatusKb("VmRSS");
+		const peakKb = readProcStatusKb("VmPeak");
+
+		if (rssKb === null) return; // /proc went away (shouldn't happen but guard it)
+
+		const rssMb = rssKb / 1024;
+		const vmPeakGb = peakKb !== null ? peakKb / (1024 * 1024) : 0;
+		const ratio = rssMb / capMb;
+
+		if (ratio < IDLE_THRESHOLD) {
+			idleStreak++;
+			// Only emit every IDLE_SKIP_AFTER intervals when consistently idle
+			if (idleStreak < IDLE_SKIP_AFTER) return;
+			idleStreak = 0; // reset so we wait another 5 before the next idle log
+		} else {
+			idleStreak = 0; // busy — always log
+		}
+
+		const reading: MemProbeReading = {
+			probe: "mem",
+			level: levelFor(ratio),
+			rss_mb: Math.round(rssMb),
+			cap_mb: Math.round(capMb),
+			ratio: Math.round(ratio * 1000) / 1000,
+			vm_peak_gb: Math.round(vmPeakGb * 100) / 100,
+		};
+
+		process.stderr.write(`${JSON.stringify(reading)}\n`);
+	}, 30_000);
+
+	// Don't keep the event loop alive on graceful shutdown
+	timer.unref();
+}


### PR DESCRIPTION
## Summary

- Adds `packages/api/src/services/mem-probe.ts` with a single `startMemProbe()` export
- Reads `/proc/self/status` every 30 s and compares `VmRSS` against the cgroup memory limit (`/sys/fs/cgroup/memory.max` → v1 fallback)
- Emits a structured JSON line to stderr with `level: info / warn / critical` at 0% / 70% / 85% RSS/cap ratio
- Idle suppression: skips output when ratio < 0.3 for 5 consecutive readings (logs every ~2.5 min when idle instead of every 30 s)
- Timer is `unref()`'d so it never prevents graceful shutdown
- Gracefully no-ops on macOS/non-Linux with a single log line: `[mem-probe] rss probe disabled (non-Linux)`
- Called from `index.ts` after the existing exit probes, before `app.listen()`

Follow-up on #99 / #100 / #101 — those PRs added exit probes and raised the memory cap; this one gives us in-process visibility *before* the kernel OOM-kills the process.

## Sample log lines

```
{"probe":"mem","level":"info","rss_mb":412,"cap_mb":8192,"ratio":0.05,"vm_peak_gb":1.2}
{"probe":"mem","level":"warn","rss_mb":5880,"cap_mb":8192,"ratio":0.718,"vm_peak_gb":6.8}
{"probe":"mem","level":"critical","rss_mb":7168,"cap_mb":8192,"ratio":0.875,"vm_peak_gb":8.1}
```

## Test plan

- [x] `bun test packages/api/src/__tests__/mem-probe.test.ts` — 2 tests pass (export shape + no-throw on macOS)
- [x] macOS guard verified: `[mem-probe] rss probe disabled (non-Linux)` emitted to stderr, no crash
- [x] `bunx biome format --write` and `bunx biome check` pass on all touched files
- [x] `bunx tsgo --noEmit` shows zero errors in `packages/api/src/` (only pre-existing research/script errors)
- [ ] On production Linux: verify JSON lines appear in `docker logs` at startup and every 30 s under load; grep `"level":"warn"` to watch for pressure spikes

🤖 Generated with [Claude Code](https://claude.com/claude-code)