### PR TITLE
fix(seo-loop): sourcear .env.seo antes de resolver SEO_REPO/MODEL

### DIFF
--- a/scripts/seo/seo-loop.sh
+++ b/scripts/seo/seo-loop.sh
@@ -10,7 +10,8 @@
 # Env (from ${SEO_ENV_FILE:-/opt/leyabierta/.env.seo}, mode 600):
 #   SEO_GSC_SA_JSON      path to the GSC service-account key JSON
 #   NAN_API_KEY          for nan:* models (the valid token, ending pcNg)
-#   GH_TOKEN             token for `gh pr create` on leyabierta/leyabierta
+#   GH_TOKEN             PAT for git push + PR REST API on leyabierta/leyabierta
+#                        (scopes: contents write + pull-requests write)
 #   claude auth          CLAUDE_CODE_OAUTH_TOKEN (or a prior `claude` login) for
 #                        claude:* models and the implement step
 # Optional:
@@ -124,9 +125,26 @@ if [ "${SEO_DRY_RUN:-0}" = "1" ]; then
 	echo "DRY RUN — would push $BRANCH and open a PR. Diff:"
 	git --no-pager diff --stat origin/main
 else
-	git push -q -u origin "$BRANCH"
-	gh pr create --repo leyabierta/leyabierta --base main --head "$BRANCH" \
-		--title "SEO loop · iter ${ITER} (${DATE})" --body "$PR_BODY"
+	if [ -z "${GH_TOKEN:-}" ]; then
+		echo "ERROR: GH_TOKEN not set in $ENV_FILE — cannot push or open a PR." >&2
+		exit 1
+	fi
+	# Push with the token via an inline credential helper. Single-quoted so
+	# $GH_TOKEN is expanded when git runs the helper (from the environment),
+	# never embedded in argv/ps. Same pattern as daily-pipeline.sh.
+	git -c 'credential.helper=!f() { echo username=x-access-token; echo "password=$GH_TOKEN"; }; f' \
+		push -q -u origin "$BRANCH"
+	# Open the PR via the GitHub REST API — no `gh` dependency on the host.
+	PR_JSON="$(python3 -c 'import json,sys; print(json.dumps({"title":sys.argv[1],"head":sys.argv[2],"base":"main","body":sys.argv[3]}))' \
+		"SEO loop · iter ${ITER} (${DATE})" "$BRANCH" "$PR_BODY")"
+	PR_URL="$(curl -fsS -X POST \
+		-H "Authorization: Bearer ${GH_TOKEN}" \
+		-H "Accept: application/vnd.github+json" \
+		https://api.github.com/repos/leyabierta/leyabierta/pulls \
+		-d "$PR_JSON" 2>/dev/null \
+		| python3 -c 'import json,sys; print(json.load(sys.stdin).get("html_url","(no url in response)"))' 2>/dev/null \
+		|| echo "(PR creation failed — check GH_TOKEN scopes: contents+pull-requests write)")"
+	echo "PR: $PR_URL"
 fi
 
 # ── 6. Persist bitácora + counter ───────────────────────────────────────────

--- a/scripts/seo/seo-loop.sh
+++ b/scripts/seo/seo-loop.sh
@@ -22,9 +22,18 @@
 
 set -euo pipefail
 
+# ── Config from the env file FIRST ──────────────────────────────────────────
+# The env file may set SEO_REPO / SEO_MODEL / SEO_STATE_DIR / PATH, so it must
+# be sourced before those defaults are resolved (sourcing it later left REPO
+# pinned to the wrong default and the loop wrote to the prod checkout).
+ENV_FILE="${SEO_ENV_FILE:-/opt/leyabierta/.env.seo}"
+if [ -f "$ENV_FILE" ]; then
+	set -a; # shellcheck disable=SC1090
+	source "$ENV_FILE"; set +a
+fi
+
 REPO="${SEO_REPO:-/opt/leyabierta/code}"
 MODEL="${SEO_MODEL:-claude:sonnet}"
-ENV_FILE="${SEO_ENV_FILE:-/opt/leyabierta/.env.seo}"
 STATE_DIR="${SEO_STATE_DIR:-/opt/leyabierta/seo-state}"
 DATE="$(date +%F)"
 
@@ -33,12 +42,6 @@ cd "$REPO"
 # ── Single-instance lock ────────────────────────────────────────────────────
 exec 9>"/var/lock/leyabierta-seo-loop.lock" || exec 9>"/tmp/leyabierta-seo-loop.lock"
 flock -n 9 || { echo "another seo-loop is already running"; exit 0; }
-
-# ── Secrets ─────────────────────────────────────────────────────────────────
-if [ -f "$ENV_FILE" ]; then
-	set -a; # shellcheck disable=SC1090
-	source "$ENV_FILE"; set +a
-fi
 
 mkdir -p "$STATE_DIR"
 IT_FILE="$STATE_DIR/iteration"


### PR DESCRIPTION
Bug: `seo-loop.sh` resolvía `REPO="${SEO_REPO:-/opt/leyabierta/code}"` (y MODEL/STATE_DIR) **antes** de sourcear `.env.seo`, así que `SEO_REPO`/`SEO_MODEL`/`SEO_STATE_DIR` del env file se ignoraban → el loop correría en el checkout de producción (permiso denegado) en vez de su clon dedicado. Fix: sourcear el env file primero (también trae el PATH del claude CLI), luego resolver defaults. Detectado montando el dry-run en KonarServer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)