### PR TITLE
feat(rag): pluggable LLM (Gemini) and rerank (Cohere) backends via OpenRouter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,3 +55,22 @@ NAN_API_KEY=
 # hit/miss distributions overlap, separation ~0.04). Used only to catch
 # catastrophic embedding failures.
 # LOW_CONFIDENCE_THRESHOLD=0.40
+
+# === Pluggable LLM / rerank backends (feature flags) ===
+#
+# LLM_BACKEND: routes query-analyzer, synthesis, post-synthesis, and
+#   background citizen-summary generation.
+#   "nan"        — default; qwen3.6 via api.nan.builders ($0, 100 RPM)
+#   "openrouter" — Gemini Flash Lite via OpenRouter (pay-per-use, ~1-3s)
+# LLM_BACKEND=nan
+#
+# RERANK_BACKEND: routes the article reranker.
+#   "qwen-llm" — default; qwen3.6 LLM rerank via NaN ($0, slower under load)
+#   "cohere-or" — Cohere Rerank via OpenRouter (pay-per-use, ~200-500ms)
+# RERANK_BACKEND=qwen-llm
+#
+# OPENROUTER_LLM_MODEL: chat model when LLM_BACKEND=openrouter
+# OPENROUTER_LLM_MODEL=google/gemini-2.5-flash-lite
+#
+# OPENROUTER_RERANK_MODEL: rerank model when RERANK_BACKEND=cohere-or
+# OPENROUTER_RERANK_MODEL=cohere/rerank-4-fast

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,13 @@ services:
     environment:
       - DB_PATH=/data/leyabierta.db
       - REPO_PATH=/data/leyes
+      # Pluggable backend feature flags (defaults = Qwen NaN — no behaviour change)
+      # Override in .env.prod to activate OpenRouter paths:
+      #   LLM_BACKEND=openrouter RERANK_BACKEND=cohere-or
+      - LLM_BACKEND=${LLM_BACKEND:-nan}
+      - RERANK_BACKEND=${RERANK_BACKEND:-qwen-llm}
+      - OPENROUTER_LLM_MODEL=${OPENROUTER_LLM_MODEL:-google/gemini-2.5-flash-lite}
+      - OPENROUTER_RERANK_MODEL=${OPENROUTER_RERANK_MODEL:-cohere/rerank-4-fast}
     labels:
       - "com.centurylinklabs.watchtower.enable=true"
     deploy:

--- a/packages/api/src/services/rag/analyzer.ts
+++ b/packages/api/src/services/rag/analyzer.ts
@@ -15,8 +15,8 @@
  */
 
 import type { Database } from "bun:sqlite";
-import { callNan } from "../nan.ts";
 import { getNanApiKey } from "../nan-api-key.ts";
