### PR TITLE
feat(web): instrument question_submitted + question_completed Umami events on /pregunta

### DIFF
--- a/packages/web/src/components/AskChat.tsx
+++ b/packages/web/src/components/AskChat.tsx
@@ -15,6 +15,7 @@ import {
 	useState,
 } from "react";
 import { config } from "../config/env";
+import { track } from "../lib/analytics";
 import {
 	type Citation,
 	renderMarkdownWithCitations,
@@ -896,6 +897,9 @@ export default function AskChat() {
 			const controller = new AbortController();
 			abortRef.current = controller;
 
+			track("question_submitted", { question_length: text.length });
+			const submitTime = performance.now();
+
 			const res = await fetch(`${API_BASE}/v1/ask/stream`, {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
@@ -1042,6 +1046,10 @@ export default function AskChat() {
 						}
 						return updated;
 					});
+					track("question_completed", {
+						latency_ms: Math.round(performance.now() - submitTime),
+						citation_count: done.citations?.length ?? 0,
+					});
 				} else if (sseEvent.event === "error") {
 					const err = JSON.parse(sseEvent.data) as { error: string };
 					setTurns((prev) => {
@@ -1053,6 +1061,7 @@ export default function AskChat() {
 						};
 						return updated;
 					});
+					track("question_failed", { error_type: "sse_error" });
 				}
 			}
 		} catch (err) {


### PR DESCRIPTION
We currently have Umami pageview data for /pregunta (19 unique sessions over 12 days) but no way to distinguish citizens who actually submitted a question from those who landed and left. This PR instruments two custom events — and a bonus third — so we can measure real Q&A engagement and post-response abandonment.

## What's instrumented

- **`question_submitted`** — fires right before the SSE fetch starts. Payload: `{ question_length: number }`. No question content (privacy: we never send user query text to analytics).
- **`question_completed`** — fires when the `done` SSE event arrives. Payload: `{ latency_ms: number, citation_count: number }`. Lets us correlate response latency and citation depth with session drop-off.
- **`question_failed`** — fires on the `error` SSE event. Payload: `{ error_type: "sse_error" }`. Stretch goal; 1 LOC next to the existing error handler.

All three calls go through the existing `analytics.ts` `track()` helper — SSR-safe, queues events that fire before the Umami script loads (typical first-paint window), and silently no-ops if Umami is blocked by an ad blocker or fails to load. No new `any` casts; the `window.umami` type is already declared in `analytics.ts`.

## Privacy note

No PII. `question_length` is an integer. No query text, no session IDs, no user identifiers beyond what Umami's own tracker collects (already GDPR-compliant per AEPD criteria: no cookies, no fingerprinting).

## Test plan

- [ ] All 680 tests pass (verified by pre-push hook — `✔️ lint ✔️ test`)
- [ ] `bunx tsgo --noEmit` on `packages/web` — clean (verified locally)
- [ ] `bunx biome check packages/web/src/components/AskChat.tsx` — no issues
- [ ] Manual: open /pregunta, submit a question, verify `question_submitted` and `question_completed` appear in Umami's live event stream at analytics.leyabierta.es
- [ ] Manual: block Umami script via devtools network block, submit a question — confirm fetch still completes normally

Follows up on today's session log `sessions/2026-05-15-api-stability-and-rag-bottleneck.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)