### PR TITLE
fix(seo-loop): no instruir tsgo/build al implementer

### DIFF
--- a/.goals/seo/PLAYBOOK.md
+++ b/.goals/seo/PLAYBOOK.md
@@ -57,11 +57,17 @@ fines:
 
 1. `claude -p` recibe el plan JSON ganador y este playbook.
 2. Aplica SOLO las acciones dentro de la whitelist.
-3. Verifica: `bunx tsgo --noEmit` && `bun run check` && `bun run build`.
+3. Verifica: `bun run check` (biome). El build (`astro build`) es el gate real y
+   corre en CI sobre el PR (`pr-checks.yml`), o localmente con `SEO_RUN_BUILD=1`.
+   NO uses `tsgo`/`tsc`: no está configurado para el paquete Astro y escupe
+   cientos de errores falsos preexistentes.
 4. Si algo falla → revierte los cambios de esa acción y sigue con las demás.
    Si todo falla → aborta sin abrir PR y registra el fallo en PROGRESS.
-5. Commit en la rama `seo-loop/iter-<N>-<fecha>`, push, `gh pr create`.
-6. El PR pasa por `claude-code-review.yml` + lint/test. Un humano mergea.
+5. Commit en la rama `seo-loop/iter-<N>-<fecha>`, push por deploy key. La Action
+   `seo-open-pr.yml` abre el PR (el host no tiene token de API de GitHub).
+6. El PR pasa por `pr-checks.yml` (build+smoke, vía trigger push). Un humano
+   revisa y mergea. `claude-code-review.yml` es `pull_request`-only y no
+   auto-corre en PRs del bot.
 
 ## Escalar a humano (NO auto-decidir)
 

--- a/scripts/seo/seo-loop.sh
+++ b/scripts/seo/seo-loop.sh
@@ -92,8 +92,9 @@ ${PLAN_FILE}. Hard rules:
 - SKIP any action with requiresHumanReview=true, and any action touching a
   blacklisted path — note it in the summary instead.
 - Keep legal accuracy sacred: never misrepresent a norm to rank.
-- After editing, ensure: bunx tsgo --noEmit && bun run check pass. If a change
-  breaks them, revert just that change.
+- After editing, ensure \`bun run check\` (biome) passes. If a change breaks it,
+  revert just that change. Do NOT run tsgo/tsc: it is not configured for the
+  Astro web package and floods hundreds of pre-existing false errors — ignore it.
 - Do NOT git push, do NOT open PRs, do NOT touch main.
 - Write a short summary of what you applied/skipped to ${SEO_DATA_DIR}/impl-${DATE}.md.
 EOF

--- a/scripts/seo/seo-loop.sh
+++ b/scripts/seo/seo-loop.sh
@@ -65,6 +65,11 @@ echo "== SEO loop · iter ${ITER} · ${DATE} · model=${MODEL} =="
 # ── Fresh branch off main ───────────────────────────────────────────────────
 git fetch --quiet origin main
 git checkout -q -B "$BRANCH" origin/main
+# Start from a pristine tree: discard leftovers from a previous aborted run (the
+# implement step edits the working tree before we commit). `git clean` without
+# -x leaves gitignored data/ + node_modules untouched.
+git reset -q --hard origin/main
+git clean -fdq
 
 # ── 1. Snapshots ────────────────────────────────────────────────────────────
 bun run scripts/seo/pull-gsc.ts
@@ -102,11 +107,16 @@ else
 fi
 
 # ── 4. Verify ───────────────────────────────────────────────────────────────
+# Match how the repo actually gates (there is NO tsgo/tsc/astro-check step in
+# CI): biome here for a fast local check, and the full astro build as the real
+# type+build gate. The build runs on the PR via pr-checks.yml (push to
+# seo-loop/**); locally it is opt-in (SEO_RUN_BUILD=1) because the 12k-page
+# build is slow and needs the leyes content.
+# NOTE: `bunx tsgo --noEmit` from the repo root does NOT work for the Astro web
+# package (it needs `astro sync`-generated types + the web tsconfig's DOM lib)
+# and floods hundreds of false errors, so it is deliberately not used here.
 echo "verifying…"
-bunx tsgo --noEmit
 bun run check
-# The full 12k-page astro build is the PR's CI gate. Running it here is opt-in
-# (it needs API access + is slow); tsgo + biome catch most breakage pre-PR.
 if [ "${SEO_RUN_BUILD:-0}" = "1" ]; then
 	bun run --cwd packages/web astro build
 fi


### PR DESCRIPTION
#113 arregló el verify del script, pero el prompt del implement y el PLAYBOOK seguían diciendo a claude que corriera `bunx tsgo --noEmit` (y `bun run build`). Como tsgo en raíz escupe errores falsos del paquete Astro, un implementer que siga "revierte lo que rompe el check" podría revertir sus propios cambios buenos → PR vacío. Se apunta ambos a biome; el build es cosa de CI. Detectado en la 1ª iteración supervisada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)