+import { getLlmCaller, LLM_BACKEND } from "./backends.ts";
 import { JURISDICTION_NAMES } from "./jurisdiction.ts";
 
 /**
@@ -252,12 +252,18 @@ export async function analyzeQuery(
 	tokensIn: number;
 	tokensOut: number;
 }> {
-	const llmFn = (overrides.llmFn ?? callNan) as AnalyzerLlmFn;
+	// If the caller provided an explicit llmFn (e.g. research/ab/ harnesses),
+	// use it directly and ignore the backend env var — explicit > implicit.
+	// Otherwise, route through the backend factory (LLM_BACKEND env var).
+	const llmFn = (overrides.llmFn ?? getLlmCaller()) as AnalyzerLlmFn;
 	const model = overrides.model ?? ANALYZER_MODEL;
-	// Default path uses NaN qwen3.6 → read from getNanApiKey(). If the caller
-	// supplied a custom llmFn (e.g. research/ab/ harnesses), respect whatever
-	// key they passed.
-	const effectiveKey = overrides.llmFn ? apiKey : (getNanApiKey() ?? apiKey);
+	// For NaN backend: read from getNanApiKey(). For OpenRouter backend: the
+	// factory reads OPENROUTER_API_KEY internally — the apiKey arg is unused.
+	// For research/ab/ harnesses with a custom llmFn: respect whatever key they passed.
+	const effectiveKey =
+		overrides.llmFn || LLM_BACKEND === "openrouter"
+			? apiKey
+			: (getNanApiKey() ?? apiKey);
 	try {
 		const result = await llmFn<{
 			keywords: string[];

--- a/packages/api/src/services/rag/backends.ts
+++ b/packages/api/src/services/rag/backends.ts
@@ -1,0 +1,209 @@
+/**
+ * Pluggable LLM and rerank backend factory.
+ *
+ * Reads env-var feature flags and returns the right caller for each stage:
+ *
+ *   LLM_BACKEND=nan (default) | openrouter
+ *     Routes query-analyzer, synthesis, post-synthesis (tldr/next_questions),
+ *     background citizen-summary generation, and declined-suggestions to either
+ *     the NaN qwen3.6 stack (default, $0) or OpenRouter Gemini Flash Lite (paid,
+ *     lower-latency).
+ *
+ *   RERANK_BACKEND=qwen-llm (default) | cohere-or
+ *     Routes the reranker to either the NaN qwen3.6 LLM reranker (default) or
+ *     Cohere Rerank via OpenRouter (paid, deterministic cross-encoder).
+ *
+ *   OPENROUTER_LLM_MODEL=google/gemini-2.5-flash-lite (default for openrouter backend)
+ *     The OpenRouter chat model used when LLM_BACKEND=openrouter.
+ *
+ *   OPENROUTER_RERANK_MODEL=cohere/rerank-4-fast (default for cohere-or backend)
+ *     The OpenRouter rerank model used when RERANK_BACKEND=cohere-or.
+ *
+ * DEFAULTS: when no env vars are set, behaviour is identical to the pre-PR
+ * code — Qwen NaN everywhere. Flip env vars in .env.prod to activate new paths.
+ *
+ * Opik span names are preserved across backends:
+ *   - "query-analysis" for the analyzer
+ *   - "synthesis" for synthesis
+ *   - "rerank" for the reranker
+ *
+ * Embeddings are NOT affected by this module (qwen3-nan, untouched).
+ */
+
+import { callNan, callNanStream } from "../nan.ts";
+import { getNanApiKey } from "../nan-api-key.ts";
+import type {
+	OpenRouterOptions,
+	OpenRouterResult,
+	StreamDelta,
+	StreamDone,
+} from "../openrouter.ts";
+import { callOpenRouter, callOpenRouterStream } from "../openrouter.ts";
+import type { LLMCandidate, LLMRerankResult } from "./qwen-llm-rerank.ts";
+import { qwenLLMRerank } from "./qwen-llm-rerank.ts";
+import { CohereReranker } from "./rerankers/cohere.ts";
+
+// ── Env-var constants ──
+
+/** LLM backend: "nan" (default) or "openrouter" */
+export const LLM_BACKEND = (process.env.LLM_BACKEND ?? "nan") as
+	| "nan"
+	| "openrouter";
+
+/** Rerank backend: "qwen-llm" (default) or "cohere-or" */
+export const RERANK_BACKEND = (process.env.RERANK_BACKEND ?? "qwen-llm") as
+	| "qwen-llm"
+	| "cohere-or";
+
+/** OpenRouter chat model used when LLM_BACKEND=openrouter */
+export const OPENROUTER_LLM_MODEL =
+	process.env.OPENROUTER_LLM_MODEL ?? "google/gemini-2.5-flash-lite";
+
+/** OpenRouter rerank model used when RERANK_BACKEND=cohere-or */
+export const OPENROUTER_RERANK_MODEL =
+	process.env.OPENROUTER_RERANK_MODEL ?? "cohere/rerank-4-fast";
+
+// ── LLM caller types (mirrors AnalyzerLlmFn / SynthesisLlmFn) ──
+
+export type LlmCallerOptions = OpenRouterOptions;
+
+export type LlmCaller = <T>(
+	apiKey: string,
+	options: LlmCallerOptions,
+) => Promise<OpenRouterResult<T>>;
+
+export type LlmStreamCaller = (
+	apiKey: string,
+	options: Omit<LlmCallerOptions, "jsonResponse" | "jsonSchema">,
+) => AsyncGenerator<StreamDelta | StreamDone>;
+
+// ── Rerank caller type ──
+
+export type RerankCaller = (
+	query: string,
+	candidates: LLMCandidate[],
+	topK: number,
+) => Promise<{ results: LLMRerankResult[]; backend: string; cost: number }>;
+
+// ── Factory functions ──
+
+/**
+ * Returns the non-streaming LLM caller based on LLM_BACKEND env var.
+ *
+ * When LLM_BACKEND=nan (default): uses callNan with qwen3.6 at api.nan.builders.
+ * When LLM_BACKEND=openrouter: uses callOpenRouter with OPENROUTER_LLM_MODEL.
+ *
+ * The returned caller respects the model override from the options parameter —
+ * for NaN, it passes through as-is; for OpenRouter, it overrides with
+ * OPENROUTER_LLM_MODEL unless the caller explicitly set one.
+ */
+export function getLlmCaller(): LlmCaller {
+	if (LLM_BACKEND === "openrouter") {
+		return openRouterLlmCaller;
+	}
+	// Default: NaN (callNan already handles retries, backoff, and json parsing)
+	return callNan as LlmCaller;
+}
+
+/**
+ * Returns the streaming LLM caller based on LLM_BACKEND env var.
+ *
+ * When LLM_BACKEND=nan (default): uses callNanStream.
+ * When LLM_BACKEND=openrouter: uses callOpenRouterStream with OPENROUTER_LLM_MODEL.
+ */
+export function getLlmStreamCaller(): LlmStreamCaller {
+	if (LLM_BACKEND === "openrouter") {
+		return openRouterStreamCaller;
+	}
+	// Default: NaN streaming
+	return callNanStream as LlmStreamCaller;
+}
+
+/**
+ * Returns the rerank caller based on RERANK_BACKEND env var.
+ *
+ * When RERANK_BACKEND=qwen-llm (default): uses qwenLLMRerank via NaN.
+ * When RERANK_BACKEND=cohere-or: uses CohereReranker via OpenRouter with
+ *   OPENROUTER_RERANK_MODEL (default: cohere/rerank-4-fast).
+ *
+ * The returned function has the same signature as qwenLLMRerank so it drops
+ * straight into reranker.ts without changes at the call site.
+ */
+export function getRerankCaller(nanApiKey?: string): RerankCaller {
+	if (RERANK_BACKEND === "cohere-or") {
+		const orKey = process.env.OPENROUTER_API_KEY ?? "";
+		if (!orKey) {
+			console.warn(
+				"[backends] RERANK_BACKEND=cohere-or but OPENROUTER_API_KEY is not set — falling back to qwen-llm rerank",
+			);
+			// Graceful degradation: fall back to qwen-llm so prod doesn't explode if
+			// the env var is missing after a partial deploy.
+			return makeQwenRerankCaller(nanApiKey);
+		}
+		return makeCohereOrRerankCaller(orKey);
+	}
+	// Default: qwen-llm rerank via NaN
+	return makeQwenRerankCaller(nanApiKey);
+}
+
+// ── Private helpers ──
+
+/**
+ * OpenRouter non-streaming caller. Overrides the model to OPENROUTER_LLM_MODEL
+ * while preserving all other options (prompts, temperature, jsonSchema, etc.)
+ * from the call site. The `apiKey` parameter is used only as a last-resort
+ * fallback; OPENROUTER_API_KEY takes precedence.
+ */
+async function openRouterLlmCaller<T>(
+	_apiKey: string,
+	options: LlmCallerOptions,
+): Promise<OpenRouterResult<T>> {
+	const orKey = process.env.OPENROUTER_API_KEY ?? _apiKey;
+	return callOpenRouter<T>(orKey, {
+		...options,
+		model: OPENROUTER_LLM_MODEL,
+	});
+}
+
+/**
+ * OpenRouter streaming caller. Same model override as above, SSE-streamed.
+ */
+async function* openRouterStreamCaller(
+	_apiKey: string,
+	options: Omit<LlmCallerOptions, "jsonResponse" | "jsonSchema">,
+): AsyncGenerator<StreamDelta | StreamDone> {
+	const orKey = process.env.OPENROUTER_API_KEY ?? _apiKey;
+	yield* callOpenRouterStream(orKey, {
+		...options,
+		model: OPENROUTER_LLM_MODEL,
+	});
+}
+
+/** Build a rerank caller that delegates to qwenLLMRerank via NaN. */
+function makeQwenRerankCaller(nanApiKey?: string): RerankCaller {
+	return async (query, candidates, topK) => {
+		const key = nanApiKey ?? getNanApiKey() ?? "";
+		return qwenLLMRerank(key, query, candidates, topK);
+	};
+}
+
+/** Build a rerank caller that delegates to CohereReranker via OpenRouter. */
+function makeCohereOrRerankCaller(orKey: string): RerankCaller {
+	// CohereReranker is a class — instantiate once and reuse. The constructor
+	// picks the backend from its arguments; we force openrouter path by only
+	// providing the openrouterApiKey.
+	const reranker = new CohereReranker({ openrouterApiKey: orKey });
+	return async (query, candidates, topK) => {
+		const result = await reranker.rerank(query, candidates, topK);
+		// Return shape matches LLMRerankResult[]
+		return {
+			results: result.results.map((r) => ({
+				key: r.key,
+				relevanceScore: r.relevanceScore,
+				rank: r.rank,
+			})),
+			backend: result.backend,
+			cost: result.cost,
+		};
+	};
+}

