### PR TITLE
fix(seo-loop): verify correcto + árbol pristine por run

### DIFF
--- a/scripts/seo/seo-loop.sh
+++ b/scripts/seo/seo-loop.sh
@@ -65,6 +65,11 @@ echo "== SEO loop · iter ${ITER} · ${DATE} · model=${MODEL} =="
 # ── Fresh branch off main ───────────────────────────────────────────────────
 git fetch --quiet origin main
 git checkout -q -B "$BRANCH" origin/main
+# Start from a pristine tree: discard leftovers from a previous aborted run (the
+# implement step edits the working tree before we commit). `git clean` without
+# -x leaves gitignored data/ + node_modules untouched.
+git reset -q --hard origin/main
+git clean -fdq
 
 # ── 1. Snapshots ────────────────────────────────────────────────────────────
 bun run scripts/seo/pull-gsc.ts
@@ -102,11 +107,16 @@ else
 fi
 
 # ── 4. Verify ───────────────────────────────────────────────────────────────
+# Match how the repo actually gates (there is NO tsgo/tsc/astro-check step in
+# CI): biome here for a fast local check, and the full astro build as the real
+# type+build gate. The build runs on the PR via pr-checks.yml (push to
+# seo-loop/**); locally it is opt-in (SEO_RUN_BUILD=1) because the 12k-page
+# build is slow and needs the leyes content.
+# NOTE: `bunx tsgo --noEmit` from the repo root does NOT work for the Astro web
+# package (it needs `astro sync`-generated types + the web tsconfig's DOM lib)
+# and floods hundreds of false errors, so it is deliberately not used here.
 echo "verifying…"
-bunx tsgo --noEmit
 bun run check
-# The full 12k-page astro build is the PR's CI gate. Running it here is opt-in
-# (it needs API access + is slow); tsgo + biome catch most breakage pre-PR.
 if [ "${SEO_RUN_BUILD:-0}" = "1" ]; then
 	bun run --cwd packages/web astro build
 fi


### PR DESCRIPTION
El paso de verify corría `bunx tsgo --noEmit` desde la raíz, que inunda de **errores falsos** al paquete Astro (falta `astro sync` → `astro:content`, y sin lib DOM porque tsgo en raíz ignora el tsconfig del web). Con `set -e` eso **abortaba cada run antes del commit/push** — el loop nunca abría PR.

El repo no tiene tsgo/tsc/astro-check en CI; sus gates reales son biome + astro build + smoke (`pr-checks.yml`). Se alinea el loop: fuera tsgo, biome como check local rápido, y el build como gate (en el PR vía el trigger push de pr-checks, o `SEO_RUN_BUILD=1` local).

Además `reset --hard` + `git clean` al inicio de cada run para que restos de una iteración abortada (el implement edita el árbol antes del commit) no se acumulen. `git clean` sin `-x` deja intactos `data/` y `node_modules` (gitignored).

Detectado en la primera iteración supervisada real (2026-07-21).

🤖 Generated with [Claude Code](https://claude.com/claude-code)