### PR TITLE
debug(rag): micro-traces inside bm25-search/vector-search wrappers

### DIFF
--- a/packages/api/src/services/rag/bm25-dispatch.ts
+++ b/packages/api/src/services/rag/bm25-dispatch.ts
@@ -11,6 +11,17 @@
  * sink the other four. This was introduced in Sprint 2 and we preserve it.
  */
 
+/** Micro-trace probe helper — emits JSON to stderr, never throws. */
+function probe(step: string, t0: number) {
+	try {
+		process.stderr.write(
+			`${JSON.stringify({ probe: "bm25-step", step, ms: Math.round(performance.now() - t0) })}\n`,
+		);
+	} catch {
+		/* safe-to-fail */
+	}
+}
+
 import type { Database } from "bun:sqlite";
 import type { AnalyzedQuery } from "./analyzer.ts";
 import { isFundamentalRank, resolveNormsByName } from "./analyzer.ts";
@@ -93,6 +104,7 @@ export async function dispatchBm25Stages(opts: {
 	vectors: InMemoryVectorIndex | null;
 }): Promise<Bm25StageResult> {
 	const { db, question, analyzed, embeddingNormIds, vectors } = opts;
+	const dispatchT0 = performance.now();
 
 	const synonymInputs =
 		analyzed.legalSynonyms.length > 0
@@ -101,12 +113,14 @@ export async function dispatchBm25Stages(opts: {
 					keywords: analyzed.legalSynonyms,
 				}
 			: null;
+	probe("synonymInputs-build", dispatchT0);
 
 	let namedLawInputs: {
 		query: string;
 		keywords: string[];
 		filter: string[];
 	} | null = null;
+	const namedLawT0 = performance.now();
 	if (analyzed.normNameHint) {
 		let matchedNormIds = resolveNormsByName(
 			db,
@@ -140,7 +154,9 @@ export async function dispatchBm25Stages(opts: {
 			};
 		}
 	}
+	probe("namedLawInputs-resolve", namedLawT0);
 
+	const coreLawT0 = performance.now();
 	const coreLawInputs =
 		analyzed.legalSynonyms.length > 0 && !analyzed.jurisdiction
 			? (() => {
@@ -156,12 +172,14 @@ export async function dispatchBm25Stages(opts: {
 						: null;
 				})()
 			: null;
+	probe("coreLawInputs-build", coreLawT0);
 
 	let recentInputs: {
 		query: string;
 		keywords: string[];
 		filter: string[];
 	} | null = null;
+	const recentQueryT0 = performance.now();
 	if (analyzed.keywords.length > 0) {
 		const cutoff = new Date();
 		cutoff.setFullYear(cutoff.getFullYear() - RECENT_YEARS);
@@ -175,6 +193,7 @@ export async function dispatchBm25Stages(opts: {
 			)
 			.all(cutoffStr)
 			.map((r) => r.id);
+		probe("recentNormIds-db-query", recentQueryT0);
 		if (recentNormIds.length > 0) {
 			const allTerms = [...analyzed.keywords, ...analyzed.legalSynonyms];
 			recentInputs = {
@@ -183,6 +202,8 @@ export async function dispatchBm25Stages(opts: {
 				filter: recentNormIds,
 			};
 		}
+	} else {
+		probe("recentNormIds-db-query", recentQueryT0);
 	}
 
 	const stageTimings: Record<string, number> = {};
@@ -219,6 +240,8 @@ export async function dispatchBm25Stages(opts: {
 	const namedLawStop = namedLawInputs ? stageT("namedLaw") : () => {};
 	const coreLawStop = coreLawInputs ? stageT("coreLaw") : () => {};
 	const recentStop = recentInputs ? stageT("recent") : () => {};
+
+	const poolDispatchT0 = performance.now();
 
 	const [main, synonym, namedLaw, coreLaw, recent] = await Promise.all([
 		runBm25(
@@ -275,6 +298,8 @@ export async function dispatchBm25Stages(opts: {
 				})
 			: Promise.resolve([] as Bm25Hit[]),
 	]);
+	probe("pool-dispatch-all-stages", poolDispatchT0);
+	probe("dispatch-total", dispatchT0);
 
 	return { main, synonym, namedLaw, coreLaw, recent, stageTimings };
 }

--- a/packages/api/src/services/rag/vector-pool.ts
+++ b/packages/api/src/services/rag/vector-pool.ts
@@ -366,6 +366,17 @@ export async function getVectorPool(
 	}
 }
 
+/** Micro-trace probe helper for vector-search — emits JSON to stderr, never throws. */
+function vectorProbe(step: string, t0: number) {
+	try {
+		process.stderr.write(
+			`${JSON.stringify({ probe: "vector-step", step, ms: Math.round(performance.now() - t0) })}\n`,
+		);
+	} catch {
+		/* safe-to-fail */
+	}
+}
+
 export async function vectorSearchPooled(
 	queryEmbedding: Float32Array,
 	meta: Array<{ normId: string; blockId: string }>,
@@ -373,17 +384,22 @@ export async function vectorSearchPooled(
 	_dims: number,
 	topK: number = 10,
 ): Promise<VectorSearchResult[]> {
+	const vsT0 = performance.now();
+	const getPoolT0 = performance.now();
 	const p = await getVectorPool(index);
+	vectorProbe("getVectorPool", getPoolT0);
 	if (!p) {
 		throw new Error("vector pool unavailable on this platform");
 	}
-	const t0 = performance.now();
+	const searchT0 = performance.now();
 	const raw = await p.search(queryEmbedding, topK);
-	const totalMs = performance.now() - t0;
+	const totalMs = performance.now() - searchT0;
+	vectorProbe("pool-search", searchT0);
 	console.log(
 		`[vector-search-pool] ${index.totalVectors} vectors → top-${raw.length} in ${totalMs.toFixed(0)}ms`,
 	);
-	return raw.slice(0, topK).map((r) => {
+	const mapT0 = performance.now();
+	const result = raw.slice(0, topK).map((r) => {
 		const article = meta[r.globalIdx]!;
 		return {
 			normId: article.normId,
@@ -391,6 +407,9 @@ export async function vectorSearchPooled(
 			score: r.score,
 		};
 	});
+	vectorProbe("meta-map", mapT0);
+	vectorProbe("vector-total", vsT0);
+	return result;
 }
 
 /**


### PR DESCRIPTION
Adds per-step stderr probes (JSON lines, never throws) to measure exactly where wall-clock time is spent inside the `bm25-search` and `vector-search` Opik spans. Opik shows 6-9s for `bm25-search` despite the inner FTS5 queries being <1ms; these probes will reveal whether the cost sits in the `recentNormIds` correlated subquery against the 486k-row embeddings table, the pool dispatch wait, or somewhere else. Each probe emits `{"probe":"bm25-step"|"vector-step","step":"...","ms":N}` to stderr and is wrapped in try-catch so it cannot affect production responses. Once 2-3 requests are profiled via `docker logs | grep bm25-step`, the branch will be deleted and a targeted fix will follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)