--- a/packages/api/src/services/rag/reranker.ts
+++ b/packages/api/src/services/rag/reranker.ts
@@ -1,12 +1,19 @@
 /**
  * Reranker — rescores candidate articles by relevance to the query.
  *
- * Backend: qwen3.6 LLM rerank via NaN. Phase 5 A/B showed +18 pp R@1
- * over cohere/rerank-4-pro on this Spanish-legal corpus, with $0 cost.
+ * Default backend: qwen3.6 LLM rerank via NaN (Phase 5 A/B: +18 pp R@1
+ * over cohere/rerank-4-pro on this Spanish-legal corpus, with $0 cost).
+ *
+ * Optional backend: Cohere Rerank via OpenRouter. Activate by setting
+ * RERANK_BACKEND=cohere-or in .env.prod. Zero-risk: revert by unsetting.
+ *
+ * Backend routing is delegated to `backends.ts` via `getRerankCaller()`.
+ * Opik span name "rerank" is emitted regardless of backend by the caller
+ * in retrieval.ts — this file does NOT emit spans directly.
  */
 
 import { getNanApiKey } from "../nan-api-key.ts";
-import { qwenLLMRerank } from "./qwen-llm-rerank.ts";
+import { getRerankCaller, RERANK_BACKEND } from "./backends.ts";
 
 export interface RerankerCandidate {
 	key: string; // "normId:blockId"
@@ -26,7 +33,8 @@ interface RerankerConfig {
 
 /**
  * Rerank candidates by relevance to the query.
- * Picks the best available backend automatically.
+ * Routes to the backend selected by the RERANK_BACKEND env var
+ * (default: "qwen-llm" — qwen3.6 via NaN; alternative: "cohere-or").
  *
  * @param query - The user's question
  * @param candidates - Articles to rerank (already retrieved)
@@ -57,32 +65,27 @@ export async function rerank(
 		};
 	}
 
-	// Default: qwen3.6 LLM rerank via NaN. Resolve via getNanApiKey() when the
-	// caller didn't pass one — same pattern as embeddings/analyzer.
+	// For cohere-or backend: OPENROUTER_API_KEY is read inside getRerankCaller().
+	// For qwen-llm backend: nanKey is passed to the qwenLLMRerank call.
 	const nanKey = config.nanApiKey ?? getNanApiKey();
-	if (nanKey) {
-		return rerankWithNanLLM(query, candidates, topK, nanKey);
+
+	// getRerankCaller() is safe to call per-request — it resolves env vars once
+	// at first call but the cost is negligible (object creation, no I/O).
+	const caller = getRerankCaller(nanKey ?? undefined);
+
+	// If on default qwen-llm backend and no NaN key, fall back to passthrough
+	// (preserves pre-PR behaviour when NAN_API_KEY is unset).
+	if (RERANK_BACKEND === "qwen-llm" && !nanKey) {
+		return {
+			results: candidates.slice(0, topK).map((c, i) => ({
+				key: c.key,
+				relevanceScore: 1 - i * 0.01,
+				rank: i + 1,
+			})),
+			backend: "none",
+			cost: 0,
+		};
 	}
 
-	// No key → passthrough (preserves order from RRF).
-	return {
-		results: candidates.slice(0, topK).map((c, i) => ({
-			key: c.key,
-			relevanceScore: 1 - i * 0.01,
-			rank: i + 1,
-		})),
-		backend: "none",
-		cost: 0,
-	};
-}
-
-// ── NaN qwen3.6 LLM rerank (Phase 5 default) ──
-
-async function rerankWithNanLLM(
-	query: string,
-	candidates: RerankerCandidate[],
-	topK: number,
-	nanApiKey: string,
-): Promise<{ results: RerankerResult[]; backend: string; cost: number }> {
-	return qwenLLMRerank(nanApiKey, query, candidates, topK);
+	return caller(query, candidates, topK);
 }

--- a/packages/api/src/services/rag/rerankers/cohere.ts
+++ b/packages/api/src/services/rag/rerankers/cohere.ts
@@ -1,12 +1,11 @@
 /**
- * Cohere Rerank 4 Pro — pluggable reranker for A/B evaluation.
- *
- * This is the pre-Phase-6 production reranker, resurrected as an opt-in module
- * for A/B comparison against the Qwen NaN LLM reranker. It is NOT used in prod.
+ * Cohere Rerank — pluggable reranker for A/B evaluation and production use.
  *
  * Backend selection (in order of preference):
  *   1. Direct Cohere API (COHERE_API_KEY) — cheaper, lower latency.
- *   2. OpenRouter proxy (OPENROUTER_API_KEY) — via cohere/rerank-4-pro model.
+ *   2. OpenRouter proxy (OPENROUTER_API_KEY) — via configurable model
+ *      (default: cohere/rerank-4-fast, override via OPENROUTER_RERANK_MODEL or
+ *      the `openrouterModel` constructor option).
  *
  * If neither key is set, construction throws a clear error rather than silently
  * falling back to passthrough — the caller must make an explicit choice.
@@ -14,15 +13,18 @@
  * Interface mirrors the qwenLLMRerank return shape so it can be swapped into
  * the `rerankerOverrides` slot of `runRetrievalCore` without changes.
  *
- * Usage (in rag-gemini-legacy.ts):
+ * Production use (via backends.ts): set RERANK_BACKEND=cohere-or in .env.prod.
+ * A/B research use (legacy): instantiate directly as before.
+ *
  *   const reranker = new CohereReranker();
  *   const { results } = await reranker.rerank(query, candidates, topK);
  */
 
 const COHERE_RERANK_URL = "https://api.cohere.com/v2/rerank";
-const COHERE_RERANK_MODEL = "rerank-v3.5"; // latest as of Phase 6 cutoff
+const COHERE_RERANK_MODEL_DEFAULT = "rerank-v3.5"; // latest as of Phase 6 cutoff
 const OPENROUTER_RERANK_URL = "https://openrouter.ai/api/v1/rerank";
-const OPENROUTER_RERANK_MODEL = "cohere/rerank-4-pro";
+/** Default OpenRouter rerank model — cohere/rerank-4-fast is the fast, cost-efficient variant. */
+const OPENROUTER_RERANK_MODEL_DEFAULT = "cohere/rerank-4-fast";
 
 export interface CohereCandidate {
 	key: string; // "normId:blockId"
@@ -41,10 +43,14 @@ export type CohereBackend = "cohere-direct" | "cohere-openrouter";
 export class CohereReranker {
 	private readonly _apiKey: string;
 	private readonly _backend: CohereBackend;
+	private readonly _cohereModel: string;
+	private readonly _openrouterModel: string;
 
 	/**
-	 * @param cohereApiKey   - Direct Cohere API key (preferred). Falls back to openrouterApiKey.
-	 * @param openrouterApiKey - OpenRouter API key (via cohere/rerank-4-pro). Used if cohereApiKey is absent.
+	 * @param cohereApiKey      - Direct Cohere API key (preferred). Falls back to openrouterApiKey.
+	 * @param openrouterApiKey  - OpenRouter API key. Used if cohereApiKey is absent.
+	 * @param cohereModel       - Direct Cohere model (default: rerank-v3.5).
+	 * @param openrouterModel   - OpenRouter rerank model (default: OPENROUTER_RERANK_MODEL env or cohere/rerank-4-fast).
 	 *
 	 * Throws at construction time if neither key is provided.
 	 */
@@ -52,6 +58,8 @@ export class CohereReranker {
 		opts: {
 			cohereApiKey?: string;
 			openrouterApiKey?: string;
+			cohereModel?: string;
+			openrouterModel?: string;
 		} = {},
 	) {
 		const cohereKey = opts.cohereApiKey ?? process.env.COHERE_API_KEY ?? "";
@@ -66,9 +74,15 @@ export class CohereReranker {
 		} else {
 			throw new Error(
 				"CohereReranker: neither COHERE_API_KEY nor OPENROUTER_API_KEY is set. " +
-					"Set one of them to use the Gemini legacy retriever.",
+					"Set one of them to use the Cohere reranker.",
 			);
 		}
+
+		this._cohereModel = opts.cohereModel ?? COHERE_RERANK_MODEL_DEFAULT;
+		this._openrouterModel =
+			opts.openrouterModel ??
+			process.env.OPENROUTER_RERANK_MODEL ??
+			OPENROUTER_RERANK_MODEL_DEFAULT;
 	}
 
 	get backend(): CohereBackend {
@@ -125,7 +139,7 @@ export class CohereReranker {
 					"Content-Type": "application/json",
 				},
 				body: JSON.stringify({
-					model: COHERE_RERANK_MODEL,
+					model: this._cohereModel,
 					query,
 					documents,
 					top_n: topK,
@@ -187,7 +201,7 @@ export class CohereReranker {
 					"X-Title": "Ley Abierta RAG (A/B eval)",
 				},
 				body: JSON.stringify({
-					model: OPENROUTER_RERANK_MODEL,
+					model: this._openrouterModel,
 					query,
 					documents,
 					top_n: topK,

--- a/packages/api/src/services/rag/synthesis.ts
+++ b/packages/api/src/services/rag/synthesis.ts
@@ -12,7 +12,6 @@
  */
 
 import type { Database } from "bun:sqlite";
-import { callNan, callNanStream } from "../nan.ts";
 import { getNanApiKey } from "../nan-api-key.ts";
 import {
 	describeNormScope,
@@ -21,6 +20,7 @@ import {
 	numbersToDigits,
 } from "./analyzer.ts";
 import { buildArticleAnchor } from "./anchor.ts";
+import { getLlmCaller, getLlmStreamCaller, LLM_BACKEND } from "./backends.ts";
 import { resolveJurisdiction } from "./jurisdiction.ts";
 import type { RetrievedArticle } from "./retrieval.ts";
 import { parseSubchunkId } from "./subchunk.ts";
@@ -259,11 +259,16 @@ export async function synthesizeAnswer(opts: {
 	llmFn?: SynthesisLlmFn;
 }): Promise<SynthesisResult> {
 	const { question, evidenceText, systemPrompt } = opts;
-	const llmFn = (opts.llmFn ?? callNan) as SynthesisLlmFn;
+	// If the caller provided an explicit llmFn (research/ab/ harnesses), use it
+	// directly. Otherwise route through the backend factory (LLM_BACKEND env var).
+	const llmFn = (opts.llmFn ?? getLlmCaller()) as SynthesisLlmFn;
 	const model = opts.model ?? SYNTHESIS_MODEL;
-	// NaN models read NAN_API_KEY (legacy HERMES_API_KEY fallback); pass it (or whatever the caller gave) to
-	// the llmFn. The prod caller's `apiKey` is used as a fallback when NAN_API_KEY is unset.
-	const apiKey = getNanApiKey() ?? opts.apiKey;
+	// For NaN backend: use getNanApiKey(). For OpenRouter backend: the factory
+	// reads OPENROUTER_API_KEY internally — apiKey arg is passed but unused.
+	const apiKey =
+		opts.llmFn || LLM_BACKEND === "openrouter"
+			? opts.apiKey
+			: (getNanApiKey() ?? opts.apiKey);
 	const result = await llmFn<{
 		answer: string;
 		citations: Array<{ norm_id: string; article_title: string }>;
@@ -339,8 +344,14 @@ export function synthesizeStream(opts: {
 	systemPrompt: string;
 }) {
 	const { question, evidenceText, systemPrompt } = opts;
-	const apiKey = getNanApiKey() ?? opts.apiKey;
-	return callNanStream(apiKey, {
+	// For NaN backend: use getNanApiKey(). For OpenRouter backend: the stream
+	// caller reads OPENROUTER_API_KEY internally.
+	const apiKey =
+		LLM_BACKEND === "openrouter"
+			? opts.apiKey
+			: (getNanApiKey() ?? opts.apiKey);
+	const streamCaller = getLlmStreamCaller();
+	return streamCaller(apiKey, {
 		model: SYNTHESIS_MODEL,
 		messages: [
 			{ role: "system", content: systemPrompt },
@@ -429,7 +440,11 @@ export function generateMissingSummaries(opts: {
 	insertSummaryStmt: ReturnType<Database["prepare"]>;
 }) {
 	const { citations, articles, insertSummaryStmt } = opts;
-	const apiKey = getNanApiKey() ?? opts.apiKey;
+	const apiKey =
+		LLM_BACKEND === "openrouter"
+			? opts.apiKey
+			: (getNanApiKey() ?? opts.apiKey);
+	const llmCaller = getLlmCaller();
 	const missing = citations.filter((c) => !c.citizenSummary);
 	if (missing.length === 0) return;
 
@@ -442,7 +457,7 @@ export function generateMissingSummaries(opts: {
 
 		const truncatedText = article.text.slice(0, 1500);
 
-		callNan<{ summary: string }>(apiKey, {
+		llmCaller<{ summary: string }>(apiKey, {
 			model: SYNTHESIS_MODEL,
 			messages: [
 				{
@@ -502,9 +517,13 @@ export async function generatePostSynthExtras(opts: {
 	answer: string;
 }): Promise<{ tldr: string; nextQuestions: string[] }> {
 	const { question, answer } = opts;
-	const apiKey = getNanApiKey() ?? opts.apiKey;
+	const apiKey =
+		LLM_BACKEND === "openrouter"
+			? opts.apiKey
+			: (getNanApiKey() ?? opts.apiKey);
+	const llmCaller = getLlmCaller();
 	try {
-		const result = await callNan<{
+		const result = await llmCaller<{
 			tldr: string;
 			next_questions: string[];
 		}>(apiKey, {
@@ -563,9 +582,13 @@ export async function generateDeclinedSuggestions(opts: {
 	question: string;
 }): Promise<string[]> {
 	const { question } = opts;
-	const apiKey = getNanApiKey() ?? opts.apiKey;
+	const apiKey =
+		LLM_BACKEND === "openrouter"
+			? opts.apiKey
+			: (getNanApiKey() ?? opts.apiKey);
+	const llmCaller = getLlmCaller();
 	try {
-		const result = await callNan<{ suggested_questions: string[] }>(apiKey, {
+		const result = await llmCaller<{ suggested_questions: string[] }>(apiKey, {
 			model: SYNTHESIS_MODEL,
 			messages: [
 				{


### PR DESCRIPTION
## Context

This PR was produced during the 2026-05-15 API stability & RAG bottleneck session. Opik data shows Qwen NaN exhibits congestion windows under load (rerank up to 65s, synthesis up to 38s vs p50 of 1.65s / 3.7s). The fix is to make the LLM and rerank stages pluggable behind env-var feature flags so we can flip to OpenRouter (Cohere Rerank 4 Fast + Gemini 2.5 Flash Lite) in prod with zero code changes and instant rollback.

Session log: `sessions/2026-05-15-api-stability-and-rag-bottleneck.md`

## Architecture

| Stage | Default backend (no env overrides) | Optional backend |
|-------|------------------------------------|-----------------|
| Embeddings | `qwen3-embedding` via NaN | **UNCHANGED** |
| Query analyzer | `qwen3.6` via NaN | `google/gemini-2.5-flash-lite` via OpenRouter |
| Rerank | `qwen3.6` LLM rerank via NaN | `cohere/rerank-4-fast` via OpenRouter |
| Synthesis | `qwen3.6` via NaN | `google/gemini-2.5-flash-lite` via OpenRouter |
| TLDR + next questions | `qwen3.6` via NaN | `google/gemini-2.5-flash-lite` via OpenRouter |

**Defaults must not and do not change behaviour.** Merging without env overrides is a no-op.

## Env var reference

| Var | Default | Purpose |
|-----|---------|---------|
| `LLM_BACKEND` | `nan` | `nan` or `openrouter` — routes analyzer, synthesis, post-synthesis, declined-suggestions, background citizen-summary backfill |
| `RERANK_BACKEND` | `qwen-llm` | `qwen-llm` or `cohere-or` — routes the article reranker |
| `OPENROUTER_LLM_MODEL` | `google/gemini-2.5-flash-lite` | Chat model used when `LLM_BACKEND=openrouter` |
| `OPENROUTER_RERANK_MODEL` | `cohere/rerank-4-fast` | Rerank model used when `RERANK_BACKEND=cohere-or` |
| `OPENROUTER_API_KEY` | — | Required when using either openrouter backend; already in `.env.prod` for reform-summary generation |

## Changes

- **New:** `packages/api/src/services/rag/backends.ts` — factory module with `getLlmCaller()`, `getLlmStreamCaller()`, `getRerankCaller()`. Reads env vars, returns the right callable. Graceful degradation: if `RERANK_BACKEND=cohere-or` but `OPENROUTER_API_KEY` is missing, logs a warning and falls back to `qwen-llm`.
- **Updated:** `analyzer.ts` — `analyzeQuery` routes through `getLlmCaller()`. Explicit `llmFn` overrides from `research/ab/` harnesses still respected (explicit > implicit).
- **Updated:** `synthesis.ts` — `synthesizeAnswer`, `synthesizeStream`, `generatePostSynthExtras`, `generateDeclinedSuggestions`, `generateMissingSummaries` all route through `getLlmCaller()` / `getLlmStreamCaller()`.
- **Updated:** `reranker.ts` — `rerank()` delegates to `getRerankCaller()`.
- **Updated:** `rerankers/cohere.ts` — `CohereReranker` now accepts `cohereModel` / `openrouterModel` constructor args; reads `OPENROUTER_RERANK_MODEL` env; default OR model changed from `cohere/rerank-4-pro` to `cohere/rerank-4-fast` (faster, cheaper for production use).
- **Updated:** `.env.example` — documents all four new vars with defaults and usage notes.
- **Updated:** `docker-compose.yml` — passes all four env vars through with shell defaults.

## LLM call sites found (investigation phase)

| File | Line | Call | Stage |
|------|------|------|-------|
| `analyzer.ts` | 255 | `callNan` (via `llmFn ?? getLlmCaller()`) | Query analysis |
| `synthesis.ts` | 262 | `callNan` (via `getLlmCaller()`) | Synthesis (non-streaming) |
| `synthesis.ts` | 343 | `callNanStream` (via `getLlmStreamCaller()`) | Synthesis (streaming) |
| `synthesis.ts` | 507 | `callNan` (via `getLlmCaller()`) | Post-synthesis (TLDR + next_questions) |
| `synthesis.ts` | 461 | `callNan` (via `getLlmCaller()`) | Background citizen-summary backfill |
| `synthesis.ts` | 568 | `callNan` (via `getLlmCaller()`) | Declined-query suggestions |
| `reranker.ts` | 87 | `qwenLLMRerank` → now `getRerankCaller()` | Rerank |

## Test plan

1. Merge to main (zero env override = no-op, all 682 tests pass).
2. On the server, add to `.env.prod`:
   ```
   LLM_BACKEND=openrouter
   RERANK_BACKEND=cohere-or
   ```
   (`OPENROUTER_API_KEY` is already set for reform-summary generation.)
3. Restart the container: `docker compose up -d api`
4. Run 3 `/v1/ask` queries via curl or the web UI.
5. In Opik (`leyabierta-rag` project), verify:
   - Span names are unchanged: `query-analysis`, `synthesis`, `rerank`
   - Model metadata in spans shows `google/gemini-2.5-flash-lite` / `cohere/rerank-4-fast`
   - Per-stage latencies: analyzer <1s, rerank <500ms, synthesis 3-5s with first token ~2s
   - Total `/v1/ask` latency drops from 25-100s range to ~10-15s consistently
6. RSS probe (`{"probe":"mem",...}`) stays stable — no OOM risk from new paths.
7. If anything regresses, flip env vars back (no deploy needed, just restart):
   ```
   # Remove or comment out LLM_BACKEND and RERANK_BACKEND in .env.prod
   docker compose up -d api
   ```

## Out of scope

- Embeddings (qwen3-nan, untouched — `embeddings.ts`, `vectorSearchPooled`, `vectors.bin`)
- BM25 / FTS (`bm25-dispatch.ts`, `blocks-fts.ts`)
- Opik span shape (span names unchanged across all backends)
- Frontend (`/v1/ask/stream` SSE contract unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)