### PR TITLE
Reformas SSR indexables (recuperación SEO) + upgrade a Astro 7 / Cloudflare Workers

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -337,6 +337,17 @@ jobs:
           app-name: web
           new-status: "⏳ **web** — Deploying to Cloudflare..."
 
+      # KNOWN GAP (2026-07, reform-SSR PR) — do not "fix" this without sign-off:
+      # @astrojs/cloudflare v13+ (the only version compatible with our Astro
+      # 6.1.9) dropped Cloudflare Pages support — it only targets Cloudflare
+      # Workers with static assets (`wrangler deploy`). This command still
+      # deploys to the existing Pages project, which means the new on-demand
+      # /cambios/reforma/ route (prerender=false) will NOT execute here: Pages
+      # will serve `dist` as plain static assets and 404 that route. Cutting
+      # over to `wrangler deploy` requires a one-time manual step in the
+      # Cloudflare Dashboard (attach the leyabierta.es custom domain to a
+      # Workers script instead of this Pages project) before this can be
+      # switched. See packages/web/wrangler.jsonc and the PR description.
       - name: Deploy to Cloudflare Pages
         working-directory: packages/web
         run: bunx wrangler pages deploy dist --project-name=leyabierta

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -337,9 +337,11 @@ jobs:
           app-name: web
           new-status: "⏳ **web** — Deploying to Cloudflare..."
 
-      # Deploy to Cloudflare Workers (static assets + on-demand reform route via
-      # the @astrojs/cloudflare adapter). `wrangler deploy` reads wrangler.jsonc
-      # in packages/web. NOTE: the leyabierta.es custom domain must be attached
+      # Deploy to Cloudflare Workers: the ~12k prebuilt static pages (dist/,
+      # via the ASSETS binding) plus a standalone Worker (src/worker/index.ts,
+      # no Astro adapter) that SSRs only /cambios/reforma/* on demand.
+      # `wrangler deploy` reads wrangler.jsonc in packages/web and bundles the
+      # worker itself. NOTE: the leyabierta.es custom domain must be attached
       # to the `leyabierta-web` Worker (one-time Dashboard cutover) for this to
       # serve production; until then it publishes to the *.workers.dev preview.
       - name: Deploy to Cloudflare Workers

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -337,20 +337,14 @@ jobs:
           app-name: web
           new-status: "⏳ **web** — Deploying to Cloudflare..."
 
-      # KNOWN GAP (2026-07, reform-SSR PR) — do not "fix" this without sign-off:
-      # @astrojs/cloudflare v13+ (the only version compatible with our Astro
-      # 6.1.9) dropped Cloudflare Pages support — it only targets Cloudflare
-      # Workers with static assets (`wrangler deploy`). This command still
-      # deploys to the existing Pages project, which means the new on-demand
-      # /cambios/reforma/ route (prerender=false) will NOT execute here: Pages
-      # will serve `dist` as plain static assets and 404 that route. Cutting
-      # over to `wrangler deploy` requires a one-time manual step in the
-      # Cloudflare Dashboard (attach the leyabierta.es custom domain to a
-      # Workers script instead of this Pages project) before this can be
-      # switched. See packages/web/wrangler.jsonc and the PR description.
-      - name: Deploy to Cloudflare Pages
+      # Deploy to Cloudflare Workers (static assets + on-demand reform route via
+      # the @astrojs/cloudflare adapter). `wrangler deploy` reads wrangler.jsonc
+      # in packages/web. NOTE: the leyabierta.es custom domain must be attached
+      # to the `leyabierta-web` Worker (one-time Dashboard cutover) for this to
+      # serve production; until then it publishes to the *.workers.dev preview.
+      - name: Deploy to Cloudflare Workers
         working-directory: packages/web
-        run: bunx wrangler pages deploy dist --project-name=leyabierta
+        run: bunx wrangler deploy
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,6 @@ __pycache__/
 .venv/
 .oc/
 packages/api/src/data/
+
+# Cloudflare Workers local build cache (@astrojs/cloudflare adapter)
+.wrangler/

--- a/bun.lock
+++ b/bun.lock
@@ -55,9 +55,9 @@
       "version": "0.1.0",
       "dependencies": {
         "@astrojs/cloudflare": "^14.1.3",
-        "@astrojs/react": "^5.0.3",
+        "@astrojs/react": "^6.0.1",
         "@lottiefiles/dotlottie-react": "^0.19.2",
-        "astro": "6.1.9",
+        "astro": "^7.1.1",
         "diff2html": "3.4.56",
         "js-yaml": "4.1.1",
         "markdown-it": "^14.1.1",
@@ -94,17 +94,37 @@
 
     "@astrojs/cloudflare": ["@astrojs/cloudflare@14.1.3", "", { "dependencies": { "@astrojs/internal-helpers": "0.10.1", "@astrojs/underscore-redirects": "1.0.3", "@cloudflare/vite-plugin": "^1.39.0", "piccolore": "^0.1.3", "vite": "^8.0.13" }, "peerDependencies": { "astro": "^7.0.0", "wrangler": "^4.83.0" } }, "sha512-idZndLb/cm64JNayPepaM0Ews971KviYPIcj/xB7Pwp2RKvBjs3MePjZLE50n6EoggeWag3iAMYpAuEKs+3o5g=="],
 
-    "@astrojs/compiler": ["@astrojs/compiler@3.0.1", "", {}, "sha512-z97oYbdebO5aoWzuJ/8q5hLK232+17KcLZ7cJ8BCWk6+qNzVxn/gftC0KzMBUTD8WAaBkPpNSQK6PXLnNrZ0CA=="],
+    "@astrojs/compiler-binding": ["@astrojs/compiler-binding@0.3.1", "", { "optionalDependencies": { "@astrojs/compiler-binding-darwin-arm64": "0.3.1", "@astrojs/compiler-binding-darwin-x64": "0.3.1", "@astrojs/compiler-binding-linux-arm64-gnu": "0.3.1", "@astrojs/compiler-binding-linux-arm64-musl": "0.3.1", "@astrojs/compiler-binding-linux-x64-gnu": "0.3.1", "@astrojs/compiler-binding-linux-x64-musl": "0.3.1", "@astrojs/compiler-binding-wasm32-wasi": "0.3.1", "@astrojs/compiler-binding-win32-arm64-msvc": "0.3.1", "@astrojs/compiler-binding-win32-x64-msvc": "0.3.1" } }, "sha512-DaAUj29AIBU2XdJ8uwcab8lW5O2pk9pY8AXkcMw0sw77nVa3oeTYRcO+Dvbbpoexf6ThMc0FMWYCQ/wN1/T7oQ=="],
+
+    "@astrojs/compiler-binding-darwin-arm64": ["@astrojs/compiler-binding-darwin-arm64@0.3.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-IEmEF2fUIlTHtpeE/isyEGVOB14cEyh/LZOFYt6wn3jNyVpdC8aR5OZ+RzFUR/f+8ZDM1LaMwZKvoA7eMyJeFw=="],
+
+    "@astrojs/compiler-binding-darwin-x64": ["@astrojs/compiler-binding-darwin-x64@0.3.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-GF2kIxjpPDLsn94zbZNMsxEmkU828QqnmM7kiQJnaooS3jmI+I7kk6+oI6EpwOsK3femCMdcm+wmOsEqtGrmjQ=="],
+
+    "@astrojs/compiler-binding-linux-arm64-gnu": ["@astrojs/compiler-binding-linux-arm64-gnu@0.3.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-XJL3SDmOtVrqFhCirNcHwE91+IesJqlgNo23I4qW9QUYfwzm/TBZuH61fgqsb1ttgR1mMYz6ooPWs0JDhwMqpQ=="],
+
+    "@astrojs/compiler-binding-linux-arm64-musl": ["@astrojs/compiler-binding-linux-arm64-musl@0.3.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-xqE8BVbDoBueK/B47w30PtkVofUWJKGkwoMVE+EOMLf11rnoANxIAdA9FPqY+rng4oNI5ndHGsri1yPj2k8vZQ=="],
+
+    "@astrojs/compiler-binding-linux-x64-gnu": ["@astrojs/compiler-binding-linux-x64-gnu@0.3.1", "", { "os": "linux", "cpu": "x64" }, "sha512-1y0StU1qiCuDFH3rmbRJXcxdfHxFPrES1Rd+RLffosvUR7I2cH5SF5SFnBN9vXpzpkmyElZm3Yr47iJBPN7vVA=="],
+
+    "@astrojs/compiler-binding-linux-x64-musl": ["@astrojs/compiler-binding-linux-x64-musl@0.3.1", "", { "os": "linux", "cpu": "x64" }, "sha512-16q0fYf7kpbmdObZEeZJEup8hQv/whgNwVjrSvT8umrKwLDSnNIWiQpm09lQQu6bweZB0XyIvHwlPitvJhC+hg=="],
+
+    "@astrojs/compiler-binding-wasm32-wasi": ["@astrojs/compiler-binding-wasm32-wasi@0.3.1", "", { "dependencies": { "@napi-rs/wasm-runtime": "^1.1.6" }, "cpu": "none" }, "sha512-cB456shIwDv/PrVT+2QG7LFndpHkVge5HjqADKZgGaAc9JHVktCtjSrcdkRQ+3tbkPazNKaTLRjXLIiz2NIx9g=="],
+
+    "@astrojs/compiler-binding-win32-arm64-msvc": ["@astrojs/compiler-binding-win32-arm64-msvc@0.3.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-ur/9+If/yTE69mmeX5MqSZndL0HOyx67GeNZUy3N7wVdWpLz9UTJXwyWS4UR2PUQHitghjsM5xoX0Ge56WRVQQ=="],
+
+    "@astrojs/compiler-binding-win32-x64-msvc": ["@astrojs/compiler-binding-win32-x64-msvc@0.3.1", "", { "os": "win32", "cpu": "x64" }, "sha512-k0W+kDBzDkNZOqu4kElDvCOIbKw5Ut9S1WZ1Krj3KTgNuBERNKXsMMsRLLcbgfdMdbe7bTekQLshZrrvmYpmwA=="],
+
+    "@astrojs/compiler-rs": ["@astrojs/compiler-rs@0.3.1", "", { "dependencies": { "@astrojs/compiler-binding": "0.3.1" } }, "sha512-aT7xkgsbNoS6nriY5qKpbihK43slFHO41iqgHCTdOvn1ifaQxLCc5yXy+6GzAtiafoaC1zA7OwVXCXMsvUZOkg=="],
 
     "@astrojs/internal-helpers": ["@astrojs/internal-helpers@0.10.1", "", { "dependencies": { "@types/hast": "^3.0.4", "@types/mdast": "^4.0.4", "js-yaml": "^4.1.1", "picomatch": "^4.0.4", "retext-smartypants": "^6.2.0", "shiki": "^4.0.2", "smol-toml": "^1.6.0", "unified": "^11.0.5" } }, "sha512-5phcroT/vmOOrYuuAxtkbPixy5hePtlz9i8K4OeDv3dNK6/UQRuXPOSRTxIOBbUY5Sonw2UaxjbuVc43Mcir6Q=="],
 
-    "@astrojs/markdown-remark": ["@astrojs/markdown-remark@7.1.1", "", { "dependencies": { "@astrojs/internal-helpers": "0.9.0", "@astrojs/prism": "4.0.1", "github-slugger": "^2.0.0", "hast-util-from-html": "^2.0.3", "hast-util-to-text": "^4.0.2", "js-yaml": "^4.1.1", "mdast-util-definitions": "^6.0.0", "rehype-raw": "^7.0.0", "rehype-stringify": "^10.0.1", "remark-gfm": "^4.0.1", "remark-parse": "^11.0.0", "remark-rehype": "^11.1.2", "remark-smartypants": "^3.0.2", "retext-smartypants": "^6.2.0", "shiki": "^4.0.0", "smol-toml": "^1.6.0", "unified": "^11.0.5", "unist-util-remove-position": "^5.0.0", "unist-util-visit": "^5.1.0", "unist-util-visit-parents": "^6.0.2", "vfile": "^6.0.3" } }, "sha512-C6e9BnLGlbdv6bV8MYGeHpHxsUHrCrB4OuRLqi5LI7oiBVcBcqfUN06zpwFQdHgV48QCCrMmLpyqBr7VqC+swA=="],
+    "@astrojs/markdown-satteri": ["@astrojs/markdown-satteri@0.3.4", "", { "dependencies": { "@astrojs/internal-helpers": "0.10.1", "@astrojs/prism": "4.0.2", "github-slugger": "^2.0.0", "hast-util-from-html": "^2.0.3", "satteri": "^0.9.1" } }, "sha512-6Lvt/bQZEBW+zzdhPblvfZEy5PGEYJaUsUqaCgwHeRPxZJL1gc9I+DRLKWJjjYTWDzVUTzXlMq4WwSK+X34CVw=="],
 
-    "@astrojs/prism": ["@astrojs/prism@4.0.1", "", { "dependencies": { "prismjs": "^1.30.0" } }, "sha512-nksZQVjlferuWzhPsBpQ1JE5XuKAf1id1/9Hj4a9KG4+ofrlzxUUwX4YGQF/SuDiuiGKEnzopGOt38F3AnVWsQ=="],
+    "@astrojs/prism": ["@astrojs/prism@4.0.2", "", { "dependencies": { "prismjs": "^1.30.0" } }, "sha512-KTivpmnz6lDsC6o9H4+DNm2SrE/GHzw8cNAvEJwAvUT+eoaEnn/4NtbDNfRRaxaJHdp15gf+tfHAWiXR4wB3BA=="],
 
-    "@astrojs/react": ["@astrojs/react@5.0.4", "", { "dependencies": { "@astrojs/internal-helpers": "0.9.0", "@vitejs/plugin-react": "^5.2.0", "devalue": "^5.6.4", "ultrahtml": "^1.6.0", "vite": "^7.3.2" }, "peerDependencies": { "@types/react": "^17.0.50 || ^18.0.21 || ^19.0.0", "@types/react-dom": "^17.0.17 || ^18.0.6 || ^19.0.0", "react": "^17.0.2 || ^18.0.0 || ^19.0.0", "react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0" } }, "sha512-yDNE4VnKOzCjH9dCBi7pT4F6kpI3M9TkS+uxnCB0sGIS6t5vKonOY+Hs/UUnSajJGT5jeBRfpI9IQp+r/n1fBA=="],
+    "@astrojs/react": ["@astrojs/react@6.0.1", "", { "dependencies": { "@astrojs/internal-helpers": "0.10.1", "@vitejs/plugin-react": "^5.2.0", "devalue": "^5.8.1", "ultrahtml": "^1.6.0", "vite": "^8.0.13" }, "peerDependencies": { "@types/react": "^17.0.50 || ^18.0.21 || ^19.0.0", "@types/react-dom": "^17.0.17 || ^18.0.6 || ^19.0.0", "react": "^17.0.2 || ^18.0.0 || ^19.0.0", "react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0" } }, "sha512-Afs1sEm72P2plDnrOGxmIteJ7bjx/VqxlcaQLNip5eHJ5tIvKUORQetC9UKcvgwKnj51t60HWl5mOANkOsWs4w=="],
 
-    "@astrojs/telemetry": ["@astrojs/telemetry@3.3.1", "", { "dependencies": { "ci-info": "^4.4.0", "dlv": "^1.1.3", "dset": "^3.1.4", "is-docker": "^4.0.0", "is-wsl": "^3.1.1", "which-pm-runs": "^1.1.0" } }, "sha512-7fcIxXS9J4ls5tr8b3ww9rbAIz2+HrhNJYZdkAhhB4za/I5IZ/60g+Bs8q7zwG0tOIZfNB4JWhVJ1Qkl/OrNCw=="],
+    "@astrojs/telemetry": ["@astrojs/telemetry@3.3.3", "", { "dependencies": { "ci-info": "^4.4.0", "dset": "^3.1.4", "is-docker": "^4.0.0", "package-manager-detector": "^1.6.0" } }, "sha512-C1TLn5sPJr0x4vk56piHWKbnqlEB8BKyte5Y45V02U+D7BGO5eMqZDH5aPjnkXQWJggvmsTXxH03QMZ9NgWLzQ=="],
 
     "@astrojs/underscore-redirects": ["@astrojs/underscore-redirects@1.0.3", "", {}, "sha512-cxnGSw+sJigBLdX4TMSZKkzV6C3gMLJMucDk2W+n281Xhie68T2/9f1+1NMNDCZsc5i0FED7Qt5I10g2O9wtZg=="],
 
@@ -166,6 +186,24 @@
 
     "@borewit/text-codec": ["@borewit/text-codec@0.2.2", "", {}, "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ=="],
 
+    "@bruits/satteri-darwin-arm64": ["@bruits/satteri-darwin-arm64@0.9.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-iw4nZgx9v30lWo/MTngQqi1pI78KI0DnkSm+lVJGYdmPLgAyDNJigVhpG42/Iq55A6c1Ll8q66ljyyRiQUxwow=="],
+
+    "@bruits/satteri-darwin-x64": ["@bruits/satteri-darwin-x64@0.9.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-6T26Z5Kf3cFW2PSlk9p7zT7yVxvuBSiJvYyz9u8KjYwMTqZyIDOj2wDyNpxKV4+6yUVG7rddq2QwvG/8LJA2+Q=="],
+
+    "@bruits/satteri-linux-arm64-gnu": ["@bruits/satteri-linux-arm64-gnu@0.9.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-u51id17uJwNEMK9nBlICsq6U31c+XVqQueVBkwRIzZG+gMpS8TOJctt5h5Wz33Z8xnMdTd+adtACVz0yHgGuOA=="],
+
+    "@bruits/satteri-linux-arm64-musl": ["@bruits/satteri-linux-arm64-musl@0.9.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-v39HxiwGC5Rqm01HksP6+5Y+xKLPlsuVFgIgpEAo+SiQ22c+mJVhS3u7Z6ePAKdhL5NJoK1xq70kLz3L13AhpQ=="],
+
+    "@bruits/satteri-linux-x64-gnu": ["@bruits/satteri-linux-x64-gnu@0.9.5", "", { "os": "linux", "cpu": "x64" }, "sha512-F3uO8uFp3pAP5ZGXttwvh57GS7s0lL953tnNdyI2gRyP4kOOkp6pyGojNJzCjkDvWI2Cvb9iNrKok3aqQPauAw=="],
+
+    "@bruits/satteri-linux-x64-musl": ["@bruits/satteri-linux-x64-musl@0.9.5", "", { "os": "linux", "cpu": "x64" }, "sha512-bicEqglLlz++mWyADaZoP0JY20s4vDfLjaPYgQqC+NI4zZLTOOg1T4GB8aqtc822Pqji8SQBmSrTb7CrP8i08Q=="],
+
+    "@bruits/satteri-wasm32-wasi": ["@bruits/satteri-wasm32-wasi@0.9.5", "", { "dependencies": { "@emnapi/core": "1.11.1", "@emnapi/runtime": "1.11.1", "@napi-rs/wasm-runtime": "^1.1.6" }, "cpu": "none" }, "sha512-zauAuMwfPnKPUkd4AFixRFpXdgKwP2mKgxrIIo2gJzW0/ZneF9dbHnLkojSpaBnCCp7VUL1hIi5WWZvB1CqmAQ=="],
+
+    "@bruits/satteri-win32-arm64-msvc": ["@bruits/satteri-win32-arm64-msvc@0.9.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-SrfE7NEsgZjBvU3c+RR6oQRu0ToXY5uVJEbieXEF0YTctIV2zAVlbaMjWLts074QCgh3a+XHWkR/lWh2VH2LUg=="],
+
+    "@bruits/satteri-win32-x64-msvc": ["@bruits/satteri-win32-x64-msvc@0.9.5", "", { "os": "win32", "cpu": "x64" }, "sha512-5Kw9ZAtTGS8WHizyn+CJhjjfIQrw+7jcZodpmpXJjefnO15M8UexIi6JR2E5thyvsmHyhL6ZDDMUNR4bKJPd4g=="],
+
     "@capsizecss/unpack": ["@capsizecss/unpack@4.0.0", "", { "dependencies": { "fontkitten": "^1.0.0" } }, "sha512-VERIM64vtTP1C4mxQ5thVT9fK0apjPFobqybMtA1UdUujWka24ERHbRHFGmpbbhp73MhV+KSsHQH9C6uOTdEQA=="],
 
     "@clack/core": ["@clack/core@1.1.0", "", { "dependencies": { "sisteransi": "^1.0.5" } }, "sha512-SVcm4Dqm2ukn64/8Gub2wnlA5nS2iWJyCkdNHcvNHPIeBTGojpdJ+9cZKwLfmqy7irD4N5qLteSilJlE0WLAtA=="],
@@ -200,57 +238,57 @@
 
     "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA=="],
 
-    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.4", "", { "os": "aix", "cpu": "ppc64" }, "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q=="],
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.1", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ=="],
 
-    "@esbuild/android-arm": ["@esbuild/android-arm@0.27.4", "", { "os": "android", "cpu": "arm" }, "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ=="],
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.28.1", "", { "os": "android", "cpu": "arm" }, "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ=="],
 
-    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.4", "", { "os": "android", "cpu": "arm64" }, "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw=="],
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.28.1", "", { "os": "android", "cpu": "arm64" }, "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg=="],
 
-    "@esbuild/android-x64": ["@esbuild/android-x64@0.27.4", "", { "os": "android", "cpu": "x64" }, "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw=="],
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.28.1", "", { "os": "android", "cpu": "x64" }, "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng=="],
 
-    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ=="],
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.28.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q=="],
 
-    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw=="],
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.28.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ=="],
 
-    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.4", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw=="],
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.28.1", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw=="],
 
-    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.4", "", { "os": "freebsd", "cpu": "x64" }, "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ=="],
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.28.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ=="],
 
-    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.4", "", { "os": "linux", "cpu": "arm" }, "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg=="],
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.28.1", "", { "os": "linux", "cpu": "arm" }, "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ=="],
 
-    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA=="],
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.28.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g=="],
 
-    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.4", "", { "os": "linux", "cpu": "ia32" }, "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA=="],
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.28.1", "", { "os": "linux", "cpu": "ia32" }, "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w=="],
 
-    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.4", "", { "os": "linux", "cpu": "none" }, "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA=="],
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg=="],
 
-    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.4", "", { "os": "linux", "cpu": "none" }, "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw=="],
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ=="],
 
-    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA=="],
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.28.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ=="],
 
-    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.4", "", { "os": "linux", "cpu": "none" }, "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw=="],
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ=="],
 
-    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA=="],
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.28.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag=="],
 
-    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.4", "", { "os": "linux", "cpu": "x64" }, "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA=="],
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.28.1", "", { "os": "linux", "cpu": "x64" }, "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA=="],
 
-    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.4", "", { "os": "none", "cpu": "arm64" }, "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q=="],
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw=="],
 
-    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.4", "", { "os": "none", "cpu": "x64" }, "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg=="],
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.28.1", "", { "os": "none", "cpu": "x64" }, "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg=="],
 
-    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.4", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow=="],
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.28.1", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q=="],
 
-    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.4", "", { "os": "openbsd", "cpu": "x64" }, "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ=="],
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.28.1", "", { "os": "openbsd", "cpu": "x64" }, "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw=="],
 
-    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.4", "", { "os": "none", "cpu": "arm64" }, "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg=="],
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg=="],
 
-    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.4", "", { "os": "sunos", "cpu": "x64" }, "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g=="],
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.28.1", "", { "os": "sunos", "cpu": "x64" }, "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ=="],
 
-    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg=="],
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.28.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA=="],
 
-    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.4", "", { "os": "win32", "cpu": "ia32" }, "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw=="],
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg=="],
 
-    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.4", "", { "os": "win32", "cpu": "x64" }, "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg=="],
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A=="],
 
     "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
 
@@ -526,9 +564,9 @@
 
     "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 
-    "@types/debug": ["@types/debug@4.1.13", "", { "dependencies": { "@types/ms": "*" } }, "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw=="],
-
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "@types/estree-jsx": ["@types/estree-jsx@1.0.5", "", { "dependencies": { "@types/estree": "*" } }, "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg=="],
 
     "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
 
@@ -541,8 +579,6 @@
     "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
 
     "@types/mdurl": ["@types/mdurl@2.0.0", "", {}, "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg=="],
-
-    "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
 
     "@types/nlcst": ["@types/nlcst@2.0.3", "", { "dependencies": { "@types/unist": "*" } }, "sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA=="],
 
@@ -590,6 +626,8 @@
 
     "ai": ["ai@6.0.168", "", { "dependencies": { "@ai-sdk/gateway": "3.0.104", "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.23", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-2HqCJuO+1V2aV7vfYs5LFEUfxbkGX+5oa54q/gCCTL7KLTdbxcCu5D7TdLA5kwsrs3Szgjah9q6D9tpjHM3hUQ=="],
 
+    "am-i-vibing": ["am-i-vibing@0.4.0", "", { "dependencies": { "process-ancestry": "^0.1.0" }, "bin": { "am-i-vibing": "dist/cli.mjs" } }, "sha512-MxT4XZL7pzLHpuvhDKdMaQHMGGkJDLluKBLsbstn+8wv9sWcFT6h+0ve9qkml95amVTZtZV83gQe2hY+ojgHLg=="],
+
     "ansi-align": ["ansi-align@3.0.1", "", { "dependencies": { "string-width": "^4.1.0" } }, "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w=="],
 
     "ansi-escapes": ["ansi-escapes@7.3.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg=="],
@@ -604,11 +642,9 @@
 
     "aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
 
-    "array-iterate": ["array-iterate@2.0.1", "", {}, "sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg=="],
-
     "asap": ["asap@2.0.6", "", {}, "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="],
 
-    "astro": ["astro@6.1.9", "", { "dependencies": { "@astrojs/compiler": "^3.0.1", "@astrojs/internal-helpers": "0.9.0", "@astrojs/markdown-remark": "7.1.1", "@astrojs/telemetry": "3.3.1", "@capsizecss/unpack": "^4.0.0", "@clack/prompts": "^1.1.0", "@oslojs/encoding": "^1.1.0", "@rollup/pluginutils": "^5.3.0", "aria-query": "^5.3.2", "axobject-query": "^4.1.0", "ci-info": "^4.4.0", "clsx": "^2.1.1", "common-ancestor-path": "^2.0.0", "cookie": "^1.1.1", "devalue": "^5.6.3", "diff": "^8.0.3", "dset": "^3.1.4", "es-module-lexer": "^2.0.0", "esbuild": "^0.27.3", "flattie": "^1.1.1", "fontace": "~0.4.1", "github-slugger": "^2.0.0", "html-escaper": "3.0.3", "http-cache-semantics": "^4.2.0", "js-yaml": "^4.1.1", "magic-string": "^0.30.21", "magicast": "^0.5.2", "mrmime": "^2.0.1", "neotraverse": "^0.6.18", "obug": "^2.1.1", "p-limit": "^7.3.0", "p-queue": "^9.1.0", "package-manager-detector": "^1.6.0", "piccolore": "^0.1.3", "picomatch": "^4.0.4", "rehype": "^13.0.2", "semver": "^7.7.4", "shiki": "^4.0.2", "smol-toml": "^1.6.0", "svgo": "^4.0.1", "tinyclip": "^0.1.12", "tinyexec": "^1.0.4", "tinyglobby": "^0.2.15", "tsconfck": "^3.1.6", "ultrahtml": "^1.6.0", "unifont": "~0.7.4", "unist-util-visit": "^5.1.0", "unstorage": "^1.17.5", "vfile": "^6.0.3", "vite": "^7.3.2", "vitefu": "^1.1.2", "xxhash-wasm": "^1.1.0", "yargs-parser": "^22.0.0", "zod": "^4.3.6" }, "optionalDependencies": { "sharp": "^0.34.0" }, "bin": { "astro": "bin/astro.mjs" } }, "sha512-NsAHzMzpznB281g2aM5qnBt2QjfH6ttKiZ3hSZw52If8JJ+62kbnBKbyKhR2glQcJLl7Jfe4GSl0DihFZ36rRQ=="],
+    "astro": ["astro@7.1.1", "", { "dependencies": { "@astrojs/compiler-rs": "^0.3.1", "@astrojs/internal-helpers": "0.10.1", "@astrojs/markdown-satteri": "0.3.4", "@astrojs/telemetry": "3.3.3", "@capsizecss/unpack": "^4.0.0", "@clack/prompts": "^1.1.0", "@oslojs/encoding": "^1.1.0", "@rollup/pluginutils": "^5.3.0", "am-i-vibing": "^0.4.0", "aria-query": "^5.3.2", "axobject-query": "^4.1.0", "ci-info": "^4.4.0", "clsx": "^2.1.1", "common-ancestor-path": "^2.0.0", "cookie": "^1.1.1", "devalue": "^5.8.1", "diff": "^8.0.3", "dset": "^3.1.4", "es-module-lexer": "^2.0.0", "esbuild": "^0.28.0", "flattie": "^1.1.1", "fontace": "~0.4.1", "get-tsconfig": "5.0.0-beta.4", "github-slugger": "^2.0.0", "html-escaper": "3.0.3", "http-cache-semantics": "^4.2.0", "js-yaml": "^4.1.1", "jsonc-parser": "^3.3.1", "magic-string": "^0.30.21", "magicast": "^0.5.2", "mrmime": "^2.0.1", "neotraverse": "^0.6.18", "obug": "^2.1.1", "p-limit": "^7.3.0", "p-queue": "^9.1.0", "package-manager-detector": "^1.6.0", "piccolore": "^0.1.3", "picomatch": "^4.0.4", "semver": "^7.7.4", "shiki": "^4.0.2", "smol-toml": "^1.6.0", "svgo": "^4.0.1", "tinyclip": "^0.1.12", "tinyexec": "^1.0.4", "tinyglobby": "^0.2.15", "ultrahtml": "^1.6.0", "unifont": "~0.7.4", "unstorage": "^1.17.5", "vite": "^8.0.13", "vitefu": "^1.1.2", "xxhash-wasm": "^1.1.0", "yargs-parser": "^22.0.0", "zod": "^4.3.6" }, "optionalDependencies": { "sharp": "^0.34.0 || ^0.35.0" }, "peerDependencies": { "@astrojs/markdown-remark": "7.2.1" }, "optionalPeers": ["@astrojs/markdown-remark"], "bin": { "astro": "./bin/astro.mjs" } }, "sha512-yfKhuvbz+DORHihJRL1DHcxyLcX9uTrxvz2nCSTzHH54k2DdACBfuOu2OAAAhdUC9xlu2IRXAiagqcPL3DftCg=="],
 
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
 
@@ -647,8 +683,6 @@
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
 
     "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
-
-    "character-entities": ["character-entities@2.0.2", "", {}, "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="],
 
     "character-entities-html4": ["character-entities-html4@2.1.0", "", {}, "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA=="],
 
@@ -710,8 +744,6 @@
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
-    "decode-named-character-reference": ["decode-named-character-reference@1.3.0", "", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q=="],
-
     "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
 
     "defu": ["defu@6.1.4", "", {}, "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg=="],
@@ -722,7 +754,7 @@
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
-    "devalue": ["devalue@5.6.4", "", {}, "sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA=="],
+    "devalue": ["devalue@5.8.1", "", {}, "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw=="],
 
     "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
@@ -731,8 +763,6 @@
     "diff-sequences": ["diff-sequences@29.6.3", "", {}, "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q=="],
 
     "diff2html": ["diff2html@3.4.56", "", { "dependencies": { "@profoundlogic/hogan": "^3.0.4", "diff": "^8.0.3" }, "optionalDependencies": { "highlight.js": "11.11.1" } }, "sha512-u9gfn+BlbHcyO7vItCIC4z49LJDUt31tODzOfAuJ5R1E7IdlRL6KjugcB9zOpejD+XiR+dDZbsnHSQ3g6A/u8A=="],
-
-    "dlv": ["dlv@1.1.3", "", {}, "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="],
 
     "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
 
@@ -772,7 +802,7 @@
 
     "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
 
-    "esbuild": ["esbuild@0.27.4", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.4", "@esbuild/android-arm": "0.27.4", "@esbuild/android-arm64": "0.27.4", "@esbuild/android-x64": "0.27.4", "@esbuild/darwin-arm64": "0.27.4", "@esbuild/darwin-x64": "0.27.4", "@esbuild/freebsd-arm64": "0.27.4", "@esbuild/freebsd-x64": "0.27.4", "@esbuild/linux-arm": "0.27.4", "@esbuild/linux-arm64": "0.27.4", "@esbuild/linux-ia32": "0.27.4", "@esbuild/linux-loong64": "0.27.4", "@esbuild/linux-mips64el": "0.27.4", "@esbuild/linux-ppc64": "0.27.4", "@esbuild/linux-riscv64": "0.27.4", "@esbuild/linux-s390x": "0.27.4", "@esbuild/linux-x64": "0.27.4", "@esbuild/netbsd-arm64": "0.27.4", "@esbuild/netbsd-x64": "0.27.4", "@esbuild/openbsd-arm64": "0.27.4", "@esbuild/openbsd-x64": "0.27.4", "@esbuild/openharmony-arm64": "0.27.4", "@esbuild/sunos-x64": "0.27.4", "@esbuild/win32-arm64": "0.27.4", "@esbuild/win32-ia32": "0.27.4", "@esbuild/win32-x64": "0.27.4" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ=="],
+    "esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
@@ -846,6 +876,8 @@
 
     "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
 
+    "get-tsconfig": ["get-tsconfig@5.0.0-beta.4", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-7nF7C9fIPFEMHgEMEfgIlO9wDdZ8CyHw27rWciFZfHvHDReIiPhsYuzPRXsfvBCqFy1l8RRyyWV7QLM+ZhUJsQ=="],
+
     "github-slugger": ["github-slugger@2.0.0", "", {}, "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw=="],
 
     "google-auth-library": ["google-auth-library@10.6.2", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^7.1.4", "gcp-metadata": "8.1.2", "google-logging-utils": "1.1.3", "jws": "^4.0.0" } }, "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw=="],
@@ -868,17 +900,9 @@
 
     "hast-util-from-parse5": ["hast-util-from-parse5@8.0.3", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "devlop": "^1.0.0", "hastscript": "^9.0.0", "property-information": "^7.0.0", "vfile": "^6.0.0", "vfile-location": "^5.0.0", "web-namespaces": "^2.0.0" } }, "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg=="],
 
-    "hast-util-is-element": ["hast-util-is-element@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g=="],
-
     "hast-util-parse-selector": ["hast-util-parse-selector@4.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A=="],
 
-    "hast-util-raw": ["hast-util-raw@9.1.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "@ungap/structured-clone": "^1.0.0", "hast-util-from-parse5": "^8.0.0", "hast-util-to-parse5": "^8.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "parse5": "^7.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0", "web-namespaces": "^2.0.0", "zwitch": "^2.0.0" } }, "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw=="],
-
     "hast-util-to-html": ["hast-util-to-html@9.0.5", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-whitespace": "^3.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "stringify-entities": "^4.0.0", "zwitch": "^2.0.4" } }, "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw=="],
-
-    "hast-util-to-parse5": ["hast-util-to-parse5@8.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "web-namespaces": "^2.0.0", "zwitch": "^2.0.0" } }, "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA=="],
-
-    "hast-util-to-text": ["hast-util-to-text@4.0.2", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "hast-util-is-element": "^3.0.0", "unist-util-find-after": "^5.0.0" } }, "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A=="],
 
     "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
 
@@ -912,8 +936,6 @@
 
     "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
 
-    "is-inside-container": ["is-inside-container@1.0.0", "", { "dependencies": { "is-docker": "^3.0.0" }, "bin": { "is-inside-container": "cli.js" } }, "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA=="],
-
     "is-interactive": ["is-interactive@2.0.0", "", {}, "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ=="],
 
     "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
@@ -921,8 +943,6 @@
     "is-plain-object": ["is-plain-object@5.0.0", "", {}, "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="],
 
     "is-unicode-supported": ["is-unicode-supported@2.1.0", "", {}, "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ=="],
-
-    "is-wsl": ["is-wsl@3.1.1", "", { "dependencies": { "is-inside-container": "^1.0.0" } }, "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw=="],
 
     "jest-diff": ["jest-diff@29.7.0", "", { "dependencies": { "chalk": "^4.0.0", "diff-sequences": "^29.6.3", "jest-get-type": "^29.6.3", "pretty-format": "^29.7.0" } }, "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw=="],
 
@@ -939,6 +959,8 @@
     "json-schema": ["json-schema@0.4.0", "", {}, "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="],
 
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
+
+    "jsonc-parser": ["jsonc-parser@3.3.1", "", {}, "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="],
 
     "jwa": ["jwa@2.0.1", "", { "dependencies": { "buffer-equal-constant-time": "^1.0.1", "ecdsa-sig-formatter": "1.0.11", "safe-buffer": "^5.0.1" } }, "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg=="],
 
@@ -978,8 +1000,6 @@
 
     "log-symbols": ["log-symbols@6.0.0", "", { "dependencies": { "chalk": "^5.3.0", "is-unicode-supported": "^1.3.0" } }, "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw=="],
 
-    "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
-
     "lru-cache": ["lru-cache@11.2.7", "", {}, "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
@@ -988,35 +1008,9 @@
 
     "markdown-it": ["markdown-it@14.1.1", "", { "dependencies": { "argparse": "^2.0.1", "entities": "^4.4.0", "linkify-it": "^5.0.0", "mdurl": "^2.0.0", "punycode.js": "^2.3.1", "uc.micro": "^2.1.0" }, "bin": { "markdown-it": "bin/markdown-it.mjs" } }, "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA=="],
 
-    "markdown-table": ["markdown-table@3.0.4", "", {}, "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="],
-
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
-    "mdast-util-definitions": ["mdast-util-definitions@6.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "unist-util-visit": "^5.0.0" } }, "sha512-scTllyX6pnYNZH/AIp/0ePz6s4cZtARxImwoPJ7kS42n+MnVsI4XbnG6d4ibehRIldYMWM2LD7ImQblVhUejVQ=="],
-
-    "mdast-util-find-and-replace": ["mdast-util-find-and-replace@3.0.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "escape-string-regexp": "^5.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg=="],
-
-    "mdast-util-from-markdown": ["mdast-util-from-markdown@2.0.3", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "mdast-util-to-string": "^4.0.0", "micromark": "^4.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q=="],
-
-    "mdast-util-gfm": ["mdast-util-gfm@3.1.0", "", { "dependencies": { "mdast-util-from-markdown": "^2.0.0", "mdast-util-gfm-autolink-literal": "^2.0.0", "mdast-util-gfm-footnote": "^2.0.0", "mdast-util-gfm-strikethrough": "^2.0.0", "mdast-util-gfm-table": "^2.0.0", "mdast-util-gfm-task-list-item": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ=="],
-
-    "mdast-util-gfm-autolink-literal": ["mdast-util-gfm-autolink-literal@2.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "ccount": "^2.0.0", "devlop": "^1.0.0", "mdast-util-find-and-replace": "^3.0.0", "micromark-util-character": "^2.0.0" } }, "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ=="],
-
-    "mdast-util-gfm-footnote": ["mdast-util-gfm-footnote@2.1.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.1.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0" } }, "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ=="],
-
-    "mdast-util-gfm-strikethrough": ["mdast-util-gfm-strikethrough@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg=="],
-
-    "mdast-util-gfm-table": ["mdast-util-gfm-table@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "markdown-table": "^3.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg=="],
-
-    "mdast-util-gfm-task-list-item": ["mdast-util-gfm-task-list-item@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ=="],
-
-    "mdast-util-phrasing": ["mdast-util-phrasing@4.1.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "unist-util-is": "^6.0.0" } }, "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w=="],
-
     "mdast-util-to-hast": ["mdast-util-to-hast@13.2.1", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@ungap/structured-clone": "^1.0.0", "devlop": "^1.0.0", "micromark-util-sanitize-uri": "^2.0.0", "trim-lines": "^3.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA=="],
-
-    "mdast-util-to-markdown": ["mdast-util-to-markdown@2.1.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "longest-streak": "^3.0.0", "mdast-util-phrasing": "^4.0.0", "mdast-util-to-string": "^4.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "unist-util-visit": "^5.0.0", "zwitch": "^2.0.0" } }, "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA=="],
-
-    "mdast-util-to-string": ["mdast-util-to-string@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0" } }, "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg=="],
 
     "mdn-data": ["mdn-data@2.27.1", "", {}, "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ=="],
 
@@ -1024,57 +1018,11 @@
 
     "memoirist": ["memoirist@0.4.0", "", {}, "sha512-zxTgA0mSYELa66DimuNQDvyLq36AwDlTuVRbnQtB+VuTcKWm5Qc4z3WkSpgsFWHNhexqkIooqpv4hdcqrX5Nmg=="],
 
-    "micromark": ["micromark@4.0.2", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="],
-
-    "micromark-core-commonmark": ["micromark-core-commonmark@2.0.3", "", { "dependencies": { "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-factory-destination": "^2.0.0", "micromark-factory-label": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-factory-title": "^2.0.0", "micromark-factory-whitespace": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-html-tag-name": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg=="],
-
-    "micromark-extension-gfm": ["micromark-extension-gfm@3.0.0", "", { "dependencies": { "micromark-extension-gfm-autolink-literal": "^2.0.0", "micromark-extension-gfm-footnote": "^2.0.0", "micromark-extension-gfm-strikethrough": "^2.0.0", "micromark-extension-gfm-table": "^2.0.0", "micromark-extension-gfm-tagfilter": "^2.0.0", "micromark-extension-gfm-task-list-item": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w=="],
-
-    "micromark-extension-gfm-autolink-literal": ["micromark-extension-gfm-autolink-literal@2.1.0", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw=="],
-
-    "micromark-extension-gfm-footnote": ["micromark-extension-gfm-footnote@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw=="],
-
-    "micromark-extension-gfm-strikethrough": ["micromark-extension-gfm-strikethrough@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw=="],
-
-    "micromark-extension-gfm-table": ["micromark-extension-gfm-table@2.1.1", "", { "dependencies": { "devlop": "^1.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg=="],
-
-    "micromark-extension-gfm-tagfilter": ["micromark-extension-gfm-tagfilter@2.0.0", "", { "dependencies": { "micromark-util-types": "^2.0.0" } }, "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg=="],
-
-    "micromark-extension-gfm-task-list-item": ["micromark-extension-gfm-task-list-item@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw=="],
-
-    "micromark-factory-destination": ["micromark-factory-destination@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA=="],
-
-    "micromark-factory-label": ["micromark-factory-label@2.0.1", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg=="],
-
-    "micromark-factory-space": ["micromark-factory-space@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg=="],
-
-    "micromark-factory-title": ["micromark-factory-title@2.0.1", "", { "dependencies": { "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw=="],
-
-    "micromark-factory-whitespace": ["micromark-factory-whitespace@2.0.1", "", { "dependencies": { "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ=="],
-
     "micromark-util-character": ["micromark-util-character@2.1.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q=="],
-
-    "micromark-util-chunked": ["micromark-util-chunked@2.0.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA=="],
-
-    "micromark-util-classify-character": ["micromark-util-classify-character@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q=="],
-
-    "micromark-util-combine-extensions": ["micromark-util-combine-extensions@2.0.1", "", { "dependencies": { "micromark-util-chunked": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg=="],
-
-    "micromark-util-decode-numeric-character-reference": ["micromark-util-decode-numeric-character-reference@2.0.2", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw=="],
-
-    "micromark-util-decode-string": ["micromark-util-decode-string@2.0.1", "", { "dependencies": { "decode-named-character-reference": "^1.0.0", "micromark-util-character": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-symbol": "^2.0.0" } }, "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ=="],
 
     "micromark-util-encode": ["micromark-util-encode@2.0.1", "", {}, "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw=="],
 
-    "micromark-util-html-tag-name": ["micromark-util-html-tag-name@2.0.1", "", {}, "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA=="],
-
-    "micromark-util-normalize-identifier": ["micromark-util-normalize-identifier@2.0.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q=="],
-
-    "micromark-util-resolve-all": ["micromark-util-resolve-all@2.0.1", "", { "dependencies": { "micromark-util-types": "^2.0.0" } }, "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg=="],
-
     "micromark-util-sanitize-uri": ["micromark-util-sanitize-uri@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-symbol": "^2.0.0" } }, "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ=="],
-
-    "micromark-util-subtokenize": ["micromark-util-subtokenize@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA=="],
 
     "micromark-util-symbol": ["micromark-util-symbol@2.0.1", "", {}, "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q=="],
 
@@ -1146,8 +1094,6 @@
 
     "parse-css-color": ["parse-css-color@0.2.1", "", { "dependencies": { "color-name": "^1.1.4", "hex-rgb": "^4.1.0" } }, "sha512-bwS/GGIFV3b6KS4uwpzCFj4w297Yl3uqnSgIPsoQkx7GMLROXfMnWvxfNkL0oh8HVhZA4hvJoEoEIqonfJ3BWg=="],
 
-    "parse-latin": ["parse-latin@7.0.0", "", { "dependencies": { "@types/nlcst": "^2.0.0", "@types/unist": "^3.0.0", "nlcst-to-string": "^4.0.0", "unist-util-modify-children": "^4.0.0", "unist-util-visit-children": "^3.0.0", "vfile": "^6.0.0" } }, "sha512-mhHgobPPua5kZ98EF4HWiH167JWBfl4pvAIXXdbaVohtK7a6YBOy56kvhCqduqyo/f3yrHFWmqmiMg/BkBkYYQ=="],
-
     "parse-srcset": ["parse-srcset@1.0.2", "", {}, "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q=="],
 
     "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
@@ -1166,7 +1112,7 @@
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+    "picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
 
     "postal-mime": ["postal-mime@2.7.4", "", {}, "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g=="],
 
@@ -1179,6 +1125,8 @@
     "prismjs": ["prismjs@1.30.0", "", {}, "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw=="],
 
     "process": ["process@0.11.10", "", {}, "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="],
+
+    "process-ancestry": ["process-ancestry@0.1.0", "", {}, "sha512-tGqJW/UnclpYASFcM6Xh8D8l/BMtaQ9+CSG0vlJSJTcdMM4lDRv4c6H0Pdcsfted+bVczdYSfk2fdukg2gQkZg=="],
 
     "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
 
@@ -1206,35 +1154,13 @@
 
     "regex-utilities": ["regex-utilities@2.3.0", "", {}, "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng=="],
 
-    "rehype": ["rehype@13.0.2", "", { "dependencies": { "@types/hast": "^3.0.0", "rehype-parse": "^9.0.0", "rehype-stringify": "^10.0.0", "unified": "^11.0.0" } }, "sha512-j31mdaRFrwFRUIlxGeuPXXKWQxet52RBQRvCmzl5eCefn/KGbomK5GMHNMsOJf55fgo3qw5tST5neDuarDYR2A=="],
-
-    "rehype-parse": ["rehype-parse@9.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-from-html": "^2.0.0", "unified": "^11.0.0" } }, "sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag=="],
-
-    "rehype-raw": ["rehype-raw@7.0.0", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-raw": "^9.0.0", "vfile": "^6.0.0" } }, "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww=="],
-
-    "rehype-stringify": ["rehype-stringify@10.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-to-html": "^9.0.0", "unified": "^11.0.0" } }, "sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA=="],
-
-    "remark-gfm": ["remark-gfm@4.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-gfm": "^3.0.0", "micromark-extension-gfm": "^3.0.0", "remark-parse": "^11.0.0", "remark-stringify": "^11.0.0", "unified": "^11.0.0" } }, "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg=="],
-
-    "remark-parse": ["remark-parse@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-from-markdown": "^2.0.0", "micromark-util-types": "^2.0.0", "unified": "^11.0.0" } }, "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA=="],
-
-    "remark-rehype": ["remark-rehype@11.1.2", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "mdast-util-to-hast": "^13.0.0", "unified": "^11.0.0", "vfile": "^6.0.0" } }, "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw=="],
-
-    "remark-smartypants": ["remark-smartypants@3.0.2", "", { "dependencies": { "retext": "^9.0.0", "retext-smartypants": "^6.0.0", "unified": "^11.0.4", "unist-util-visit": "^5.0.0" } }, "sha512-ILTWeOriIluwEvPjv67v7Blgrcx+LZOkAUVtKI3putuhlZm84FnqDORNXPPm+HY3NdZOMhyDwZ1E+eZB/Df5dA=="],
-
-    "remark-stringify": ["remark-stringify@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-to-markdown": "^2.0.0", "unified": "^11.0.0" } }, "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw=="],
-
     "resend": ["resend@6.10.0", "", { "dependencies": { "postal-mime": "2.7.4", "svix": "1.88.0" }, "peerDependencies": { "@react-email/render": "*" }, "optionalPeers": ["@react-email/render"] }, "sha512-i7CwZpYj4Oho1RxsTpLcCUkO08+HiL4NXrm6jLJ2WzJ89UGI8eROSieLONJA3hnUrf1OYnCyfq5F6POnHUMv1Q=="],
+
+    "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
 
     "restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
 
-    "retext": ["retext@9.0.0", "", { "dependencies": { "@types/nlcst": "^2.0.0", "retext-latin": "^4.0.0", "retext-stringify": "^4.0.0", "unified": "^11.0.0" } }, "sha512-sbMDcpHCNjvlheSgMfEcVrZko3cDzdbe1x/e7G66dFp0Ff7Mldvi2uv6JkJQzdRcvLYE8CA8Oe8siQx8ZOgTcA=="],
-
-    "retext-latin": ["retext-latin@4.0.0", "", { "dependencies": { "@types/nlcst": "^2.0.0", "parse-latin": "^7.0.0", "unified": "^11.0.0" } }, "sha512-hv9woG7Fy0M9IlRQloq/N6atV82NxLGveq+3H2WOi79dtIYWN8OaxogDm77f8YnVXJL2VD3bbqowu5E3EMhBYA=="],
-
     "retext-smartypants": ["retext-smartypants@6.2.0", "", { "dependencies": { "@types/nlcst": "^2.0.0", "nlcst-to-string": "^4.0.0", "unist-util-visit": "^5.0.0" } }, "sha512-kk0jOU7+zGv//kfjXEBjdIryL1Acl4i9XNkHxtM7Tm5lFiCog576fjNC9hjoR7LTKQ0DsPWy09JummSsH1uqfQ=="],
-
-    "retext-stringify": ["retext-stringify@4.0.0", "", { "dependencies": { "@types/nlcst": "^2.0.0", "nlcst-to-string": "^4.0.0", "unified": "^11.0.0" } }, "sha512-rtfN/0o8kL1e+78+uxPTqu1Klt0yPzKuQ2BfWwwfgIUSayyzxpM1PJzkKt4V8803uB9qSy32MvI7Xep9khTpiA=="],
 
     "rolldown": ["rolldown@1.1.5", "", { "dependencies": { "@oxc-project/types": "=0.139.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.1.5", "@rolldown/binding-darwin-arm64": "1.1.5", "@rolldown/binding-darwin-x64": "1.1.5", "@rolldown/binding-freebsd-x64": "1.1.5", "@rolldown/binding-linux-arm-gnueabihf": "1.1.5", "@rolldown/binding-linux-arm64-gnu": "1.1.5", "@rolldown/binding-linux-arm64-musl": "1.1.5", "@rolldown/binding-linux-ppc64-gnu": "1.1.5", "@rolldown/binding-linux-s390x-gnu": "1.1.5", "@rolldown/binding-linux-x64-gnu": "1.1.5", "@rolldown/binding-linux-x64-musl": "1.1.5", "@rolldown/binding-openharmony-arm64": "1.1.5", "@rolldown/binding-wasm32-wasi": "1.1.5", "@rolldown/binding-win32-arm64-msvc": "1.1.5", "@rolldown/binding-win32-x64-msvc": "1.1.5" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA=="],
 
@@ -1245,6 +1171,8 @@
     "sanitize-html": ["sanitize-html@2.17.2", "", { "dependencies": { "deepmerge": "^4.2.2", "escape-string-regexp": "^4.0.0", "htmlparser2": "^10.1.0", "is-plain-object": "^5.0.0", "parse-srcset": "^1.0.2", "postcss": "^8.3.11" } }, "sha512-EnffJUl46VE9uvZ0XeWzObHLurClLlT12gsOk1cHyP2Ol1P0BnBnsXmShlBmWVJM+dKieQI68R0tsPY5m/B+Jg=="],
 
     "satori": ["satori@0.26.0", "", { "dependencies": { "@shuding/opentype.js": "1.4.0-beta.0", "css-background-parser": "^0.1.0", "css-box-shadow": "1.0.0-3", "css-gradient-parser": "^0.0.17", "css-to-react-native": "^3.0.0", "emoji-regex-xs": "^2.0.1", "escape-html": "^1.0.3", "linebreak": "^1.1.0", "parse-css-color": "^0.2.1", "postcss-value-parser": "^4.2.0", "yoga-layout": "^3.2.1" } }, "sha512-tkMFrfIs3l2mQ2JEcyW0ADTy3zGggFRFzi6Ef8YozQSFsFKEqaSO1Y8F9wJg4//PJGQauMalHGTUEkPrFwhVPA=="],
+
+    "satteri": ["satteri@0.9.5", "", { "dependencies": { "@types/estree-jsx": "^1.0.5", "@types/hast": "^3.0.4", "@types/mdast": "^4.0.4", "@types/unist": "^3.0.3" }, "optionalDependencies": { "@bruits/satteri-darwin-arm64": "0.9.5", "@bruits/satteri-darwin-x64": "0.9.5", "@bruits/satteri-linux-arm64-gnu": "0.9.5", "@bruits/satteri-linux-arm64-musl": "0.9.5", "@bruits/satteri-linux-x64-gnu": "0.9.5", "@bruits/satteri-linux-x64-musl": "0.9.5", "@bruits/satteri-wasm32-wasi": "0.9.5", "@bruits/satteri-win32-arm64-msvc": "0.9.5", "@bruits/satteri-win32-x64-msvc": "0.9.5" } }, "sha512-ZuWVl+vnM64y+/TtX8Kosv2c00W+hLQiiwnEL6H0UKVVrxFqMw4D2CJHHQaouVd89OAhtBBfjWLqhKi3TVUV4w=="],
 
     "sax": ["sax@1.6.0", "", {}, "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA=="],
 
@@ -1310,15 +1238,13 @@
 
     "tinyexec": ["tinyexec@1.0.4", "", {}, "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw=="],
 
-    "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
+    "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
 
     "token-types": ["token-types@6.1.2", "", { "dependencies": { "@borewit/text-codec": "^0.2.1", "@tokenizer/token": "^0.3.0", "ieee754": "^1.2.1" } }, "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww=="],
 
     "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
 
     "trough": ["trough@2.2.0", "", {}, "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="],
-
-    "tsconfck": ["tsconfck@3.1.6", "", { "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "tsconfck": "bin/tsconfck.js" } }, "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
@@ -1350,21 +1276,13 @@
 
     "unifont": ["unifont@0.7.4", "", { "dependencies": { "css-tree": "^3.1.0", "ofetch": "^1.5.1", "ohash": "^2.0.11" } }, "sha512-oHeis4/xl42HUIeHuNZRGEvxj5AaIKR+bHPNegRq5LV1gdc3jundpONbjglKpihmJf+dswygdMJn3eftGIMemg=="],
 
-    "unist-util-find-after": ["unist-util-find-after@5.0.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ=="],
-
     "unist-util-is": ["unist-util-is@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g=="],
 
-    "unist-util-modify-children": ["unist-util-modify-children@4.0.0", "", { "dependencies": { "@types/unist": "^3.0.0", "array-iterate": "^2.0.0" } }, "sha512-+tdN5fGNddvsQdIzUF3Xx82CU9sMM+fA0dLgR9vOmT0oPT2jH+P1nd5lSqfCfXAw+93NhcXNY2qqvTUtE4cQkw=="],
-
     "unist-util-position": ["unist-util-position@5.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA=="],
-
-    "unist-util-remove-position": ["unist-util-remove-position@5.0.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-visit": "^5.0.0" } }, "sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q=="],
 
     "unist-util-stringify-position": ["unist-util-stringify-position@4.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ=="],
 
     "unist-util-visit": ["unist-util-visit@5.1.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg=="],
-
-    "unist-util-visit-children": ["unist-util-visit-children@3.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-RgmdTfSBOg04sdPcpTSD1jzoNBjt9a80/ZCzp5cI9n1qPzLZWF9YdvWGN2zmTumP1HWhXKdUWexjy/Wy/lJ7tA=="],
 
     "unist-util-visit-parents": ["unist-util-visit-parents@6.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="],
 
@@ -1391,8 +1309,6 @@
     "web-namespaces": ["web-namespaces@2.0.1", "", {}, "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="],
 
     "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
-
-    "which-pm-runs": ["which-pm-runs@1.1.0", "", {}, "sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA=="],
 
     "widest-line": ["widest-line@5.0.0", "", { "dependencies": { "string-width": "^7.0.0" } }, "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA=="],
 
@@ -1424,14 +1340,6 @@
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
-    "@astrojs/internal-helpers/picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
-
-    "@astrojs/markdown-remark/@astrojs/internal-helpers": ["@astrojs/internal-helpers@0.9.0", "", { "dependencies": { "picomatch": "^4.0.4" } }, "sha512-GdYkzR26re8izmyYlBqf4z2s7zNngmWLFuxw0UKiPNqHraZGS6GKWIwSHgS22RDlu2ePFJ8bzmpBcUszut/SDg=="],
-
-    "@astrojs/react/@astrojs/internal-helpers": ["@astrojs/internal-helpers@0.9.0", "", { "dependencies": { "picomatch": "^4.0.4" } }, "sha512-GdYkzR26re8izmyYlBqf4z2s7zNngmWLFuxw0UKiPNqHraZGS6GKWIwSHgS22RDlu2ePFJ8bzmpBcUszut/SDg=="],
-
-    "@astrojs/react/vite": ["vite@7.3.2", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg=="],
-
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@babel/generator/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
@@ -1439,6 +1347,8 @@
     "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
     "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "@bruits/satteri-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
 
     "@jest/schemas/@sinclair/typebox": ["@sinclair/typebox@0.27.10", "", {}, "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA=="],
 
@@ -1450,17 +1360,13 @@
 
     "@rolldown/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
 
+    "@rollup/pluginutils/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
     "@scalar/themes/@scalar/types": ["@scalar/types@0.1.7", "", { "dependencies": { "@scalar/openapi-types": "0.2.0", "@unhead/schema": "^1.11.11", "nanoid": "^5.1.5", "type-fest": "^4.20.0", "zod": "^3.23.8" } }, "sha512-irIDYzTQG2KLvFbuTI8k2Pz/R4JR+zUUSykVTbEMatkzMmVFnn1VzNSMlODbadycwZunbnL2tA27AXed9URVjw=="],
 
     "ansi-align/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "anymatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
-
-    "astro/@astrojs/internal-helpers": ["@astrojs/internal-helpers@0.9.0", "", { "dependencies": { "picomatch": "^4.0.4" } }, "sha512-GdYkzR26re8izmyYlBqf4z2s7zNngmWLFuxw0UKiPNqHraZGS6GKWIwSHgS22RDlu2ePFJ8bzmpBcUszut/SDg=="],
-
-    "astro/vite": ["vite@7.3.2", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg=="],
-
-    "astro/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "buffer/base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
@@ -1472,13 +1378,9 @@
 
     "htmlparser2/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
-    "is-inside-container/is-docker": ["is-docker@3.0.0", "", { "bin": { "is-docker": "cli.js" } }, "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="],
-
     "jest-diff/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "log-symbols/is-unicode-supported": ["is-unicode-supported@1.3.0", "", {}, "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ=="],
-
-    "mdast-util-find-and-replace/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
     "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
@@ -1492,13 +1394,7 @@
 
     "unenv/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
-    "vite/picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
-
     "vite/postcss": ["postcss@8.5.19", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ=="],
-
-    "vite/tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
-
-    "wrangler/esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
 
     "@scalar/themes/@scalar/types/@scalar/openapi-types": ["@scalar/openapi-types@0.2.0", "", { "dependencies": { "zod": "^3.23.8" } }, "sha512-waiKk12cRCqyUCWTOX0K1WEVX46+hVUK+zRPzAahDJ7G0TApvbNkuy5wx7aoUyEk++HHde0XuQnshXnt8jsddA=="],
 
@@ -1517,58 +1413,6 @@
     "jest-diff/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "vite/postcss/nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
-
-    "wrangler/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.1", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ=="],
-
-    "wrangler/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.28.1", "", { "os": "android", "cpu": "arm" }, "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ=="],
-
-    "wrangler/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.28.1", "", { "os": "android", "cpu": "arm64" }, "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg=="],
-
-    "wrangler/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.28.1", "", { "os": "android", "cpu": "x64" }, "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng=="],
-
-    "wrangler/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.28.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q=="],
-
-    "wrangler/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.28.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ=="],
-
-    "wrangler/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.28.1", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw=="],
-
-    "wrangler/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.28.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ=="],
-
-    "wrangler/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.28.1", "", { "os": "linux", "cpu": "arm" }, "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ=="],
-
-    "wrangler/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.28.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g=="],
-
-    "wrangler/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.28.1", "", { "os": "linux", "cpu": "ia32" }, "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w=="],
-
-    "wrangler/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg=="],
-
-    "wrangler/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ=="],
-
-    "wrangler/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.28.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ=="],
-
-    "wrangler/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ=="],
-
-    "wrangler/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.28.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag=="],
-
-    "wrangler/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.28.1", "", { "os": "linux", "cpu": "x64" }, "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA=="],
-
-    "wrangler/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw=="],
-
-    "wrangler/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.28.1", "", { "os": "none", "cpu": "x64" }, "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg=="],
-
-    "wrangler/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.28.1", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q=="],
-
-    "wrangler/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.28.1", "", { "os": "openbsd", "cpu": "x64" }, "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw=="],
-
-    "wrangler/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg=="],
-
-    "wrangler/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.28.1", "", { "os": "sunos", "cpu": "x64" }, "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ=="],
-
-    "wrangler/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.28.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA=="],
-
-    "wrangler/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg=="],
-
-    "wrangler/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A=="],
 
     "ansi-align/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
   }

--- a/bun.lock
+++ b/bun.lock
@@ -54,6 +54,7 @@
       "name": "@leyabierta/web",
       "version": "0.1.0",
       "dependencies": {
+        "@astrojs/cloudflare": "^14.1.3",
         "@astrojs/react": "^5.0.3",
         "@lottiefiles/dotlottie-react": "^0.19.2",
         "astro": "6.1.9",
@@ -91,9 +92,11 @@
 
     "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.23", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg=="],
 
+    "@astrojs/cloudflare": ["@astrojs/cloudflare@14.1.3", "", { "dependencies": { "@astrojs/internal-helpers": "0.10.1", "@astrojs/underscore-redirects": "1.0.3", "@cloudflare/vite-plugin": "^1.39.0", "piccolore": "^0.1.3", "vite": "^8.0.13" }, "peerDependencies": { "astro": "^7.0.0", "wrangler": "^4.83.0" } }, "sha512-idZndLb/cm64JNayPepaM0Ews971KviYPIcj/xB7Pwp2RKvBjs3MePjZLE50n6EoggeWag3iAMYpAuEKs+3o5g=="],
+
     "@astrojs/compiler": ["@astrojs/compiler@3.0.1", "", {}, "sha512-z97oYbdebO5aoWzuJ/8q5hLK232+17KcLZ7cJ8BCWk6+qNzVxn/gftC0KzMBUTD8WAaBkPpNSQK6PXLnNrZ0CA=="],
 
-    "@astrojs/internal-helpers": ["@astrojs/internal-helpers@0.9.0", "", { "dependencies": { "picomatch": "^4.0.4" } }, "sha512-GdYkzR26re8izmyYlBqf4z2s7zNngmWLFuxw0UKiPNqHraZGS6GKWIwSHgS22RDlu2ePFJ8bzmpBcUszut/SDg=="],
+    "@astrojs/internal-helpers": ["@astrojs/internal-helpers@0.10.1", "", { "dependencies": { "@types/hast": "^3.0.4", "@types/mdast": "^4.0.4", "js-yaml": "^4.1.1", "picomatch": "^4.0.4", "retext-smartypants": "^6.2.0", "shiki": "^4.0.2", "smol-toml": "^1.6.0", "unified": "^11.0.5" } }, "sha512-5phcroT/vmOOrYuuAxtkbPixy5hePtlz9i8K4OeDv3dNK6/UQRuXPOSRTxIOBbUY5Sonw2UaxjbuVc43Mcir6Q=="],
 
     "@astrojs/markdown-remark": ["@astrojs/markdown-remark@7.1.1", "", { "dependencies": { "@astrojs/internal-helpers": "0.9.0", "@astrojs/prism": "4.0.1", "github-slugger": "^2.0.0", "hast-util-from-html": "^2.0.3", "hast-util-to-text": "^4.0.2", "js-yaml": "^4.1.1", "mdast-util-definitions": "^6.0.0", "rehype-raw": "^7.0.0", "rehype-stringify": "^10.0.1", "remark-gfm": "^4.0.1", "remark-parse": "^11.0.0", "remark-rehype": "^11.1.2", "remark-smartypants": "^3.0.2", "retext-smartypants": "^6.2.0", "shiki": "^4.0.0", "smol-toml": "^1.6.0", "unified": "^11.0.5", "unist-util-remove-position": "^5.0.0", "unist-util-visit": "^5.1.0", "unist-util-visit-parents": "^6.0.2", "vfile": "^6.0.3" } }, "sha512-C6e9BnLGlbdv6bV8MYGeHpHxsUHrCrB4OuRLqi5LI7oiBVcBcqfUN06zpwFQdHgV48QCCrMmLpyqBr7VqC+swA=="],
 
@@ -102,6 +105,8 @@
     "@astrojs/react": ["@astrojs/react@5.0.4", "", { "dependencies": { "@astrojs/internal-helpers": "0.9.0", "@vitejs/plugin-react": "^5.2.0", "devalue": "^5.6.4", "ultrahtml": "^1.6.0", "vite": "^7.3.2" }, "peerDependencies": { "@types/react": "^17.0.50 || ^18.0.21 || ^19.0.0", "@types/react-dom": "^17.0.17 || ^18.0.6 || ^19.0.0", "react": "^17.0.2 || ^18.0.0 || ^19.0.0", "react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0" } }, "sha512-yDNE4VnKOzCjH9dCBi7pT4F6kpI3M9TkS+uxnCB0sGIS6t5vKonOY+Hs/UUnSajJGT5jeBRfpI9IQp+r/n1fBA=="],
 
     "@astrojs/telemetry": ["@astrojs/telemetry@3.3.1", "", { "dependencies": { "ci-info": "^4.4.0", "dlv": "^1.1.3", "dset": "^3.1.4", "is-docker": "^4.0.0", "is-wsl": "^3.1.1", "which-pm-runs": "^1.1.0" } }, "sha512-7fcIxXS9J4ls5tr8b3ww9rbAIz2+HrhNJYZdkAhhB4za/I5IZ/60g+Bs8q7zwG0tOIZfNB4JWhVJ1Qkl/OrNCw=="],
+
+    "@astrojs/underscore-redirects": ["@astrojs/underscore-redirects@1.0.3", "", {}, "sha512-cxnGSw+sJigBLdX4TMSZKkzV6C3gMLJMucDk2W+n281Xhie68T2/9f1+1NMNDCZsc5i0FED7Qt5I10g2O9wtZg=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
@@ -167,11 +172,33 @@
 
     "@clack/prompts": ["@clack/prompts@1.1.0", "", { "dependencies": { "@clack/core": "1.1.0", "sisteransi": "^1.0.5" } }, "sha512-pkqbPGtohJAvm4Dphs2M8xE29ggupihHdy1x84HNojZuMtFsHiUlRvqD24tM2+XmI+61LlfNceM3Wr7U5QES5g=="],
 
+    "@cloudflare/kv-asset-handler": ["@cloudflare/kv-asset-handler@0.5.0", "", {}, "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg=="],
+
+    "@cloudflare/unenv-preset": ["@cloudflare/unenv-preset@2.16.1", "", { "peerDependencies": { "unenv": "2.0.0-rc.24", "workerd": ">1.20260305.0 <2.0.0-0" }, "optionalPeers": ["workerd"] }, "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw=="],
+
+    "@cloudflare/vite-plugin": ["@cloudflare/vite-plugin@1.45.1", "", { "dependencies": { "@cloudflare/unenv-preset": "2.16.1", "miniflare": "4.20260714.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260714.1", "wrangler": "4.112.0", "ws": "8.21.0" }, "peerDependencies": { "vite": "^6.1.0 || ^7.0.0 || ^8.0.0" }, "bin": { "cf-vite": "bin/cf-vite" } }, "sha512-C+iDpO9pVH7IqrjdYtUV+obcTAdpiNk0OSinGEZZyd2ZWyGVjGk7iJ2p3xpMBpZuTa1I4hfAECNp0yN/8f3PIQ=="],
+
+    "@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260714.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-ZWXqAN8G7Cx9hMRQuk+59ziJhR3j1F4iO+Qs8aHdfKZ3Dq5Yi/57xvkJTgCGBnW1YU/L78r8f6HEy51bwbTpNw=="],
+
+    "@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260714.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-tueWxWC3wyCbMG6zRAxsMXX0YLgrRWbiAPYFQ2uJ7dUH8G+5E7UTWaQS9B1HdJ0bpKFW1NWxhs1o2noKVFSUYg=="],
+
+    "@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260714.1", "", { "os": "linux", "cpu": "x64" }, "sha512-1VChTZRb0l0F7R4e1G5RtLKV4oFi6x+rQgxh2+yu887j3l/3TLgatuv1L8/5zhc9gKEhATTxOh0e52Rtd9dDWQ=="],
+
+    "@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260714.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-rMm3G+NirG2UdgHIRDdF1asNC6FqgIzZzkRG+VDhhDGcVxAQwvrMT1E38BivEvHr3G04MB4AfhcOczX0+GtRkQ=="],
+
+    "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260714.1", "", { "os": "win32", "cpu": "x64" }, "sha512-cGqnU3Hg2YZS/k3SAqrMp1DjpdsyFde72tWltdl6ZT9+SFz/Zrk/8gyTU1TcxC4YApXeNVH5TyU5cOGPgUJ0pg=="],
+
+    "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
+
     "@elysiajs/cors": ["@elysiajs/cors@1.4.1", "", { "peerDependencies": { "elysia": ">= 1.4.0" } }, "sha512-lQfad+F3r4mNwsxRKbXyJB8Jg43oAOXjRwn7sKUL6bcOW3KjUqUimTS+woNpO97efpzjtDE0tEjGk9DTw8lqTQ=="],
 
     "@elysiajs/swagger": ["@elysiajs/swagger@1.3.1", "", { "dependencies": { "@scalar/themes": "^0.9.52", "@scalar/types": "^0.0.12", "openapi-types": "^12.1.3", "pathe": "^1.1.2" }, "peerDependencies": { "elysia": ">= 1.3.0" } }, "sha512-LcbLHa0zE6FJKWPWKsIC/f+62wbDv3aXydqcNPVPyqNcaUgwvCajIi+5kHEU6GO3oXUCpzKaMsb3gsjt8sLzFQ=="],
 
+    "@emnapi/core": ["@emnapi/core@1.11.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],
+
     "@emnapi/runtime": ["@emnapi/runtime@1.9.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA=="],
+
+    "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA=="],
 
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.4", "", { "os": "aix", "cpu": "ppc64" }, "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q=="],
 
@@ -285,7 +312,7 @@
 
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
-    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
 
     "@leyabierta/api": ["@leyabierta/api@workspace:packages/api"],
 
@@ -321,11 +348,21 @@
 
     "@napi-rs/canvas-win32-x64-msvc": ["@napi-rs/canvas-win32-x64-msvc@0.1.80", "", { "os": "win32", "cpu": "x64" }, "sha512-Z8jPsM6df5V8B1HrCHB05+bDiCxjE9QA//3YrkKIdVDEwn5RKaqOxCJDRJkl48cJbylcrJbW4HxZbTte8juuPg=="],
 
+    "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
+
     "@nodable/entities": ["@nodable/entities@2.1.0", "", {}, "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 
     "@oslojs/encoding": ["@oslojs/encoding@1.1.0", "", {}, "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ=="],
+
+    "@oxc-project/types": ["@oxc-project/types@0.139.0", "", {}, "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw=="],
+
+    "@poppinss/colors": ["@poppinss/colors@4.1.6", "", { "dependencies": { "kleur": "^4.1.5" } }, "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg=="],
+
+    "@poppinss/dumper": ["@poppinss/dumper@0.6.5", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@sindresorhus/is": "^7.0.2", "supports-color": "^10.0.0" } }, "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw=="],
+
+    "@poppinss/exception": ["@poppinss/exception@1.2.3", "", {}, "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw=="],
 
     "@profoundlogic/hogan": ["@profoundlogic/hogan@3.0.4", "", { "dependencies": { "nopt": "1.0.10" }, "bin": { "hulk": "bin/hulk" } }, "sha512-pmNVGuooS30Mm7YbZd5T7E5zYVO6D5Ct91sn4T39mUvMUc3sCGridcnhAufL1/Bz2QzAtzEn0agNrdk3+5yWzw=="],
 
@@ -354,6 +391,36 @@
     "@resvg/resvg-js-win32-ia32-msvc": ["@resvg/resvg-js-win32-ia32-msvc@2.6.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-har4aPAlvjnLcil40AC77YDIk6loMawuJwFINEM7n0pZviwMkMvjb2W5ZirsNOZY4aDbo5tLx0wNMREp5Brk+w=="],
 
     "@resvg/resvg-js-win32-x64-msvc": ["@resvg/resvg-js-win32-x64-msvc@2.6.2", "", { "os": "win32", "cpu": "x64" }, "sha512-ZXtYhtUr5SSaBrUDq7DiyjOFJqBVL/dOBN7N/qmi/pO0IgiWW/f/ue3nbvu9joWE5aAKDoIzy/CxsY0suwGosQ=="],
+
+    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.1.5", "", { "os": "android", "cpu": "arm64" }, "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ=="],
+
+    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.1.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw=="],
+
+    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.1.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g=="],
+
+    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.1.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA=="],
+
+    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.1.5", "", { "os": "linux", "cpu": "arm" }, "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw=="],
+
+    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.1.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q=="],
+
+    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.1.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA=="],
+
+    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.1.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg=="],
+
+    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.1.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA=="],
+
+    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.1.5", "", { "os": "linux", "cpu": "x64" }, "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ=="],
+
+    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.1.5", "", { "os": "linux", "cpu": "x64" }, "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg=="],
+
+    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.1.5", "", { "os": "none", "cpu": "arm64" }, "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw=="],
+
+    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.1.5", "", { "dependencies": { "@emnapi/core": "1.11.1", "@emnapi/runtime": "1.11.1", "@napi-rs/wasm-runtime": "^1.1.6" }, "cpu": "none" }, "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA=="],
+
+    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.1.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw=="],
+
+    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.1.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA=="],
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.3", "", {}, "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q=="],
 
@@ -435,6 +502,10 @@
 
     "@sinclair/typebox": ["@sinclair/typebox@0.34.49", "", {}, "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A=="],
 
+    "@sindresorhus/is": ["@sindresorhus/is@7.2.0", "", {}, "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw=="],
+
+    "@speed-highlight/core": ["@speed-highlight/core@1.2.17", "", {}, "sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg=="],
+
     "@stablelib/base64": ["@stablelib/base64@1.0.1", "", {}, "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
@@ -442,6 +513,8 @@
     "@tokenizer/inflate": ["@tokenizer/inflate@0.4.1", "", { "dependencies": { "debug": "^4.4.3", "token-types": "^6.1.1" } }, "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA=="],
 
     "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
+
+    "@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
 
     "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
 
@@ -546,6 +619,8 @@
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.21", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-Q+rUQ7Uz8AHM7DEaNdwvfFCTq7a43lNTzuS94eiWqwyxfV/wJv+oUivef51T91mmRY4d4A1u9rcSvkeufCVXlA=="],
 
     "bignumber.js": ["bignumber.js@9.3.1", "", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
+
+    "blake3-wasm": ["blake3-wasm@2.1.5", "", {}, "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g=="],
 
     "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
 
@@ -686,6 +761,8 @@
     "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "environment": ["environment@1.1.0", "", {}, "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="],
+
+    "error-stack-parser-es": ["error-stack-parser-es@1.0.5", "", {}, "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA=="],
 
     "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
 
@@ -869,6 +946,32 @@
 
     "kind-of": ["kind-of@6.0.3", "", {}, "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="],
 
+    "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
+
+    "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
+
+    "lightningcss-android-arm64": ["lightningcss-android-arm64@1.32.0", "", { "os": "android", "cpu": "arm64" }, "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg=="],
+
+    "lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.32.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ=="],
+
+    "lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.32.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w=="],
+
+    "lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.32.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig=="],
+
+    "lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.32.0", "", { "os": "linux", "cpu": "arm" }, "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw=="],
+
+    "lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ=="],
+
+    "lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg=="],
+
+    "lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA=="],
+
+    "lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg=="],
+
+    "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.32.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw=="],
+
+    "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
+
     "linebreak": ["linebreak@1.1.0", "", { "dependencies": { "base64-js": "0.0.8", "unicode-trie": "^2.0.0" } }, "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ=="],
 
     "linkify-it": ["linkify-it@5.0.0", "", { "dependencies": { "uc.micro": "^2.0.0" } }, "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ=="],
@@ -979,6 +1082,8 @@
 
     "mimic-function": ["mimic-function@5.0.1", "", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
 
+    "miniflare": ["miniflare@4.20260714.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "0.34.5", "undici": "7.28.0", "workerd": "1.20260714.1", "ws": "8.21.0", "youch": "4.1.0-beta.10" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-MYlTCLdWCPqvrYY2uLwOjXwmglXuiHE3TGGkbOW4BwjUPa1r07E0iuHwrNDIs/sxK21r+o90Jx58AV2KeNdJZw=="],
+
     "mrmime": ["mrmime@2.0.1", "", {}, "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
@@ -1048,6 +1153,8 @@
     "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
     "path-expression-matcher": ["path-expression-matcher@1.5.0", "", {}, "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ=="],
+
+    "path-to-regexp": ["path-to-regexp@6.3.0", "", {}, "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="],
 
     "pathe": ["pathe@1.1.2", "", {}, "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="],
 
@@ -1128,6 +1235,8 @@
     "retext-smartypants": ["retext-smartypants@6.2.0", "", { "dependencies": { "@types/nlcst": "^2.0.0", "nlcst-to-string": "^4.0.0", "unist-util-visit": "^5.0.0" } }, "sha512-kk0jOU7+zGv//kfjXEBjdIryL1Acl4i9XNkHxtM7Tm5lFiCog576fjNC9hjoR7LTKQ0DsPWy09JummSsH1uqfQ=="],
 
     "retext-stringify": ["retext-stringify@4.0.0", "", { "dependencies": { "@types/nlcst": "^2.0.0", "nlcst-to-string": "^4.0.0", "unified": "^11.0.0" } }, "sha512-rtfN/0o8kL1e+78+uxPTqu1Klt0yPzKuQ2BfWwwfgIUSayyzxpM1PJzkKt4V8803uB9qSy32MvI7Xep9khTpiA=="],
+
+    "rolldown": ["rolldown@1.1.5", "", { "dependencies": { "@oxc-project/types": "=0.139.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.1.5", "@rolldown/binding-darwin-arm64": "1.1.5", "@rolldown/binding-darwin-x64": "1.1.5", "@rolldown/binding-freebsd-x64": "1.1.5", "@rolldown/binding-linux-arm-gnueabihf": "1.1.5", "@rolldown/binding-linux-arm64-gnu": "1.1.5", "@rolldown/binding-linux-arm64-musl": "1.1.5", "@rolldown/binding-linux-ppc64-gnu": "1.1.5", "@rolldown/binding-linux-s390x-gnu": "1.1.5", "@rolldown/binding-linux-x64-gnu": "1.1.5", "@rolldown/binding-linux-x64-musl": "1.1.5", "@rolldown/binding-openharmony-arm64": "1.1.5", "@rolldown/binding-wasm32-wasi": "1.1.5", "@rolldown/binding-win32-arm64-msvc": "1.1.5", "@rolldown/binding-win32-x64-msvc": "1.1.5" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA=="],
 
     "rollup": ["rollup@4.60.0", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.0", "@rollup/rollup-android-arm64": "4.60.0", "@rollup/rollup-darwin-arm64": "4.60.0", "@rollup/rollup-darwin-x64": "4.60.0", "@rollup/rollup-freebsd-arm64": "4.60.0", "@rollup/rollup-freebsd-x64": "4.60.0", "@rollup/rollup-linux-arm-gnueabihf": "4.60.0", "@rollup/rollup-linux-arm-musleabihf": "4.60.0", "@rollup/rollup-linux-arm64-gnu": "4.60.0", "@rollup/rollup-linux-arm64-musl": "4.60.0", "@rollup/rollup-linux-loong64-gnu": "4.60.0", "@rollup/rollup-linux-loong64-musl": "4.60.0", "@rollup/rollup-linux-ppc64-gnu": "4.60.0", "@rollup/rollup-linux-ppc64-musl": "4.60.0", "@rollup/rollup-linux-riscv64-gnu": "4.60.0", "@rollup/rollup-linux-riscv64-musl": "4.60.0", "@rollup/rollup-linux-s390x-gnu": "4.60.0", "@rollup/rollup-linux-x64-gnu": "4.60.0", "@rollup/rollup-linux-x64-musl": "4.60.0", "@rollup/rollup-openbsd-x64": "4.60.0", "@rollup/rollup-openharmony-arm64": "4.60.0", "@rollup/rollup-win32-arm64-msvc": "4.60.0", "@rollup/rollup-win32-ia32-msvc": "4.60.0", "@rollup/rollup-win32-x64-gnu": "4.60.0", "@rollup/rollup-win32-x64-msvc": "4.60.0", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ=="],
 
@@ -1229,7 +1338,11 @@
 
     "uncrypto": ["uncrypto@0.1.3", "", {}, "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q=="],
 
+    "undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
+
     "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+
+    "unenv": ["unenv@2.0.0-rc.24", "", { "dependencies": { "pathe": "^2.0.3" } }, "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw=="],
 
     "unicode-trie": ["unicode-trie@2.0.0", "", { "dependencies": { "pako": "^0.2.5", "tiny-inflate": "^1.0.0" } }, "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ=="],
 
@@ -1271,7 +1384,7 @@
 
     "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
 
-    "vite": ["vite@7.3.2", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg=="],
+    "vite": ["vite@8.1.5", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.5", "postcss": "^8.5.17", "rolldown": "~1.1.5", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.3.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw=="],
 
     "vitefu": ["vitefu@1.1.2", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-beta.0" }, "optionalPeers": ["vite"] }, "sha512-zpKATdUbzbsycPFBN71nS2uzBUQiVnFoOrr2rvqv34S1lcAgMKKkjWleLGeiJlZ8lwCXvtWaRn7R3ZC16SYRuw=="],
 
@@ -1283,7 +1396,13 @@
 
     "widest-line": ["widest-line@5.0.0", "", { "dependencies": { "string-width": "^7.0.0" } }, "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA=="],
 
+    "workerd": ["workerd@1.20260714.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260714.1", "@cloudflare/workerd-darwin-arm64": "1.20260714.1", "@cloudflare/workerd-linux-64": "1.20260714.1", "@cloudflare/workerd-linux-arm64": "1.20260714.1", "@cloudflare/workerd-windows-64": "1.20260714.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-oIbQzfdyl9UQUnG6XLegcSq0Mgt/7WKDbFOoqGgOWCS+/fhyGB460uKEgdAQQ9RHCO/ttcNCX/KiMIQzdoeu3Q=="],
+
+    "wrangler": ["wrangler@4.112.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.5.0", "@cloudflare/unenv-preset": "2.16.1", "blake3-wasm": "2.1.5", "esbuild": "0.28.1", "miniflare": "4.20260714.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260714.1" }, "optionalDependencies": { "fsevents": "2.3.3" }, "peerDependencies": { "@cloudflare/workers-types": "^5.20260714.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "cf-wrangler": "bin/cf-wrangler.js", "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-5H+XUD0TySCv1LuktFHDIEOkboH2nTfQs+35L+USt3MtntjDTMVIJprLgQcL2WBjulOyjxpd1vyTiSTJVW5MjQ=="],
+
     "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
+
+    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
     "xxhash-wasm": ["xxhash-wasm@1.1.0", "", {}, "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA=="],
 
@@ -1295,13 +1414,27 @@
 
     "yoga-layout": ["yoga-layout@3.2.1", "", {}, "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="],
 
+    "youch": ["youch@4.1.0-beta.10", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@poppinss/dumper": "^0.6.4", "@speed-highlight/core": "^1.2.7", "cookie": "^1.0.2", "youch-core": "^0.3.3" } }, "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ=="],
+
+    "youch-core": ["youch-core@0.3.3", "", { "dependencies": { "@poppinss/exception": "^1.2.2", "error-stack-parser-es": "^1.0.5" } }, "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA=="],
+
     "zhead": ["zhead@2.2.4", "", {}, "sha512-8F0OI5dpWIA5IGG5NHUg9staDwz/ZPxZtvGVf01j7vHqSyZ0raHY+78atOVxRqb73AotX22uV1pXt3gYSstGag=="],
 
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
+    "@astrojs/internal-helpers/picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
+
+    "@astrojs/markdown-remark/@astrojs/internal-helpers": ["@astrojs/internal-helpers@0.9.0", "", { "dependencies": { "picomatch": "^4.0.4" } }, "sha512-GdYkzR26re8izmyYlBqf4z2s7zNngmWLFuxw0UKiPNqHraZGS6GKWIwSHgS22RDlu2ePFJ8bzmpBcUszut/SDg=="],
+
+    "@astrojs/react/@astrojs/internal-helpers": ["@astrojs/internal-helpers@0.9.0", "", { "dependencies": { "picomatch": "^4.0.4" } }, "sha512-GdYkzR26re8izmyYlBqf4z2s7zNngmWLFuxw0UKiPNqHraZGS6GKWIwSHgS22RDlu2ePFJ8bzmpBcUszut/SDg=="],
+
+    "@astrojs/react/vite": ["vite@7.3.2", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg=="],
+
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "@babel/generator/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
     "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
@@ -1309,11 +1442,23 @@
 
     "@jest/schemas/@sinclair/typebox": ["@sinclair/typebox@0.27.10", "", {}, "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA=="],
 
+    "@jridgewell/gen-mapping/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@jridgewell/remapping/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@poppinss/dumper/supports-color": ["supports-color@10.2.2", "", {}, "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g=="],
+
+    "@rolldown/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
+
     "@scalar/themes/@scalar/types": ["@scalar/types@0.1.7", "", { "dependencies": { "@scalar/openapi-types": "0.2.0", "@unhead/schema": "^1.11.11", "nanoid": "^5.1.5", "type-fest": "^4.20.0", "zod": "^3.23.8" } }, "sha512-irIDYzTQG2KLvFbuTI8k2Pz/R4JR+zUUSykVTbEMatkzMmVFnn1VzNSMlODbadycwZunbnL2tA27AXed9URVjw=="],
 
     "ansi-align/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "anymatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
+
+    "astro/@astrojs/internal-helpers": ["@astrojs/internal-helpers@0.9.0", "", { "dependencies": { "picomatch": "^4.0.4" } }, "sha512-GdYkzR26re8izmyYlBqf4z2s7zNngmWLFuxw0UKiPNqHraZGS6GKWIwSHgS22RDlu2ePFJ8bzmpBcUszut/SDg=="],
+
+    "astro/vite": ["vite@7.3.2", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg=="],
 
     "astro/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
@@ -1339,9 +1484,21 @@
 
     "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
+    "rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.1", "", {}, "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="],
+
     "svgo/commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
 
     "svix/uuid": ["uuid@10.0.0", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="],
+
+    "unenv/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "vite/picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
+
+    "vite/postcss": ["postcss@8.5.19", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ=="],
+
+    "vite/tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
+
+    "wrangler/esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
 
     "@scalar/themes/@scalar/types/@scalar/openapi-types": ["@scalar/openapi-types@0.2.0", "", { "dependencies": { "zod": "^3.23.8" } }, "sha512-waiKk12cRCqyUCWTOX0K1WEVX46+hVUK+zRPzAahDJ7G0TApvbNkuy5wx7aoUyEk++HHde0XuQnshXnt8jsddA=="],
 
@@ -1358,6 +1515,60 @@
     "gray-matter/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
     "jest-diff/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "vite/postcss/nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
+
+    "wrangler/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.1", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ=="],
+
+    "wrangler/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.28.1", "", { "os": "android", "cpu": "arm" }, "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ=="],
+
+    "wrangler/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.28.1", "", { "os": "android", "cpu": "arm64" }, "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg=="],
+
+    "wrangler/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.28.1", "", { "os": "android", "cpu": "x64" }, "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng=="],
+
+    "wrangler/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.28.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q=="],
+
+    "wrangler/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.28.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ=="],
+
+    "wrangler/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.28.1", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw=="],
+
+    "wrangler/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.28.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ=="],
+
+    "wrangler/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.28.1", "", { "os": "linux", "cpu": "arm" }, "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ=="],
+
+    "wrangler/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.28.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g=="],
+
+    "wrangler/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.28.1", "", { "os": "linux", "cpu": "ia32" }, "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w=="],
+
+    "wrangler/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg=="],
+
+    "wrangler/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ=="],
+
+    "wrangler/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.28.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ=="],
+
+    "wrangler/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ=="],
+
+    "wrangler/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.28.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag=="],
+
+    "wrangler/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.28.1", "", { "os": "linux", "cpu": "x64" }, "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA=="],
+
+    "wrangler/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw=="],
+
+    "wrangler/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.28.1", "", { "os": "none", "cpu": "x64" }, "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg=="],
+
+    "wrangler/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.28.1", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q=="],
+
+    "wrangler/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.28.1", "", { "os": "openbsd", "cpu": "x64" }, "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw=="],
+
+    "wrangler/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg=="],
+
+    "wrangler/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.28.1", "", { "os": "sunos", "cpu": "x64" }, "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ=="],
+
+    "wrangler/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.28.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA=="],
+
+    "wrangler/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg=="],
+
+    "wrangler/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A=="],
 
     "ansi-align/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
   }

--- a/bun.lock
+++ b/bun.lock
@@ -54,7 +54,6 @@
       "name": "@leyabierta/web",
       "version": "0.1.0",
       "dependencies": {
-        "@astrojs/cloudflare": "^14.1.3",
         "@astrojs/react": "^6.0.1",
         "@lottiefiles/dotlottie-react": "^0.19.2",
         "astro": "^7.1.1",
@@ -67,6 +66,7 @@
         "zod": "^4.4.3",
       },
       "devDependencies": {
+        "@cloudflare/workers-types": "^5.20260718.1",
         "@types/markdown-it": "^14.1.2",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -91,8 +91,6 @@
     "@ai-sdk/provider": ["@ai-sdk/provider@3.0.8", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ=="],
 
     "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.23", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg=="],
-
-    "@astrojs/cloudflare": ["@astrojs/cloudflare@14.1.3", "", { "dependencies": { "@astrojs/internal-helpers": "0.10.1", "@astrojs/underscore-redirects": "1.0.3", "@cloudflare/vite-plugin": "^1.39.0", "piccolore": "^0.1.3", "vite": "^8.0.13" }, "peerDependencies": { "astro": "^7.0.0", "wrangler": "^4.83.0" } }, "sha512-idZndLb/cm64JNayPepaM0Ews971KviYPIcj/xB7Pwp2RKvBjs3MePjZLE50n6EoggeWag3iAMYpAuEKs+3o5g=="],
 
     "@astrojs/compiler-binding": ["@astrojs/compiler-binding@0.3.1", "", { "optionalDependencies": { "@astrojs/compiler-binding-darwin-arm64": "0.3.1", "@astrojs/compiler-binding-darwin-x64": "0.3.1", "@astrojs/compiler-binding-linux-arm64-gnu": "0.3.1", "@astrojs/compiler-binding-linux-arm64-musl": "0.3.1", "@astrojs/compiler-binding-linux-x64-gnu": "0.3.1", "@astrojs/compiler-binding-linux-x64-musl": "0.3.1", "@astrojs/compiler-binding-wasm32-wasi": "0.3.1", "@astrojs/compiler-binding-win32-arm64-msvc": "0.3.1", "@astrojs/compiler-binding-win32-x64-msvc": "0.3.1" } }, "sha512-DaAUj29AIBU2XdJ8uwcab8lW5O2pk9pY8AXkcMw0sw77nVa3oeTYRcO+Dvbbpoexf6ThMc0FMWYCQ/wN1/T7oQ=="],
 
@@ -125,8 +123,6 @@
     "@astrojs/react": ["@astrojs/react@6.0.1", "", { "dependencies": { "@astrojs/internal-helpers": "0.10.1", "@vitejs/plugin-react": "^5.2.0", "devalue": "^5.8.1", "ultrahtml": "^1.6.0", "vite": "^8.0.13" }, "peerDependencies": { "@types/react": "^17.0.50 || ^18.0.21 || ^19.0.0", "@types/react-dom": "^17.0.17 || ^18.0.6 || ^19.0.0", "react": "^17.0.2 || ^18.0.0 || ^19.0.0", "react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0" } }, "sha512-Afs1sEm72P2plDnrOGxmIteJ7bjx/VqxlcaQLNip5eHJ5tIvKUORQetC9UKcvgwKnj51t60HWl5mOANkOsWs4w=="],
 
     "@astrojs/telemetry": ["@astrojs/telemetry@3.3.3", "", { "dependencies": { "ci-info": "^4.4.0", "dset": "^3.1.4", "is-docker": "^4.0.0", "package-manager-detector": "^1.6.0" } }, "sha512-C1TLn5sPJr0x4vk56piHWKbnqlEB8BKyte5Y45V02U+D7BGO5eMqZDH5aPjnkXQWJggvmsTXxH03QMZ9NgWLzQ=="],
-
-    "@astrojs/underscore-redirects": ["@astrojs/underscore-redirects@1.0.3", "", {}, "sha512-cxnGSw+sJigBLdX4TMSZKkzV6C3gMLJMucDk2W+n281Xhie68T2/9f1+1NMNDCZsc5i0FED7Qt5I10g2O9wtZg=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
@@ -210,23 +206,7 @@
 
     "@clack/prompts": ["@clack/prompts@1.1.0", "", { "dependencies": { "@clack/core": "1.1.0", "sisteransi": "^1.0.5" } }, "sha512-pkqbPGtohJAvm4Dphs2M8xE29ggupihHdy1x84HNojZuMtFsHiUlRvqD24tM2+XmI+61LlfNceM3Wr7U5QES5g=="],
 
-    "@cloudflare/kv-asset-handler": ["@cloudflare/kv-asset-handler@0.5.0", "", {}, "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg=="],
-
-    "@cloudflare/unenv-preset": ["@cloudflare/unenv-preset@2.16.1", "", { "peerDependencies": { "unenv": "2.0.0-rc.24", "workerd": ">1.20260305.0 <2.0.0-0" }, "optionalPeers": ["workerd"] }, "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw=="],
-
-    "@cloudflare/vite-plugin": ["@cloudflare/vite-plugin@1.45.1", "", { "dependencies": { "@cloudflare/unenv-preset": "2.16.1", "miniflare": "4.20260714.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260714.1", "wrangler": "4.112.0", "ws": "8.21.0" }, "peerDependencies": { "vite": "^6.1.0 || ^7.0.0 || ^8.0.0" }, "bin": { "cf-vite": "bin/cf-vite" } }, "sha512-C+iDpO9pVH7IqrjdYtUV+obcTAdpiNk0OSinGEZZyd2ZWyGVjGk7iJ2p3xpMBpZuTa1I4hfAECNp0yN/8f3PIQ=="],
-
-    "@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260714.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-ZWXqAN8G7Cx9hMRQuk+59ziJhR3j1F4iO+Qs8aHdfKZ3Dq5Yi/57xvkJTgCGBnW1YU/L78r8f6HEy51bwbTpNw=="],
-
-    "@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260714.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-tueWxWC3wyCbMG6zRAxsMXX0YLgrRWbiAPYFQ2uJ7dUH8G+5E7UTWaQS9B1HdJ0bpKFW1NWxhs1o2noKVFSUYg=="],
-
-    "@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260714.1", "", { "os": "linux", "cpu": "x64" }, "sha512-1VChTZRb0l0F7R4e1G5RtLKV4oFi6x+rQgxh2+yu887j3l/3TLgatuv1L8/5zhc9gKEhATTxOh0e52Rtd9dDWQ=="],
-
-    "@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260714.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-rMm3G+NirG2UdgHIRDdF1asNC6FqgIzZzkRG+VDhhDGcVxAQwvrMT1E38BivEvHr3G04MB4AfhcOczX0+GtRkQ=="],
-
-    "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260714.1", "", { "os": "win32", "cpu": "x64" }, "sha512-cGqnU3Hg2YZS/k3SAqrMp1DjpdsyFde72tWltdl6ZT9+SFz/Zrk/8gyTU1TcxC4YApXeNVH5TyU5cOGPgUJ0pg=="],
-
-    "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260718.1", "", {}, "sha512-PSeVPF0ZPsqv7snSwiywQX/c4jNDSXClOvFwxWoVysoltQEr6oPnOh7oRh1GoAUnVxkzzrqXbsPRTxzb3LIbag=="],
 
     "@elysiajs/cors": ["@elysiajs/cors@1.4.1", "", { "peerDependencies": { "elysia": ">= 1.4.0" } }, "sha512-lQfad+F3r4mNwsxRKbXyJB8Jg43oAOXjRwn7sKUL6bcOW3KjUqUimTS+woNpO97efpzjtDE0tEjGk9DTw8lqTQ=="],
 
@@ -350,7 +330,7 @@
 
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
-    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
     "@leyabierta/api": ["@leyabierta/api@workspace:packages/api"],
 
@@ -395,12 +375,6 @@
     "@oslojs/encoding": ["@oslojs/encoding@1.1.0", "", {}, "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.139.0", "", {}, "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw=="],
-
-    "@poppinss/colors": ["@poppinss/colors@4.1.6", "", { "dependencies": { "kleur": "^4.1.5" } }, "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg=="],
-
-    "@poppinss/dumper": ["@poppinss/dumper@0.6.5", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@sindresorhus/is": "^7.0.2", "supports-color": "^10.0.0" } }, "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw=="],
-
-    "@poppinss/exception": ["@poppinss/exception@1.2.3", "", {}, "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw=="],
 
     "@profoundlogic/hogan": ["@profoundlogic/hogan@3.0.4", "", { "dependencies": { "nopt": "1.0.10" }, "bin": { "hulk": "bin/hulk" } }, "sha512-pmNVGuooS30Mm7YbZd5T7E5zYVO6D5Ct91sn4T39mUvMUc3sCGridcnhAufL1/Bz2QzAtzEn0agNrdk3+5yWzw=="],
 
@@ -540,10 +514,6 @@
 
     "@sinclair/typebox": ["@sinclair/typebox@0.34.49", "", {}, "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A=="],
 
-    "@sindresorhus/is": ["@sindresorhus/is@7.2.0", "", {}, "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw=="],
-
-    "@speed-highlight/core": ["@speed-highlight/core@1.2.17", "", {}, "sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg=="],
-
     "@stablelib/base64": ["@stablelib/base64@1.0.1", "", {}, "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
@@ -655,8 +625,6 @@
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.21", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-Q+rUQ7Uz8AHM7DEaNdwvfFCTq7a43lNTzuS94eiWqwyxfV/wJv+oUivef51T91mmRY4d4A1u9rcSvkeufCVXlA=="],
 
     "bignumber.js": ["bignumber.js@9.3.1", "", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
-
-    "blake3-wasm": ["blake3-wasm@2.1.5", "", {}, "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g=="],
 
     "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
 
@@ -791,8 +759,6 @@
     "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "environment": ["environment@1.1.0", "", {}, "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="],
-
-    "error-stack-parser-es": ["error-stack-parser-es@1.0.5", "", {}, "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA=="],
 
     "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
 
@@ -968,8 +934,6 @@
 
     "kind-of": ["kind-of@6.0.3", "", {}, "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="],
 
-    "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
-
     "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 
     "lightningcss-android-arm64": ["lightningcss-android-arm64@1.32.0", "", { "os": "android", "cpu": "arm64" }, "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg=="],
@@ -1029,8 +993,6 @@
     "micromark-util-types": ["micromark-util-types@2.0.2", "", {}, "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="],
 
     "mimic-function": ["mimic-function@5.0.1", "", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
-
-    "miniflare": ["miniflare@4.20260714.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "0.34.5", "undici": "7.28.0", "workerd": "1.20260714.1", "ws": "8.21.0", "youch": "4.1.0-beta.10" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-MYlTCLdWCPqvrYY2uLwOjXwmglXuiHE3TGGkbOW4BwjUPa1r07E0iuHwrNDIs/sxK21r+o90Jx58AV2KeNdJZw=="],
 
     "mrmime": ["mrmime@2.0.1", "", {}, "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ=="],
 
@@ -1099,8 +1061,6 @@
     "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
     "path-expression-matcher": ["path-expression-matcher@1.5.0", "", {}, "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ=="],
-
-    "path-to-regexp": ["path-to-regexp@6.3.0", "", {}, "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="],
 
     "pathe": ["pathe@1.1.2", "", {}, "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="],
 
@@ -1264,11 +1224,7 @@
 
     "uncrypto": ["uncrypto@0.1.3", "", {}, "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q=="],
 
-    "undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
-
     "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
-
-    "unenv": ["unenv@2.0.0-rc.24", "", { "dependencies": { "pathe": "^2.0.3" } }, "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw=="],
 
     "unicode-trie": ["unicode-trie@2.0.0", "", { "dependencies": { "pako": "^0.2.5", "tiny-inflate": "^1.0.0" } }, "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ=="],
 
@@ -1312,13 +1268,7 @@
 
     "widest-line": ["widest-line@5.0.0", "", { "dependencies": { "string-width": "^7.0.0" } }, "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA=="],
 
-    "workerd": ["workerd@1.20260714.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260714.1", "@cloudflare/workerd-darwin-arm64": "1.20260714.1", "@cloudflare/workerd-linux-64": "1.20260714.1", "@cloudflare/workerd-linux-arm64": "1.20260714.1", "@cloudflare/workerd-windows-64": "1.20260714.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-oIbQzfdyl9UQUnG6XLegcSq0Mgt/7WKDbFOoqGgOWCS+/fhyGB460uKEgdAQQ9RHCO/ttcNCX/KiMIQzdoeu3Q=="],
-
-    "wrangler": ["wrangler@4.112.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.5.0", "@cloudflare/unenv-preset": "2.16.1", "blake3-wasm": "2.1.5", "esbuild": "0.28.1", "miniflare": "4.20260714.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260714.1" }, "optionalDependencies": { "fsevents": "2.3.3" }, "peerDependencies": { "@cloudflare/workers-types": "^5.20260714.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "cf-wrangler": "bin/cf-wrangler.js", "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-5H+XUD0TySCv1LuktFHDIEOkboH2nTfQs+35L+USt3MtntjDTMVIJprLgQcL2WBjulOyjxpd1vyTiSTJVW5MjQ=="],
-
     "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
-
-    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
     "xxhash-wasm": ["xxhash-wasm@1.1.0", "", {}, "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA=="],
 
@@ -1330,10 +1280,6 @@
 
     "yoga-layout": ["yoga-layout@3.2.1", "", {}, "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="],
 
-    "youch": ["youch@4.1.0-beta.10", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@poppinss/dumper": "^0.6.4", "@speed-highlight/core": "^1.2.7", "cookie": "^1.0.2", "youch-core": "^0.3.3" } }, "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ=="],
-
-    "youch-core": ["youch-core@0.3.3", "", { "dependencies": { "@poppinss/exception": "^1.2.2", "error-stack-parser-es": "^1.0.5" } }, "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA=="],
-
     "zhead": ["zhead@2.2.4", "", {}, "sha512-8F0OI5dpWIA5IGG5NHUg9staDwz/ZPxZtvGVf01j7vHqSyZ0raHY+78atOVxRqb73AotX22uV1pXt3gYSstGag=="],
 
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
@@ -1342,8 +1288,6 @@
 
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
-    "@babel/generator/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
-
     "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
     "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
@@ -1351,12 +1295,6 @@
     "@bruits/satteri-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
 
     "@jest/schemas/@sinclair/typebox": ["@sinclair/typebox@0.27.10", "", {}, "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA=="],
-
-    "@jridgewell/gen-mapping/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
-
-    "@jridgewell/remapping/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
-
-    "@poppinss/dumper/supports-color": ["supports-color@10.2.2", "", {}, "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g=="],
 
     "@rolldown/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
 
@@ -1391,8 +1329,6 @@
     "svgo/commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
 
     "svix/uuid": ["uuid@10.0.0", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="],
-
-    "unenv/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
     "vite/postcss": ["postcss@8.5.19", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ=="],
 

--- a/packages/web/astro.config.mjs
+++ b/packages/web/astro.config.mjs
@@ -1,4 +1,3 @@
-import { resolve } from "node:path";
 import cloudflare from "@astrojs/cloudflare";
 import react from "@astrojs/react";
 import { defineConfig } from "astro/config";
@@ -9,25 +8,19 @@ export default defineConfig({
 	adapter: cloudflare(),
 	vite: {
 		envDir: "../..",
-		resolve: {
-			alias: {
-				entities: resolve("../../node_modules/entities/lib/esm/index.js"),
-			},
-		},
+		// NOTE: the old `entities → …/esm/index.js` alias was removed on the Astro
+		// 7 upgrade — it broke subpath imports (`entities/decode` in htmlparser2)
+		// under the new rolldown bundler ("Not a directory"). Modern resolution
+		// handles the `entities` package exports natively, no alias needed.
 	},
 	server: { port: Number(process.env.PORT) || 3000 },
-	// Stays "static": ~12k law pages remain prebuilt files (Pages Free's 20k-file
-	// limit). Only routes with `export const prerender = false` (the reform
-	// detail page) become on-demand Pages Functions via the adapter.
+	// Stays "static": ~12k law pages remain prebuilt static assets (Workers Free's
+	// 20k-file limit). Only routes with `export const prerender = false` (the
+	// reform detail page) are rendered on-demand by the Worker — those are not
+	// files, so they don't count against the limit.
 	output: "static",
 	trailingSlash: "always",
 	build: {
 		concurrency: 4,
-	},
-	experimental: {
-		queuedRendering: {
-			enabled: true,
-			contentCache: true,
-		},
 	},
 });

--- a/packages/web/astro.config.mjs
+++ b/packages/web/astro.config.mjs
@@ -1,10 +1,12 @@
 import { resolve } from "node:path";
+import cloudflare from "@astrojs/cloudflare";
 import react from "@astrojs/react";
 import { defineConfig } from "astro/config";
 
 export default defineConfig({
 	integrations: [react()],
 	site: "https://leyabierta.es",
+	adapter: cloudflare(),
 	vite: {
 		envDir: "../..",
 		resolve: {
@@ -14,6 +16,9 @@ export default defineConfig({
 		},
 	},
 	server: { port: Number(process.env.PORT) || 3000 },
+	// Stays "static": ~12k law pages remain prebuilt files (Pages Free's 20k-file
+	// limit). Only routes with `export const prerender = false` (the reform
+	// detail page) become on-demand Pages Functions via the adapter.
 	output: "static",
 	trailingSlash: "always",
 	build: {

--- a/packages/web/astro.config.mjs
+++ b/packages/web/astro.config.mjs
@@ -1,11 +1,9 @@
-import cloudflare from "@astrojs/cloudflare";
 import react from "@astrojs/react";
 import { defineConfig } from "astro/config";
 
 export default defineConfig({
 	integrations: [react()],
 	site: "https://leyabierta.es",
-	adapter: cloudflare(),
 	vite: {
 		envDir: "../..",
 		// NOTE: the old `entities → …/esm/index.js` alias was removed on the Astro
@@ -14,10 +12,14 @@ export default defineConfig({
 		// handles the `entities` package exports natively, no alias needed.
 	},
 	server: { port: Number(process.env.PORT) || 3000 },
-	// Stays "static": ~12k law pages remain prebuilt static assets (Workers Free's
-	// 20k-file limit). Only routes with `export const prerender = false` (the
-	// reform detail page) are rendered on-demand by the Worker — those are not
-	// files, so they don't count against the limit.
+	// Pure static build — no adapter. All ~12k law pages plus every other route
+	// are prebuilt to dist/ at `astro build` time. The reforma detail page
+	// (/cambios/reforma/) is a static client-rendered shell here; a standalone
+	// Cloudflare Worker in front (src/worker/index.ts) intercepts requests to
+	// that path with `?id&date` and injects server-rendered content into the
+	// shell before serving it, without needing an Astro SSR adapter (whose
+	// workerd prerenderer can't do fs reads at render time — that's why it
+	// only built 81/12k pages when we tried it).
 	output: "static",
 	trailingSlash: "always",
 	build: {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -8,7 +8,6 @@
 		"preview": "astro preview"
 	},
 	"dependencies": {
-		"@astrojs/cloudflare": "^14.1.3",
 		"@astrojs/react": "^6.0.1",
 		"@lottiefiles/dotlottie-react": "^0.19.2",
 		"astro": "^7.1.1",
@@ -21,6 +20,7 @@
 		"zod": "^4.4.3"
 	},
 	"devDependencies": {
+		"@cloudflare/workers-types": "^5.20260718.1",
 		"@types/markdown-it": "^14.1.2",
 		"@types/react": "^19.2.14",
 		"@types/react-dom": "^19.2.3",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -8,6 +8,7 @@
 		"preview": "astro preview"
 	},
 	"dependencies": {
+		"@astrojs/cloudflare": "^14.1.3",
 		"@astrojs/react": "^5.0.3",
 		"@lottiefiles/dotlottie-react": "^0.19.2",
 		"astro": "6.1.9",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -9,9 +9,9 @@
 	},
 	"dependencies": {
 		"@astrojs/cloudflare": "^14.1.3",
-		"@astrojs/react": "^5.0.3",
+		"@astrojs/react": "^6.0.1",
 		"@lottiefiles/dotlottie-react": "^0.19.2",
-		"astro": "6.1.9",
+		"astro": "^7.1.1",
 		"diff2html": "3.4.56",
 		"js-yaml": "4.1.1",
 		"markdown-it": "^14.1.1",

--- a/packages/web/src/lib/reform-render.ts
+++ b/packages/web/src/lib/reform-render.ts
@@ -1,0 +1,399 @@
+// Server-side rendering for the reforma detail page content, shared by the
+// standalone Cloudflare Worker (src/worker/index.ts). Pure TS — no Astro, no
+// fs, no browser globals — so it can run inside workerd without a bundler
+// adapter. Ported from the (removed) SSR version of
+// src/pages/cambios/reforma/index.astro; see git history on feat/reform-ssr
+// before the restore-from-main commit for the original Astro source.
+
+import { escapeHtml } from "./escape.ts";
+
+// ── API response shapes (mirrors packages/api/src/routes/reforms.ts, omnibus.ts, laws.ts) ──
+export interface ReformInfo {
+	date: string;
+	reform_type: string | null;
+	headline: string | null;
+	summary: string | null;
+	importance: string | null;
+}
+export interface LawInfo {
+	id: string;
+	title: string;
+	short_title?: string | null;
+	rank: string;
+	status: string;
+	source_url: string;
+	last_reform_date: string | null;
+}
+export interface AffectedBlock {
+	block_id: string;
+	block_type: string;
+	title: string;
+	before_text: string | null;
+	after_text: string;
+}
+export interface ReformDetailResponse {
+	law: LawInfo;
+	reform: ReformInfo;
+	affected_blocks: AffectedBlock[];
+	prev_reform_date: string | null;
+	next_reform_date: string | null;
+	source_url: string;
+}
+export interface OmnibusTopic {
+	topic_label: string;
+	block_ids: string[];
+}
+export interface OmnibusResponse {
+	topics: OmnibusTopic[];
+}
+
+// ── Citizen-facing label maps (ported from the former client-side <script>) ──
+export const RANK_LABELS: Record<string, string> = {
+	constitucion: "Constitución",
+	ley_organica: "Ley Orgánica",
+	ley: "Ley",
+	real_decreto_ley: "Decreto urgente",
+	real_decreto_legislativo: "Decreto legislativo",
+	real_decreto: "Real Decreto",
+	orden: "Orden",
+	resolucion: "Resolución",
+	acuerdo_internacional: "Acuerdo internacional",
+	circular: "Circular",
+	instruccion: "Instrucción",
+	decreto: "Decreto",
+	reglamento: "Reglamento",
+	acuerdo: "Acuerdo",
+};
+export const STATUS_LABELS: Record<string, string> = {
+	vigente: "En vigor",
+	derogada: "Ya no está en vigor",
+	parcialmente_derogada: "Parcialmente en vigor",
+};
+export const TYPE_LABELS: Record<string, string> = {
+	new_law: "Ley nueva",
+	modification: "Modificación",
+	correction: "Corrección",
+	derogation: "Derogación",
+};
+
+// ── Diff helpers ──
+export type DiffOp<T> = { t: "eq" | "del" | "add"; v: T };
+
+export function seqDiff<T>(
+	a: T[],
+	b: T[],
+	eq: (x: T, y: T) => boolean,
+): DiffOp<T>[] {
+	const n = a.length;
+	const m = b.length;
+	// For large sequences use a size cap to avoid O(n*m) blowup
+	if (n * m > 200_000) {
+		const ops: DiffOp<T>[] = [];
+		for (const x of a) ops.push({ t: "del", v: x });
+		for (const y of b) ops.push({ t: "add", v: y });
+		return ops;
+	}
+	const dp: Int32Array[] = [];
+	for (let i = 0; i <= n; i++) dp[i] = new Int32Array(m + 1);
+	for (let i = n - 1; i >= 0; i--) {
+		const row = dp[i] as Int32Array;
+		const nextRow = dp[i + 1] as Int32Array;
+		for (let j = m - 1; j >= 0; j--) {
+			row[j] = eq(a[i] as T, b[j] as T)
+				? (nextRow[j + 1] as number) + 1
+				: Math.max(nextRow[j] as number, row[j + 1] as number);
+		}
+	}
+	const result: DiffOp<T>[] = [];
+	let pi = 0;
+	let pj = 0;
+	while (pi < n && pj < m) {
+		if (eq(a[pi] as T, b[pj] as T)) {
+			result.push({ t: "eq", v: a[pi] as T });
+			pi++;
+			pj++;
+		} else if (
+			(dp[pi + 1] as Int32Array)[pj]! >= (dp[pi] as Int32Array)[pj + 1]!
+		) {
+			result.push({ t: "del", v: a[pi] as T });
+			pi++;
+		} else {
+			result.push({ t: "add", v: b[pj] as T });
+			pj++;
+		}
+	}
+	while (pi < n) result.push({ t: "del", v: a[pi++] as T });
+	while (pj < m) result.push({ t: "add", v: b[pj++] as T });
+	return result;
+}
+
+export function wordDiff(before: string, after: string): DiffOp<string>[] {
+	const a = before.split(/(\s+)/);
+	const b = after.split(/(\s+)/);
+	return seqDiff(a, b, (x, y) => x === y);
+}
+
+/** Exact escaping used by every render function below — ported 1:1 from the
+ *  former SSR Astro page's `esc()`. Backed by the shared `escapeHtml` helper
+ *  (identical replacement set: & < > "). */
+export function esc(s: unknown): string {
+	return escapeHtml(String(s));
+}
+
+const MONTHS = [
+	"ene",
+	"feb",
+	"mar",
+	"abr",
+	"may",
+	"jun",
+	"jul",
+	"ago",
+	"sep",
+	"oct",
+	"nov",
+	"dic",
+];
+export function formatDate(d: string): string {
+	const dt = new Date(`${d}T00:00:00`);
+	return `${dt.getDate()} ${MONTHS[dt.getMonth()]} ${dt.getFullYear()}`;
+}
+
+export function truncate(s: string, max: number): string {
+	if (s.length <= max) return s;
+	return `${s.slice(0, max).replace(/\s+\S*$/, "")}…`;
+}
+
+export function buildWordDiffHtml(
+	beforePara: string,
+	afterPara: string,
+): string {
+	const ops = wordDiff(beforePara, afterPara);
+	let beforeHtml = '<span class="diff-label">Antes</span>';
+	let afterHtml = '<span class="diff-label">Ahora</span>';
+	for (const op of ops) {
+		const v = esc(op.v);
+		if (op.t === "eq") {
+			beforeHtml += v;
+			afterHtml += v;
+		} else if (op.t === "del") {
+			beforeHtml += `<span class="diff-word-removed">${v}</span>`;
+		} else {
+			afterHtml += `<span class="diff-word-added">${v}</span>`;
+		}
+	}
+	return `<div class="diff-mod-pair"><div class="diff-para diff-para-removed">${beforeHtml}</div><div class="diff-para diff-para-added">${afterHtml}</div></div>`;
+}
+
+const NO_CHANGE_NOTICE =
+	'<div class="diff-content"><p style="color:var(--text-muted);font-size:0.8125rem;padding:0.75rem;font-style:italic">El texto de este artículo no cambió en esta reforma. Es posible que el cambio afecte a su numeración o contexto dentro de la ley.</p></div>';
+
+export function renderBlockDiffHtml(
+	beforeText: string,
+	afterText: string,
+): string {
+	if (beforeText === afterText) return NO_CHANGE_NOTICE;
+
+	const bParas = beforeText
+		.split(/\n\n/)
+		.map((p) => p.trim())
+		.filter(Boolean);
+	const aParas = afterText
+		.split(/\n\n/)
+		.map((p) => p.trim())
+		.filter(Boolean);
+
+	// LCS diff at paragraph level — detects insertions/deletions correctly
+	const paraOps = seqDiff(bParas, aParas, (x, y) => x === y);
+
+	// Group consecutive del+add into modification pairs
+	type Group =
+		| { t: "mod"; before: string; after: string }
+		| { t: "add" | "del"; v: string };
+	const groups: Group[] = [];
+	let k = 0;
+	while (k < paraOps.length) {
+		const op = paraOps[k] as DiffOp<string>;
+		if (op.t === "del") {
+			const next = paraOps[k + 1];
+			if (next?.t === "add") {
+				groups.push({ t: "mod", before: op.v, after: next.v });
+				k += 2;
+			} else {
+				groups.push({ t: "del", v: op.v });
+				k++;
+			}
+		} else if (op.t === "add") {
+			groups.push({ t: "add", v: op.v });
+			k++;
+		} else {
+			// eq — unchanged paragraphs don't need to be shown
+			k++;
+		}
+	}
+
+	if (groups.length === 0) return NO_CHANGE_NOTICE;
+
+	let html = '<div class="diff-content">';
+	for (const g of groups) {
+		if (g.t === "mod") {
+			html += buildWordDiffHtml(g.before, g.after);
+		} else if (g.t === "add") {
+			html += `<div class="new-block" style="margin:0 0 0.75rem"><div class="version-label">Párrafo añadido</div><div class="version-text">${esc(g.v)}</div></div>`;
+		} else {
+			html += `<div class="diff-mod-pair"><div class="diff-para diff-para-removed"><span class="diff-label">Eliminado</span><span class="diff-word-removed">${esc(g.v)}</span></div></div>`;
+		}
+	}
+	html += "</div>";
+	return html;
+}
+
+export function renderUnifiedDiffHtml(diffText: string): string {
+	const lines = diffText.split("\n");
+	let html = '<div class="unified-diff">';
+	let skippedHeader = false;
+	for (const line of lines) {
+		if (!skippedHeader) {
+			if (
+				line.startsWith("diff --git") ||
+				line.startsWith("index ") ||
+				line.startsWith("---") ||
+				line.startsWith("+++")
+			)
+				continue;
+			if (line.startsWith("@@")) skippedHeader = true;
+		}
+		let cls = "unified-diff-line-ctx";
+		if (line.startsWith("+") && !line.startsWith("+++"))
+			cls = "unified-diff-line-add";
+		else if (line.startsWith("-") && !line.startsWith("---"))
+			cls = "unified-diff-line-del";
+		else if (line.startsWith("@@")) cls = "unified-diff-line-hunk";
+		html += `<div class="unified-diff-line ${cls}">${esc(line)}</div>`;
+	}
+	html += "</div>";
+	return html;
+}
+
+export interface RenderReformOptions {
+	/** Omnibus topic this reform is being viewed under (via ?from=omnibus&topic=N), if any. */
+	topicInfo: OmnibusTopic | null;
+	/** block_ids restricted to that topic, if resolved. */
+	topicBlockIds: string[] | null;
+	/** affected_blocks already filtered down to topicBlockIds when applicable. */
+	blocks: AffectedBlock[];
+	/** Pre-rendered unified diff HTML (from renderUnifiedDiffHtml), used when there
+	 *  are no per-block diffs to show (omnibus-less reforms without affected_blocks). */
+	unifiedDiffHtml: string | null;
+}
+
+export interface RenderReformResult {
+	contentHtml: string;
+	title: string;
+	description: string;
+}
+
+/** Renders the full inner HTML of `#reforma-content` for a successfully
+ *  fetched reform, plus the page `<title>` and meta description. Pure
+ *  function — the caller resolves topic/blocks/diff data before calling. */
+export function renderReformContent(
+	apiData: ReformDetailResponse,
+	opts: RenderReformOptions,
+): RenderReformResult {
+	const { law, reform } = apiData;
+	const { topicInfo, topicBlockIds, blocks, unifiedDiffHtml } = opts;
+
+	const hasHeadline = !!(reform.headline && reform.headline.length > 0);
+	const importance = reform.importance || "";
+	const rankLabel = RANK_LABELS[law.rank] ?? law.rank ?? "";
+	const isDerogatingReform =
+		law.status === "derogada" && law.last_reform_date === reform.date;
+	const typeLabel = isDerogatingReform
+		? "Derogación"
+		: (TYPE_LABELS[reform.reform_type ?? ""] ?? "");
+	const headline = hasHeadline ? (reform.headline as string) : law.title;
+	const fechaLegible = formatDate(reform.date);
+	const shortTitle = law.short_title || law.title;
+
+	const title = `${headline} — ${shortTitle} (${fechaLegible})`;
+	const description = reform.summary
+		? truncate(reform.summary, 150)
+		: `Qué cambió en ${law.title} el ${fechaLegible}: ${typeLabel || "modificación"}.`;
+
+	let html = '<div class="reforma-header">';
+	html += '<div class="reforma-date-row">';
+	html += `<span class="reforma-date">${esc(fechaLegible)}</span>`;
+	if (typeLabel)
+		html += `<span class="reforma-type-badge"> · ${esc(typeLabel)}</span>`;
+	if (importance === "high")
+		html += '<span class="reforma-importance-badge">Cambio importante</span>';
+	if (topicInfo)
+		html += `<span class="reforma-topic-badge">${esc(topicInfo.topic_label)}</span>`;
+	html += "</div>";
+	html += `<h1 class="reforma-headline">${esc(headline)}</h1>`;
+	html += '<div class="reforma-law-info">';
+	html += `${esc(rankLabel)} · ${esc(STATUS_LABELS[law.status] ?? law.status)}`;
+	html += ` · <a href="/leyes/${encodeURIComponent(law.id)}/">${esc(law.title)}</a>`;
+	html += "</div></div>";
+
+	if (reform.summary) {
+		html += `<div class="reforma-summary">${esc(reform.summary)}</div>`;
+	}
+
+	if (topicBlockIds && blocks.length === 0) {
+		html += `<p style="color:var(--text-muted);font-size:0.9375rem;margin-bottom:0.5rem">Los ${topicBlockIds.length} artículo${
+			topicBlockIds.length !== 1 ? "s" : ""
+		} de este tema no se modificaron en esta reforma.</p>`;
+		html += `<p style="font-size:0.875rem"><a href="/cambios/reforma/?id=${encodeURIComponent(law.id)}&date=${encodeURIComponent(
+			reform.date,
+		)}&from=omnibus" style="color:var(--accent)">Ver todos los cambios de esta reforma →</a></p>`;
+	}
+
+	if (blocks.length > 0) {
+		html += '<section class="reforma-changes">';
+		html += `<h2>Qué ha cambiado <span class="reforma-changes-count">(${blocks.length} artículo${blocks.length !== 1 ? "s" : ""})</span></h2>`;
+		blocks.forEach((b, i) => {
+			const isNew = !b.before_text;
+			const isOpen = i < 5;
+			const isNotaInicial =
+				b.block_type === "nota_inicial" || b.block_id === "no";
+			const blockLabel = isNotaInicial
+				? "Nota oficial del BOE"
+				: b.title || b.block_id;
+			const diffHtml = isNew
+				? ""
+				: renderBlockDiffHtml(b.before_text as string, b.after_text);
+
+			html += '<div class="block-change">';
+			html += `<div class="block-change-header" data-idx="${i}">`;
+			html += `<span>${esc(blockLabel)}</span>`;
+			html += `<span style="font-size:0.75rem;color:var(--text-muted)">${isOpen ? "▾" : "▸"}</span>`;
+			html += "</div>";
+			html += `<div class="block-change-body${isOpen ? " open" : ""}" id="block-${i}">`;
+			if (isNew) {
+				html += '<div class="new-block">';
+				html += `<div class="version-label">${isNotaInicial ? "Aviso oficial" : "Artículo nuevo"}</div>`;
+				html += `<div class="version-text">${esc(b.after_text)}</div>`;
+				html += "</div>";
+			} else {
+				html += `<div>${diffHtml}</div>`;
+			}
+			html += "</div></div>";
+		});
+		html += "</section>";
+	} else if (apiData.prev_reform_date && !topicBlockIds) {
+		html += '<section class="reforma-changes">';
+		html += "<h2>Qué ha cambiado</h2>";
+		html += unifiedDiffHtml
+			? unifiedDiffHtml
+			: '<p style="color:var(--text-muted);font-size:0.875rem">No se encontraron diferencias para esta reforma.</p>';
+		html += "</section>";
+	}
+
+	html += '<nav class="reforma-nav">';
+	html += `<a href="/leyes/${encodeURIComponent(law.id)}/?from=reforma">Ver ley completa →</a>`;
+	html += `<a href="${esc(apiData.source_url)}" target="_blank" rel="noopener">Ver en BOE ↗</a>`;
+	html += "</nav>";
+
+	return { contentHtml: html, title, description };
+}

--- a/packages/web/src/pages/cambios/reforma/index.astro
+++ b/packages/web/src/pages/cambios/reforma/index.astro
@@ -1,13 +1,401 @@
 ---
+// Reforma detail — server-rendered (Cloudflare Pages Function).
+//
+// This route was 100% client-side (fetch + innerHTML) until 2026-07, which
+// meant Google saw an empty shell and the page was noindex'd. It is now
+// rendered on-demand so the diff content is present in the initial HTML.
+// See docs/legislative-process-as-git.md (private) and the reform-SSR plan
+// for the full rationale.
+export const prerender = false;
+
 import Base from "../../../layouts/Base.astro";
+
+const API_BASE = import.meta.env.PUBLIC_API_URL ?? "https://api.leyabierta.es";
+
+// ── API response shapes (mirrors packages/api/src/routes/reforms.ts, omnibus.ts, laws.ts) ──
+interface ReformInfo {
+	date: string;
+	reform_type: string | null;
+	headline: string | null;
+	summary: string | null;
+	importance: string | null;
+}
+interface LawInfo {
+	id: string;
+	title: string;
+	short_title?: string | null;
+	rank: string;
+	status: string;
+	source_url: string;
+	last_reform_date: string | null;
+}
+interface AffectedBlock {
+	block_id: string;
+	block_type: string;
+	title: string;
+	before_text: string | null;
+	after_text: string;
+}
+interface ReformDetailResponse {
+	law: LawInfo;
+	reform: ReformInfo;
+	affected_blocks: AffectedBlock[];
+	prev_reform_date: string | null;
+	next_reform_date: string | null;
+	source_url: string;
+}
+interface OmnibusTopic {
+	topic_label: string;
+	block_ids: string[];
+}
+interface OmnibusResponse {
+	topics: OmnibusTopic[];
+}
+
+// ── Citizen-facing label maps (ported from the former client-side <script>) ──
+const RANK_LABELS: Record<string, string> = {
+	constitucion: "Constitución",
+	ley_organica: "Ley Orgánica",
+	ley: "Ley",
+	real_decreto_ley: "Decreto urgente",
+	real_decreto_legislativo: "Decreto legislativo",
+	real_decreto: "Real Decreto",
+	orden: "Orden",
+	resolucion: "Resolución",
+	acuerdo_internacional: "Acuerdo internacional",
+	circular: "Circular",
+	instruccion: "Instrucción",
+	decreto: "Decreto",
+	reglamento: "Reglamento",
+	acuerdo: "Acuerdo",
+};
+const STATUS_LABELS: Record<string, string> = {
+	vigente: "En vigor",
+	derogada: "Ya no está en vigor",
+	parcialmente_derogada: "Parcialmente en vigor",
+};
+const TYPE_LABELS: Record<string, string> = {
+	new_law: "Ley nueva",
+	modification: "Modificación",
+	correction: "Corrección",
+	derogation: "Derogación",
+};
+
+// ── Server-side diff helpers (ported from the former client-side <script>) ──
+type DiffOp<T> = { t: "eq" | "del" | "add"; v: T };
+
+function seqDiff<T>(a: T[], b: T[], eq: (x: T, y: T) => boolean): DiffOp<T>[] {
+	const n = a.length;
+	const m = b.length;
+	// For large sequences use a size cap to avoid O(n*m) blowup
+	if (n * m > 200_000) {
+		const ops: DiffOp<T>[] = [];
+		for (const x of a) ops.push({ t: "del", v: x });
+		for (const y of b) ops.push({ t: "add", v: y });
+		return ops;
+	}
+	const dp: Int32Array[] = [];
+	for (let i = 0; i <= n; i++) dp[i] = new Int32Array(m + 1);
+	for (let i = n - 1; i >= 0; i--) {
+		for (let j = m - 1; j >= 0; j--) {
+			dp[i][j] = eq(a[i], b[j]) ? dp[i + 1][j + 1] + 1 : Math.max(dp[i + 1][j], dp[i][j + 1]);
+		}
+	}
+	const result: DiffOp<T>[] = [];
+	let pi = 0;
+	let pj = 0;
+	while (pi < n && pj < m) {
+		if (eq(a[pi], b[pj])) {
+			result.push({ t: "eq", v: a[pi] });
+			pi++;
+			pj++;
+		} else if (dp[pi + 1][pj] >= dp[pi][pj + 1]) {
+			result.push({ t: "del", v: a[pi] });
+			pi++;
+		} else {
+			result.push({ t: "add", v: b[pj] });
+			pj++;
+		}
+	}
+	while (pi < n) result.push({ t: "del", v: a[pi++] });
+	while (pj < m) result.push({ t: "add", v: b[pj++] });
+	return result;
+}
+
+function wordDiff(before: string, after: string): DiffOp<string>[] {
+	const a = before.split(/(\s+)/);
+	const b = after.split(/(\s+)/);
+	return seqDiff(a, b, (x, y) => x === y);
+}
+
+function esc(s: unknown): string {
+	return String(s)
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/"/g, "&quot;");
+}
+
+const MONTHS = ["ene", "feb", "mar", "abr", "may", "jun", "jul", "ago", "sep", "oct", "nov", "dic"];
+function formatDate(d: string): string {
+	const dt = new Date(`${d}T00:00:00`);
+	return `${dt.getDate()} ${MONTHS[dt.getMonth()]} ${dt.getFullYear()}`;
+}
+
+function truncate(s: string, max: number): string {
+	if (s.length <= max) return s;
+	return `${s.slice(0, max).replace(/\s+\S*$/, "")}…`;
+}
+
+function buildWordDiffHtml(beforePara: string, afterPara: string): string {
+	const ops = wordDiff(beforePara, afterPara);
+	let beforeHtml = '<span class="diff-label">Antes</span>';
+	let afterHtml = '<span class="diff-label">Ahora</span>';
+	for (const op of ops) {
+		const v = esc(op.v);
+		if (op.t === "eq") {
+			beforeHtml += v;
+			afterHtml += v;
+		} else if (op.t === "del") {
+			beforeHtml += `<span class="diff-word-removed">${v}</span>`;
+		} else {
+			afterHtml += `<span class="diff-word-added">${v}</span>`;
+		}
+	}
+	return `<div class="diff-mod-pair"><div class="diff-para diff-para-removed">${beforeHtml}</div><div class="diff-para diff-para-added">${afterHtml}</div></div>`;
+}
+
+const NO_CHANGE_NOTICE =
+	'<div class="diff-content"><p style="color:var(--text-muted);font-size:0.8125rem;padding:0.75rem;font-style:italic">El texto de este artículo no cambió en esta reforma. Es posible que el cambio afecte a su numeración o contexto dentro de la ley.</p></div>';
+
+function renderBlockDiffHtml(beforeText: string, afterText: string): string {
+	if (beforeText === afterText) return NO_CHANGE_NOTICE;
+
+	const bParas = beforeText
+		.split(/\n\n/)
+		.map((p) => p.trim())
+		.filter(Boolean);
+	const aParas = afterText
+		.split(/\n\n/)
+		.map((p) => p.trim())
+		.filter(Boolean);
+
+	// LCS diff at paragraph level — detects insertions/deletions correctly
+	const paraOps = seqDiff(bParas, aParas, (x, y) => x === y);
+
+	// Group consecutive del+add into modification pairs
+	type Group = { t: "mod"; before: string; after: string } | { t: "add" | "del"; v: string };
+	const groups: Group[] = [];
+	let k = 0;
+	while (k < paraOps.length) {
+		const op = paraOps[k];
+		if (op.t === "del") {
+			const next = paraOps[k + 1];
+			if (next?.t === "add") {
+				groups.push({ t: "mod", before: op.v, after: next.v });
+				k += 2;
+			} else {
+				groups.push({ t: "del", v: op.v });
+				k++;
+			}
+		} else if (op.t === "add") {
+			groups.push({ t: "add", v: op.v });
+			k++;
+		} else {
+			// eq — unchanged paragraphs don't need to be shown
+			k++;
+		}
+	}
+
+	if (groups.length === 0) return NO_CHANGE_NOTICE;
+
+	let html = '<div class="diff-content">';
+	for (const g of groups) {
+		if (g.t === "mod") {
+			html += buildWordDiffHtml(g.before, g.after);
+		} else if (g.t === "add") {
+			html += `<div class="new-block" style="margin:0 0 0.75rem"><div class="version-label">Párrafo añadido</div><div class="version-text">${esc(g.v)}</div></div>`;
+		} else {
+			html += `<div class="diff-mod-pair"><div class="diff-para diff-para-removed"><span class="diff-label">Eliminado</span><span class="diff-word-removed">${esc(g.v)}</span></div></div>`;
+		}
+	}
+	html += "</div>";
+	return html;
+}
+
+function renderUnifiedDiffHtml(diffText: string): string {
+	const lines = diffText.split("\n");
+	let html = '<div class="unified-diff">';
+	let skippedHeader = false;
+	for (const line of lines) {
+		if (!skippedHeader) {
+			if (line.startsWith("diff --git") || line.startsWith("index ") || line.startsWith("---") || line.startsWith("+++")) continue;
+			if (line.startsWith("@@")) skippedHeader = true;
+		}
+		let cls = "unified-diff-line-ctx";
+		if (line.startsWith("+") && !line.startsWith("+++")) cls = "unified-diff-line-add";
+		else if (line.startsWith("-") && !line.startsWith("---")) cls = "unified-diff-line-del";
+		else if (line.startsWith("@@")) cls = "unified-diff-line-hunk";
+		html += `<div class="unified-diff-line ${cls}">${esc(line)}</div>`;
+	}
+	html += "</div>";
+	return html;
+}
+
+// ── Back-link + error-back-link helpers (server-side best guess from `from`;
+//    refined client-side by document.referrer, see the <script> below) ──
+function backLinkFor(from: string | null, id: string | null): { href: string; label: string } {
+	if (from === "cambios") return { href: "/cambios/recientes/", label: "← Volver a cambios recientes" };
+	if (from === "mis-cambios") return { href: "/cambios/para-mi/", label: "← Volver a mis cambios" };
+	if (from === "omnibus" || from === "law") {
+		return { href: id ? `/leyes/${encodeURIComponent(id)}/` : "/cambios/recientes/", label: "← Volver a la ley" };
+	}
+	return { href: "/cambios/recientes/", label: "← Volver" };
+}
+function errorBackLinkFor(from: string | null, id: string | null): { href: string; label: string } {
+	if (from === "cambios") return { href: "/cambios/recientes/", label: "Volver a cambios recientes" };
+	if (from === "omnibus" || from === "law") {
+		return { href: id ? `/leyes/${encodeURIComponent(id)}/` : "/cambios/recientes/", label: "Volver a la ley" };
+	}
+	return { href: "/cambios/para-mi/", label: "Volver a mis cambios" };
+}
+
+// ── Read params server-side ──
+const searchParams = Astro.url.searchParams;
+const normId = searchParams.get("id");
+const date = searchParams.get("date");
+const fromParam = searchParams.get("from");
+const topicParam = searchParams.get("topic");
+const topicIndex = topicParam !== null ? Number.parseInt(topicParam, 10) : Number.NaN;
+const fromOmnibus = fromParam === "omnibus";
+
+// Skip rate-limits on the public API when a bypass key is configured for this
+// Pages Function's runtime. `Astro.locals.runtime.env` was removed in Astro v6
+// for this adapter — the replacement is the `cloudflare:workers` module, which
+// only resolves inside the Cloudflare/workerd runtime, hence the try/catch.
+let bypassKey: string | undefined;
+try {
+	const cf = await import("cloudflare:workers");
+	bypassKey = (cf.env as Record<string, string | undefined> | undefined)?.API_BYPASS_KEY;
+} catch {
+	bypassKey = undefined;
+}
+const apiHeaders: HeadersInit = bypassKey ? { "x-bypass-key": bypassKey } : {};
+
+type PageResult =
+	| {
+			ok: true;
+			data: ReformDetailResponse;
+			topicInfo: OmnibusTopic | null;
+			topicBlockIds: string[] | null;
+			blocks: AffectedBlock[];
+			unifiedDiffHtml: string | null;
+	  }
+	| { ok: false; message: string };
+
+let result: PageResult;
+
+if (!normId || !date) {
+	Astro.response.status = 404;
+	result = { ok: false, message: "Faltan parámetros." };
+} else {
+	try {
+		const reformRes = await fetch(`${API_BASE}/v1/reforms/${encodeURIComponent(normId)}/${encodeURIComponent(date)}`, {
+			headers: apiHeaders,
+		});
+		if (!reformRes.ok) {
+			Astro.response.status = reformRes.status === 404 ? 404 : 500;
+			result = { ok: false, message: "No se pudo cargar la reforma." };
+		} else {
+			const data = (await reformRes.json()) as ReformDetailResponse;
+
+			let topicInfo: OmnibusTopic | null = null;
+			let topicBlockIds: string[] | null = null;
+			if (fromOmnibus && !Number.isNaN(topicIndex)) {
+				try {
+					const omnibusRes = await fetch(`${API_BASE}/v1/omnibus/${encodeURIComponent(normId)}`, { headers: apiHeaders });
+					if (omnibusRes.ok) {
+						const omnibusData = (await omnibusRes.json()) as OmnibusResponse;
+						topicInfo = omnibusData.topics?.[topicIndex] ?? null;
+						if (topicInfo && Array.isArray(topicInfo.block_ids) && topicInfo.block_ids.length > 0) {
+							topicBlockIds = topicInfo.block_ids;
+						}
+					}
+				} catch {
+					// Omnibus enrichment is best-effort — the reform itself still renders.
+				}
+			}
+
+			const allBlocks = data.affected_blocks || [];
+			const blockIds = topicBlockIds;
+			const blocks = blockIds ? allBlocks.filter((b) => blockIds.includes(b.block_id)) : allBlocks;
+
+			let unifiedDiffHtml: string | null = null;
+			if (blocks.length === 0 && data.prev_reform_date && !topicBlockIds) {
+				try {
+					const diffRes = await fetch(
+						`${API_BASE}/v1/laws/${encodeURIComponent(normId)}/diff?from=${encodeURIComponent(data.prev_reform_date)}&to=${encodeURIComponent(date)}`,
+						{ headers: apiHeaders },
+					);
+					if (diffRes.ok) {
+						const diffData = (await diffRes.json()) as { diff?: string };
+						unifiedDiffHtml = diffData.diff ? renderUnifiedDiffHtml(diffData.diff) : null;
+					}
+				} catch {
+					unifiedDiffHtml = null;
+				}
+			}
+
+			result = { ok: true, data, topicInfo, topicBlockIds, blocks, unifiedDiffHtml };
+		}
+	} catch {
+		Astro.response.status = 500;
+		result = { ok: false, message: "No se pudo cargar la reforma." };
+	}
+}
+
+// ── Derive display fields (title/description/canonical) only on success ──
+let pageTitle = "Detalle de reforma";
+let pageDescription = "Qué ha cambiado en esta ley y por qué te importa.";
+let canonicalUrl: string | undefined;
+let fechaLegible = "";
+let rankLabel = "";
+let typeLabel = "";
+let headline = "";
+let importance = "";
+
+if (result.ok) {
+	const { reform, law } = result.data;
+	const hasHeadline = !!(reform.headline && reform.headline.length > 0);
+	importance = reform.importance || "";
+	rankLabel = RANK_LABELS[law.rank] ?? law.rank ?? "";
+	const isDerogatingReform = law.status === "derogada" && law.last_reform_date === reform.date;
+	typeLabel = isDerogatingReform ? "Derogación" : (TYPE_LABELS[reform.reform_type ?? ""] ?? "");
+	headline = hasHeadline ? (reform.headline as string) : law.title;
+	fechaLegible = formatDate(reform.date);
+	const shortTitle = law.short_title || law.title;
+	pageTitle = `${headline} — ${shortTitle} (${fechaLegible})`;
+	pageDescription = reform.summary
+		? truncate(reform.summary, 150)
+		: `Qué cambió en ${law.title} el ${fechaLegible}: ${typeLabel || "modificación"}.`;
+	// Canonical intentionally omits `from`/`topic` — those are navigation
+	// context, not a distinct piece of content, and would otherwise create
+	// duplicate-content variants of the same reform for search engines.
+	canonicalUrl = `/cambios/reforma/?id=${encodeURIComponent(normId as string)}&date=${encodeURIComponent(date as string)}`;
+}
+
+const backLink = backLinkFor(fromParam, normId);
+const errorBack = errorBackLinkFor(fromParam, normId);
+
+if (result.ok) {
+	// A reform is immutable once published — cache aggressively. The deploy
+	// pipeline purges the CF zone on every deploy, so a reprocessed reform
+	// (rare) still refreshes promptly.
+	Astro.response.headers.set("Cache-Control", "public, s-maxage=7776000, stale-while-revalidate=86400");
+}
 ---
 
-<Base
-	title="Detalle de reforma"
-	description="Qué ha cambiado en esta ley y por qué te importa."
-	ogTitle="Detalle de reforma — Ley Abierta"
-	noindex
->
+<Base title={pageTitle} description={pageDescription} ogTitle={`${pageTitle} — Ley Abierta`} canonicalUrl={canonicalUrl} noindex={!result.ok}>
 	<style is:global>
 		.reforma-wrap {
 			max-width: 780px;
@@ -45,7 +433,11 @@ import Base from "../../../layouts/Base.astro";
 			font-size: 0.6875rem; font-weight: 600; color: var(--accent);
 			background: var(--accent-bg); padding: 0.1875rem 0.5625rem; border-radius: 4px;
 		}
-		:global(.reforma-headline) {
+		.reforma-topic-badge {
+			font-size: 0.6875rem; font-weight: 600; color: var(--accent);
+			background: var(--accent-bg); padding: 0.125rem 0.5rem; border-radius: 4px;
+		}
+		.reforma-headline {
 			font-family: var(--font-serif); font-size: 1.875rem; font-weight: 700;
 			line-height: 1.2; color: var(--text); margin: 0 0 0.625rem;
 			letter-spacing: -0.02em;
@@ -142,13 +534,6 @@ import Base from "../../../layouts/Base.astro";
 		}
 		.reforma-nav a:hover { background: var(--accent-faint); border-color: var(--accent); }
 
-		/* ── Skeleton ── */
-		.skeleton-line {
-			height: 0.875rem; background: var(--border-light); border-radius: 4px;
-			margin-bottom: 0.625rem; animation: pulse 1.5s ease-in-out infinite;
-		}
-		@keyframes pulse { 0%, 100% { opacity: 0.4; } 50% { opacity: 1; } }
-
 		.error-state {
 			text-align: center; padding: 3rem 1.5rem;
 			background: var(--danger-bg); border: 1px solid var(--danger); border-radius: 12px;
@@ -189,404 +574,134 @@ import Base from "../../../layouts/Base.astro";
 		}
 
 		@media (max-width: 640px) {
-			:global(.reforma-headline) { font-size: 1.625rem; }
+			.reforma-headline { font-size: 1.625rem; }
 		}
 	</style>
 
 	<div class="reforma-wrap">
-		<a href="/cambios/recientes/" class="reforma-back" id="reforma-back">&larr; Volver</a>
+		<a href={backLink.href} class="reforma-back" id="reforma-back">{backLink.label}</a>
 		<div id="reforma-content">
-			<div class="reforma-header">
-				<div class="skeleton-line" style="width:30%"></div>
-				<div class="skeleton-line" style="width:80%;height:1.5rem"></div>
-				<div class="skeleton-line" style="width:60%"></div>
-			</div>
-			<div class="skeleton-line" style="width:100%;height:4rem;border-radius:10px"></div>
-			<br>
-			<div class="skeleton-line" style="width:40%"></div>
-			<div class="skeleton-line" style="width:100%;height:6rem;border-radius:10px"></div>
+			{result.ok ? (
+				<Fragment>
+					<div class="reforma-header">
+						<div class="reforma-date-row">
+							<span class="reforma-date">{fechaLegible}</span>
+							{typeLabel && <span class="reforma-type-badge"> · {typeLabel}</span>}
+							{importance === "high" && <span class="reforma-importance-badge">Cambio importante</span>}
+							{result.topicInfo && <span class="reforma-topic-badge">{result.topicInfo.topic_label}</span>}
+						</div>
+						<h1 class="reforma-headline">{headline}</h1>
+						<div class="reforma-law-info">
+							{rankLabel} · {STATUS_LABELS[result.data.law.status] ?? result.data.law.status} ·{" "}
+							<a href={`/leyes/${encodeURIComponent(result.data.law.id)}/`}>{result.data.law.title}</a>
+						</div>
+					</div>
+
+					{result.data.reform.summary && <div class="reforma-summary">{result.data.reform.summary}</div>}
+
+					{result.topicBlockIds && result.blocks.length === 0 && (
+						<Fragment>
+							<p style="color:var(--text-muted);font-size:0.9375rem;margin-bottom:0.5rem">
+								Los {result.topicBlockIds.length} artículo{result.topicBlockIds.length !== 1 ? "s" : ""} de este tema no se modificaron en esta reforma.
+							</p>
+							<p style="font-size:0.875rem">
+								<a
+									href={`/cambios/reforma/?id=${encodeURIComponent(result.data.law.id)}&date=${encodeURIComponent(result.data.reform.date)}&from=omnibus`}
+									style="color:var(--accent)"
+								>
+									Ver todos los cambios de esta reforma →
+								</a>
+							</p>
+						</Fragment>
+					)}
+
+					{result.blocks.length > 0 && (
+						<section class="reforma-changes">
+							<h2>Qué ha cambiado <span class="reforma-changes-count">({result.blocks.length} artículo{result.blocks.length !== 1 ? "s" : ""})</span></h2>
+							{result.blocks.map((b, i) => {
+								const isNew = !b.before_text;
+								const isOpen = i < 5;
+								const isNotaInicial = b.block_type === "nota_inicial" || b.block_id === "no";
+								const blockLabel = isNotaInicial ? "Nota oficial del BOE" : b.title || b.block_id;
+								const diffHtml = isNew ? "" : renderBlockDiffHtml(b.before_text as string, b.after_text);
+								return (
+									<div class="block-change">
+										<div class="block-change-header" data-idx={i}>
+											<span>{blockLabel}</span>
+											<span style="font-size:0.75rem;color:var(--text-muted)">{isOpen ? "▾" : "▸"}</span>
+										</div>
+										<div class={`block-change-body${isOpen ? " open" : ""}`} id={`block-${i}`}>
+											{isNew ? (
+												<div class="new-block">
+													<div class="version-label">{isNotaInicial ? "Aviso oficial" : "Artículo nuevo"}</div>
+													<div class="version-text">{b.after_text}</div>
+												</div>
+											) : (
+												<div set:html={diffHtml} />
+											)}
+										</div>
+									</div>
+								);
+							})}
+						</section>
+					)}
+
+					{result.blocks.length === 0 && result.data.prev_reform_date && !result.topicBlockIds && (
+						<section class="reforma-changes">
+							<h2>Qué ha cambiado</h2>
+							{result.unifiedDiffHtml ? (
+								<div set:html={result.unifiedDiffHtml} />
+							) : (
+								<p style="color:var(--text-muted);font-size:0.875rem">No se encontraron diferencias para esta reforma.</p>
+							)}
+						</section>
+					)}
+
+					<nav class="reforma-nav">
+						<a href={`/leyes/${encodeURIComponent(result.data.law.id)}/?from=reforma`}>Ver ley completa →</a>
+						<a href={result.data.source_url} target="_blank" rel="noopener">Ver en BOE ↗</a>
+					</nav>
+				</Fragment>
+			) : (
+				<div class="error-state">
+					<p>{result.message}</p>
+					<a href={errorBack.href} style="color:var(--accent)">{errorBack.label}</a>
+				</div>
+			)}
 		</div>
 	</div>
 
 	<script is:inline>
 		(function () {
-			// Generic LCS-based sequence diff (works for both token arrays and paragraph arrays)
-			function seqDiff(a, b, eq) {
-				var n = a.length, m = b.length;
-				// For large sequences use a size cap to avoid O(n*m) blowup
-				if (n * m > 200000) {
-					// Fallback: treat everything as replaced
-					var ops = [];
-					for (var x = 0; x < n; x++) ops.push({ t: "del", v: a[x] });
-					for (var y = 0; y < m; y++) ops.push({ t: "add", v: b[y] });
-					return ops;
-				}
-				var dp = [];
-				for (var xi = 0; xi <= n; xi++) {
-					dp[xi] = new Int32Array(m + 1);
-				}
-				for (var i = n - 1; i >= 0; i--) {
-					for (var j = m - 1; j >= 0; j--) {
-						dp[i][j] = eq(a[i], b[j]) ? dp[i+1][j+1] + 1 : Math.max(dp[i+1][j], dp[i][j+1]);
-					}
-				}
-				var result = [];
-				var pi = 0, pj = 0;
-				while (pi < n && pj < m) {
-					if (eq(a[pi], b[pj])) { result.push({ t: "eq", v: a[pi] }); pi++; pj++; }
-					else if (dp[pi+1][pj] >= dp[pi][pj+1]) { result.push({ t: "del", v: a[pi] }); pi++; }
-					else { result.push({ t: "add", v: b[pj] }); pj++; }
-				}
-				while (pi < n) { result.push({ t: "del", v: a[pi++] }); }
-				while (pj < m) { result.push({ t: "add", v: b[pj++] }); }
-				return result;
-			}
-
-			function wordDiff(before, after) {
-				var a = before.split(/(\s+)/);
-				var b = after.split(/(\s+)/);
-				return seqDiff(a, b, function(x, y) { return x === y; });
-			}
-
-			function esc(s) { return String(s).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;"); }
-			function formatDate(d) {
-				var dt = new Date(d + "T00:00:00");
-				var months = ["ene", "feb", "mar", "abr", "may", "jun", "jul", "ago", "sep", "oct", "nov", "dic"];
-				return dt.getDate() + " " + months[dt.getMonth()] + " " + dt.getFullYear();
-			}
-
-			function buildWordDiffHtml(beforePara, afterPara) {
-				var ops = wordDiff(beforePara, afterPara);
-				var beforeHtml = '<span class="diff-label">Antes</span>';
-				var afterHtml = '<span class="diff-label">Ahora</span>';
-				for (var k = 0; k < ops.length; k++) {
-					var o = ops[k];
-					var v = esc(o.v);
-					if (o.t === "eq") {
-						beforeHtml += v;
-						afterHtml += v;
-					} else if (o.t === "del") {
-						beforeHtml += '<span class="diff-word-removed">' + v + '</span>';
-					} else {
-						afterHtml += '<span class="diff-word-added">' + v + '</span>';
-					}
-				}
-				return '<div class="diff-mod-pair">'
-					+ '<div class="diff-para diff-para-removed">' + beforeHtml + '</div>'
-					+ '<div class="diff-para diff-para-added">' + afterHtml + '</div>'
-					+ '</div>';
-			}
-
-			function renderBlockDiff(beforeText, afterText, container) {
-				if (beforeText === afterText) {
-					container.innerHTML = '<div class="diff-content"><p style="color:var(--text-muted);font-size:0.8125rem;padding:0.75rem;font-style:italic">El texto de este artículo no cambió en esta reforma. Es posible que el cambio afecte a su numeración o contexto dentro de la ley.</p></div>';
-					return;
-				}
-				var bParas = beforeText.split(/\n\n/).map(function(p){return p.trim();}).filter(Boolean);
-				var aParas = afterText.split(/\n\n/).map(function(p){return p.trim();}).filter(Boolean);
-
-				// LCS diff at paragraph level — detects insertions/deletions correctly
-				var paraOps = seqDiff(bParas, aParas, function(x, y) { return x === y; });
-
-				// Group consecutive del+add into modification pairs
-				var groups = [];
-				var k = 0;
-				while (k < paraOps.length) {
-					var op = paraOps[k];
-					if (op.t === "del") {
-						// Peek: is the next op an "add"? → modification pair
-						if (k + 1 < paraOps.length && paraOps[k + 1].t === "add") {
-							groups.push({ t: "mod", before: op.v, after: paraOps[k + 1].v });
-							k += 2;
-						} else {
-							groups.push({ t: "del", v: op.v });
-							k++;
-						}
-					} else if (op.t === "add") {
-						groups.push({ t: "add", v: op.v });
-						k++;
-					} else {
-						// eq — skip unchanged paragraphs (they don't need to be shown)
-						k++;
-					}
-				}
-
-				if (groups.length === 0) {
-					container.innerHTML = '<div class="diff-content"><p style="color:var(--text-muted);font-size:0.8125rem;padding:0.75rem;font-style:italic">El texto de este artículo no cambió en esta reforma. Es posible que el cambio afecte a su numeración o contexto dentro de la ley.</p></div>';
-					return;
-				}
-
-				var html = '<div class="diff-content">';
-				for (var gi = 0; gi < groups.length; gi++) {
-					var g = groups[gi];
-					if (g.t === "mod") {
-						html += buildWordDiffHtml(g.before, g.after);
-					} else if (g.t === "add") {
-						html += '<div class="new-block" style="margin:0 0 0.75rem">'
-							+ '<div class="version-label">Párrafo añadido</div>'
-							+ '<div class="version-text">' + esc(g.v) + '</div>'
-							+ '</div>';
-					} else {
-						// del
-						html += '<div class="diff-mod-pair">'
-							+ '<div class="diff-para diff-para-removed"><span class="diff-label">Eliminado</span>'
-							+ '<span class="diff-word-removed">' + esc(g.v) + '</span></div>'
-							+ '</div>';
-					}
-				}
-				html += '</div>';
-				container.innerHTML = html;
-			}
-
-			// Context-aware back link
+			// Progressive enhancement only — all content above is already in the
+			// server-rendered HTML. This script just adds collapse/expand toggles
+			// and refines the back link using document.referrer (unknown server-side).
 			var backLink = document.getElementById("reforma-back");
-			if (backLink) {
-				var params = new URLSearchParams(window.location.search);
-				var from = params.get("from");
-				var normId = params.get("id") || "";
-
-				if (from === "cambios") {
+			if (backLink && document.referrer && document.referrer.indexOf(location.origin) === 0) {
+				var refPath = new URL(document.referrer).pathname;
+				if (refPath === "/cambios/recientes/" || refPath === "/cambios/") {
 					backLink.innerHTML = "&larr; Volver a cambios recientes";
-				} else if (from === "mis-cambios") {
+				} else if (refPath === "/cambios/para-mi/") {
 					backLink.innerHTML = "&larr; Volver a mis cambios";
-					backLink.href = "/cambios/para-mi/";
-				} else if (from === "omnibus" || from === "law") {
+				} else if (refPath.indexOf("/leyes/") === 0) {
 					backLink.innerHTML = "&larr; Volver a la ley";
-				} else if (document.referrer && document.referrer.indexOf(location.origin) === 0) {
-					var refPath = new URL(document.referrer).pathname;
-					if (refPath === "/cambios/recientes/" || refPath === "/cambios/") {
-						backLink.innerHTML = "&larr; Volver a cambios recientes";
-					} else if (refPath === "/cambios/para-mi/") {
-						backLink.innerHTML = "&larr; Volver a mis cambios";
-					} else if (refPath.indexOf("/leyes/") === 0) {
-						backLink.innerHTML = "&larr; Volver a la ley";
-					}
 				}
-
-				if (document.referrer && document.referrer.indexOf(location.origin) === 0) {
-					backLink.addEventListener("click", function(e) {
-						e.preventDefault();
-						history.back();
-					});
-				} else if (from === "cambios") {
-					backLink.href = "/cambios/recientes/";
-				} else if ((from === "omnibus" || from === "law") && normId) {
-					backLink.href = "/leyes/" + encodeURIComponent(normId) + "/";
-				}
-			}
-
-			var RANK_LABELS = {
-				constitucion: "Constitución", ley_organica: "Ley Orgánica", ley: "Ley",
-				real_decreto_ley: "Decreto urgente", real_decreto_legislativo: "Decreto legislativo",
-				real_decreto: "Real Decreto", orden: "Orden", resolucion: "Resolución",
-				acuerdo_internacional: "Acuerdo internacional", circular: "Circular",
-				instruccion: "Instrucción", decreto: "Decreto", reglamento: "Reglamento",
-				acuerdo: "Acuerdo"
-			};
-			var STATUS_LABELS = {
-				vigente: "En vigor",
-				derogada: "Ya no está en vigor",
-				parcialmente_derogada: "Parcialmente en vigor"
-			};
-			var TYPE_LABELS = {
-				new_law: "Ley nueva", modification: "Modificación",
-				correction: "Corrección", derogation: "Derogación"
-			};
-
-			var qParams = new URLSearchParams(window.location.search);
-			var normId = qParams.get("id") || "";
-			var date = qParams.get("date");
-			var topicParam = qParams.get("topic");
-			var topicIndex = topicParam !== null ? parseInt(topicParam, 10) : NaN;
-			var fromOmnibus = qParams.get("from") === "omnibus";
-
-			var API = document.documentElement.dataset.api;
-			var contentDiv = document.getElementById("reforma-content");
-
-			if (!normId || !date) {
-				contentDiv.innerHTML = '<div class="error-state"><p>Faltan parámetros.</p></div>';
-				return;
-			}
-
-			var reformUrl = API + "/v1/reforms/" + encodeURIComponent(normId) + "/" + encodeURIComponent(date);
-			var promises = [fetch(reformUrl).then(function(r) { if (!r.ok) throw new Error(r.status); return r.json(); })];
-			if (fromOmnibus && !isNaN(topicIndex)) {
-				promises.push(
-					fetch(API + "/v1/omnibus/" + encodeURIComponent(normId))
-						.then(function(r) { return r.ok ? r.json() : null; })
-						.catch(function() { return null; })
-				);
-			}
-
-			Promise.all(promises)
-				.then(function (results) {
-					var data = results[0];
-					var omnibusData = results[1] || null;
-					var topicInfo = null;
-					var topicBlockIds = null;
-
-					if (omnibusData && omnibusData.topics && !isNaN(topicIndex)) {
-						topicInfo = omnibusData.topics[topicIndex] || null;
-						if (topicInfo && Array.isArray(topicInfo.block_ids) && topicInfo.block_ids.length > 0) {
-							topicBlockIds = topicInfo.block_ids;
-						}
-					}
-
-					var reform = data.reform;
-					var law = data.law;
-					var allBlocks = data.affected_blocks || [];
-					var blocks = topicBlockIds
-						? allBlocks.filter(function(b) { return topicBlockIds.indexOf(b.block_id) !== -1; })
-						: allBlocks;
-					var hasHeadline = reform.headline && reform.headline.length > 0;
-					var importance = reform.importance || "";
-					var rankLabel = RANK_LABELS[law.rank] || law.rank || "";
-
-					var isDerogatingReform = law.status === "derogada" && law.last_reform_date === reform.date;
-					var typeLabel = isDerogatingReform ? "Derogación" : (TYPE_LABELS[reform.reform_type] || "");
-					var headline = hasHeadline ? reform.headline : law.title;
-
-					// ── Header ──
-					var html = '<div class="reforma-header">';
-					html += '<div class="reforma-date-row">';
-					html += '<span class="reforma-date">' + esc(formatDate(reform.date)) + '</span>';
-					if (typeLabel) html += '<span class="reforma-type-badge"> · ' + esc(typeLabel) + '</span>';
-					if (importance === "high") html += '<span class="reforma-importance-badge">Cambio importante</span>';
-					if (topicInfo) html += '<span style="font-size:0.6875rem;font-weight:600;color:var(--accent);background:var(--accent-bg);padding:0.125rem 0.5rem;border-radius:4px">' + esc(topicInfo.topic_label) + '</span>';
-					html += '</div>';
-					html += '<h1 class="reforma-headline">' + esc(headline) + '</h1>';
-					html += '<div class="reforma-law-info">';
-					html += esc(rankLabel) + ' · ' + esc(STATUS_LABELS[law.status] || law.status);
-					html += ' · <a href="/leyes/' + encodeURIComponent(law.id) + '/">' + esc(law.title) + '</a>';
-					html += '</div></div>';
-
-					// ── Summary ──
-					if (reform.summary) {
-						html += '<div class="reforma-summary">' + esc(reform.summary) + '</div>';
-					}
-
-					// ── Empty topic intersection ──
-					if (topicBlockIds && blocks.length === 0) {
-						html += '<p style="color:var(--text-muted);font-size:0.9375rem;margin-bottom:0.5rem">Los ' + topicBlockIds.length + ' artículo' + (topicBlockIds.length !== 1 ? 's' : '') + ' de este tema no se modificaron en esta reforma.</p>';
-						html += '<p style="font-size:0.875rem"><a href="/cambios/reforma/?id=' + encodeURIComponent(law.id) + '&date=' + encodeURIComponent(reform.date) + '&from=omnibus" style="color:var(--accent)">Ver todos los cambios de esta reforma &rarr;</a></p>';
-					}
-
-					// ── Affected blocks ──
-					if (blocks.length > 0) {
-						html += '<section class="reforma-changes">';
-						html += '<h2>Qué ha cambiado <span class="reforma-changes-count">(' + blocks.length + ' artículo' + (blocks.length !== 1 ? 's' : '') + ')</span></h2>';
-
-						for (var i = 0; i < blocks.length; i++) {
-							var b = blocks[i];
-							var isNew = !b.before_text;
-							var isOpen = i < 5;
-
-							html += '<div class="block-change">';
-							var isNotaInicial = b.block_type === "nota_inicial" || b.block_id === "no";
-							var blockLabel = isNotaInicial ? "Nota oficial del BOE" : (b.title || b.block_id);
-
-							html += '<div class="block-change-header" data-idx="' + i + '">';
-							html += '<span>' + esc(blockLabel) + '</span>';
-							html += '<span style="font-size:0.75rem;color:var(--text-muted)">' + (isOpen ? '▾' : '▸') + '</span>';
-							html += '</div>';
-							html += '<div class="block-change-body' + (isOpen ? ' open' : '') + '" id="block-' + i + '">';
-
-							if (isNew) {
-								var newBlockLabel = isNotaInicial ? "Aviso oficial" : "Artículo nuevo";
-								html += '<div class="new-block">';
-								html += '<div class="version-label">' + newBlockLabel + '</div>';
-								html += '<div class="version-text">' + esc(b.after_text) + '</div>';
-								html += '</div>';
-							} else {
-								html += '<div id="diff-block-' + i + '"><div class="diff-content" style="color:var(--text-muted);font-size:0.8125rem;padding:1rem">Cargando diferencias...</div></div>';
-							}
-							html += '</div></div>';
-						}
-						html += '</section>';
-					} else if (data.prev_reform_date && !topicBlockIds) {
-						html += '<section class="reforma-changes">';
-						html += '<h2>Qué ha cambiado</h2>';
-						html += '<div id="unified-diff-container"><div class="diff-content" style="color:var(--text-muted);font-size:0.8125rem;padding:1rem">Cargando diferencias...</div></div>';
-						html += '</section>';
-					}
-
-					// ── Nav ──
-					html += '<nav class="reforma-nav">';
-					html += '<a href="/leyes/' + encodeURIComponent(law.id) + '/?from=reforma">Ver ley completa &rarr;</a>';
-					html += '<a href="' + esc(data.source_url) + '" target="_blank" rel="noopener">Ver en BOE ↗</a>';
-					html += '</nav>';
-
-					contentDiv.innerHTML = html;
-					document.title = headline + ' — Ley Abierta';
-
-					// ── Toggles ──
-					contentDiv.querySelectorAll('.block-change-header').forEach(function (hdr) {
-						hdr.addEventListener('click', function () {
-							var idx = this.getAttribute('data-idx');
-							var body = document.getElementById('block-' + idx);
-							var arrow = this.querySelector('span:last-child');
-							body.classList.toggle('open');
-							arrow.textContent = body.classList.contains('open') ? '▾' : '▸';
-						});
-					});
-
-					// ── Unified diff fallback ──
-					if (blocks.length === 0 && data.prev_reform_date && !topicBlockIds) {
-						var diffUrl = API + "/v1/laws/" + encodeURIComponent(normId) + "/diff?from=" + encodeURIComponent(data.prev_reform_date) + "&to=" + encodeURIComponent(date);
-						fetch(diffUrl)
-							.then(function (r) { return r.ok ? r.json() : null; })
-							.then(function (diffData) {
-								var container = document.getElementById("unified-diff-container");
-								if (!container || !diffData || !diffData.diff) {
-									if (container) container.innerHTML = '<p style="color:var(--text-muted);font-size:0.875rem">No se encontraron diferencias para esta reforma.</p>';
-									return;
-								}
-								var lines = diffData.diff.split("\n");
-								var diffHtml = '<div class="unified-diff">';
-								var skippedHeader = false;
-								for (var j = 0; j < lines.length; j++) {
-									var line = lines[j];
-									if (!skippedHeader) {
-										if (line.indexOf("diff --git") === 0 || line.indexOf("index ") === 0 || line.indexOf("---") === 0 || line.indexOf("+++") === 0) continue;
-										if (line.indexOf("@@") === 0) skippedHeader = true;
-									}
-									var cls = "unified-diff-line-ctx";
-									if (line.indexOf("+") === 0 && line.indexOf("+++") !== 0) cls = "unified-diff-line-add";
-									else if (line.indexOf("-") === 0 && line.indexOf("---") !== 0) cls = "unified-diff-line-del";
-									else if (line.indexOf("@@") === 0) cls = "unified-diff-line-hunk";
-									diffHtml += '<div class="unified-diff-line ' + cls + '">' + esc(line) + '</div>';
-								}
-								diffHtml += '</div>';
-								container.innerHTML = diffHtml;
-							})
-							.catch(function () {
-								var container = document.getElementById("unified-diff-container");
-								if (container) container.innerHTML = '<p style="color:var(--text-muted);font-size:0.875rem">No se pudieron cargar las diferencias.</p>';
-							});
-					}
-
-					// Render word diff for blocks that have before_text
-					if (blocks.length > 0) {
-						for (var bi = 0; bi < blocks.length; bi++) {
-							var blk = blocks[bi];
-							if (!blk.before_text) continue;
-							var container = document.getElementById("diff-block-" + bi);
-							if (container) {
-								renderBlockDiff(blk.before_text, blk.after_text, container);
-							}
-						}
-					}
-				})
-				.catch(function () {
-					var params2 = new URLSearchParams(window.location.search);
-					var from2 = params2.get("from") || "";
-					var errorBackHref = "/cambios/para-mi/";
-					var errorBackLabel = "Volver a mis cambios";
-					if (from2 === "cambios") { errorBackHref = "/cambios/recientes/"; errorBackLabel = "Volver a cambios recientes"; }
-					else if (from2 === "omnibus") { errorBackHref = "/leyes/" + encodeURIComponent(params2.get("id") || "") + "/"; errorBackLabel = "Volver a la ley"; }
-					else if (from2 === "law") { errorBackHref = "/leyes/" + encodeURIComponent(params2.get("id") || "") + "/"; errorBackLabel = "Volver a la ley"; }
-					contentDiv.innerHTML = '<div class="error-state"><p>No se pudo cargar la reforma.</p><a href="' + errorBackHref + '" style="color:var(--accent)">' + errorBackLabel + '</a></div>';
+				backLink.addEventListener("click", function (e) {
+					e.preventDefault();
+					history.back();
 				});
+			}
+
+			document.querySelectorAll(".block-change-header").forEach(function (hdr) {
+				hdr.addEventListener("click", function () {
+					var idx = this.getAttribute("data-idx");
+					var body = document.getElementById("block-" + idx);
+					var arrow = this.querySelector("span:last-child");
+					if (!body) return;
+					body.classList.toggle("open");
+					if (arrow) arrow.textContent = body.classList.contains("open") ? "▾" : "▸";
+				});
+			});
 		})();
 	</script>
 </Base>

--- a/packages/web/src/pages/cambios/reforma/index.astro
+++ b/packages/web/src/pages/cambios/reforma/index.astro
@@ -1,404 +1,13 @@
 ---
-// Reforma detail — server-rendered (Cloudflare Pages Function).
-//
-// This route was 100% client-side (fetch + innerHTML) until 2026-07, which
-// meant Google saw an empty shell and the page was noindex'd. It is now
-// rendered on-demand so the diff content is present in the initial HTML.
-// See docs/legislative-process-as-git.md (private) and the reform-SSR plan
-// for the full rationale.
-export const prerender = false;
-
 import Base from "../../../layouts/Base.astro";
-
-const API_BASE = import.meta.env.PUBLIC_API_URL ?? "https://api.leyabierta.es";
-
-// ── API response shapes (mirrors packages/api/src/routes/reforms.ts, omnibus.ts, laws.ts) ──
-interface ReformInfo {
-	date: string;
-	reform_type: string | null;
-	headline: string | null;
-	summary: string | null;
-	importance: string | null;
-}
-interface LawInfo {
-	id: string;
-	title: string;
-	short_title?: string | null;
-	rank: string;
-	status: string;
-	source_url: string;
-	last_reform_date: string | null;
-}
-interface AffectedBlock {
-	block_id: string;
-	block_type: string;
-	title: string;
-	before_text: string | null;
-	after_text: string;
-}
-interface ReformDetailResponse {
-	law: LawInfo;
-	reform: ReformInfo;
-	affected_blocks: AffectedBlock[];
-	prev_reform_date: string | null;
-	next_reform_date: string | null;
-	source_url: string;
-}
-interface OmnibusTopic {
-	topic_label: string;
-	block_ids: string[];
-}
-interface OmnibusResponse {
-	topics: OmnibusTopic[];
-}
-
-// ── Citizen-facing label maps (ported from the former client-side <script>) ──
-const RANK_LABELS: Record<string, string> = {
-	constitucion: "Constitución",
-	ley_organica: "Ley Orgánica",
-	ley: "Ley",
-	real_decreto_ley: "Decreto urgente",
-	real_decreto_legislativo: "Decreto legislativo",
-	real_decreto: "Real Decreto",
-	orden: "Orden",
-	resolucion: "Resolución",
-	acuerdo_internacional: "Acuerdo internacional",
-	circular: "Circular",
-	instruccion: "Instrucción",
-	decreto: "Decreto",
-	reglamento: "Reglamento",
-	acuerdo: "Acuerdo",
-};
-const STATUS_LABELS: Record<string, string> = {
-	vigente: "En vigor",
-	derogada: "Ya no está en vigor",
-	parcialmente_derogada: "Parcialmente en vigor",
-};
-const TYPE_LABELS: Record<string, string> = {
-	new_law: "Ley nueva",
-	modification: "Modificación",
-	correction: "Corrección",
-	derogation: "Derogación",
-};
-
-// ── Server-side diff helpers (ported from the former client-side <script>) ──
-type DiffOp<T> = { t: "eq" | "del" | "add"; v: T };
-
-function seqDiff<T>(a: T[], b: T[], eq: (x: T, y: T) => boolean): DiffOp<T>[] {
-	const n = a.length;
-	const m = b.length;
-	// For large sequences use a size cap to avoid O(n*m) blowup
-	if (n * m > 200_000) {
-		const ops: DiffOp<T>[] = [];
-		for (const x of a) ops.push({ t: "del", v: x });
-		for (const y of b) ops.push({ t: "add", v: y });
-		return ops;
-	}
-	const dp: Int32Array[] = [];
-	for (let i = 0; i <= n; i++) dp[i] = new Int32Array(m + 1);
-	for (let i = n - 1; i >= 0; i--) {
-		for (let j = m - 1; j >= 0; j--) {
-			dp[i][j] = eq(a[i], b[j]) ? dp[i + 1][j + 1] + 1 : Math.max(dp[i + 1][j], dp[i][j + 1]);
-		}
-	}
-	const result: DiffOp<T>[] = [];
-	let pi = 0;
-	let pj = 0;
-	while (pi < n && pj < m) {
-		if (eq(a[pi], b[pj])) {
-			result.push({ t: "eq", v: a[pi] });
-			pi++;
-			pj++;
-		} else if (dp[pi + 1][pj] >= dp[pi][pj + 1]) {
-			result.push({ t: "del", v: a[pi] });
-			pi++;
-		} else {
-			result.push({ t: "add", v: b[pj] });
-			pj++;
-		}
-	}
-	while (pi < n) result.push({ t: "del", v: a[pi++] });
-	while (pj < m) result.push({ t: "add", v: b[pj++] });
-	return result;
-}
-
-function wordDiff(before: string, after: string): DiffOp<string>[] {
-	const a = before.split(/(\s+)/);
-	const b = after.split(/(\s+)/);
-	return seqDiff(a, b, (x, y) => x === y);
-}
-
-function esc(s: unknown): string {
-	return String(s)
-		.replace(/&/g, "&amp;")
-		.replace(/</g, "&lt;")
-		.replace(/>/g, "&gt;")
-		.replace(/"/g, "&quot;");
-}
-
-const MONTHS = ["ene", "feb", "mar", "abr", "may", "jun", "jul", "ago", "sep", "oct", "nov", "dic"];
-function formatDate(d: string): string {
-	const dt = new Date(`${d}T00:00:00`);
-	return `${dt.getDate()} ${MONTHS[dt.getMonth()]} ${dt.getFullYear()}`;
-}
-
-function truncate(s: string, max: number): string {
-	if (s.length <= max) return s;
-	return `${s.slice(0, max).replace(/\s+\S*$/, "")}…`;
-}
-
-function buildWordDiffHtml(beforePara: string, afterPara: string): string {
-	const ops = wordDiff(beforePara, afterPara);
-	let beforeHtml = '<span class="diff-label">Antes</span>';
-	let afterHtml = '<span class="diff-label">Ahora</span>';
-	for (const op of ops) {
-		const v = esc(op.v);
-		if (op.t === "eq") {
-			beforeHtml += v;
-			afterHtml += v;
-		} else if (op.t === "del") {
-			beforeHtml += `<span class="diff-word-removed">${v}</span>`;
-		} else {
-			afterHtml += `<span class="diff-word-added">${v}</span>`;
-		}
-	}
-	return `<div class="diff-mod-pair"><div class="diff-para diff-para-removed">${beforeHtml}</div><div class="diff-para diff-para-added">${afterHtml}</div></div>`;
-}
-
-const NO_CHANGE_NOTICE =
-	'<div class="diff-content"><p style="color:var(--text-muted);font-size:0.8125rem;padding:0.75rem;font-style:italic">El texto de este artículo no cambió en esta reforma. Es posible que el cambio afecte a su numeración o contexto dentro de la ley.</p></div>';
-
-function renderBlockDiffHtml(beforeText: string, afterText: string): string {
-	if (beforeText === afterText) return NO_CHANGE_NOTICE;
-
-	const bParas = beforeText
-		.split(/\n\n/)
-		.map((p) => p.trim())
-		.filter(Boolean);
-	const aParas = afterText
-		.split(/\n\n/)
-		.map((p) => p.trim())
-		.filter(Boolean);
-
-	// LCS diff at paragraph level — detects insertions/deletions correctly
-	const paraOps = seqDiff(bParas, aParas, (x, y) => x === y);
-
-	// Group consecutive del+add into modification pairs
-	type Group = { t: "mod"; before: string; after: string } | { t: "add" | "del"; v: string };
-	const groups: Group[] = [];
-	let k = 0;
-	while (k < paraOps.length) {
-		const op = paraOps[k];
-		if (op.t === "del") {
-			const next = paraOps[k + 1];
-			if (next?.t === "add") {
-				groups.push({ t: "mod", before: op.v, after: next.v });
-				k += 2;
-			} else {
-				groups.push({ t: "del", v: op.v });
-				k++;
-			}
-		} else if (op.t === "add") {
-			groups.push({ t: "add", v: op.v });
-			k++;
-		} else {
-			// eq — unchanged paragraphs don't need to be shown
-			k++;
-		}
-	}
-
-	if (groups.length === 0) return NO_CHANGE_NOTICE;
-
-	let html = '<div class="diff-content">';
-	for (const g of groups) {
-		if (g.t === "mod") {
-			html += buildWordDiffHtml(g.before, g.after);
-		} else if (g.t === "add") {
-			html += `<div class="new-block" style="margin:0 0 0.75rem"><div class="version-label">Párrafo añadido</div><div class="version-text">${esc(g.v)}</div></div>`;
-		} else {
-			html += `<div class="diff-mod-pair"><div class="diff-para diff-para-removed"><span class="diff-label">Eliminado</span><span class="diff-word-removed">${esc(g.v)}</span></div></div>`;
-		}
-	}
-	html += "</div>";
-	return html;
-}
-
-function renderUnifiedDiffHtml(diffText: string): string {
-	const lines = diffText.split("\n");
-	let html = '<div class="unified-diff">';
-	let skippedHeader = false;
-	for (const line of lines) {
-		if (!skippedHeader) {
-			if (line.startsWith("diff --git") || line.startsWith("index ") || line.startsWith("---") || line.startsWith("+++")) continue;
-			if (line.startsWith("@@")) skippedHeader = true;
-		}
-		let cls = "unified-diff-line-ctx";
-		if (line.startsWith("+") && !line.startsWith("+++")) cls = "unified-diff-line-add";
-		else if (line.startsWith("-") && !line.startsWith("---")) cls = "unified-diff-line-del";
-		else if (line.startsWith("@@")) cls = "unified-diff-line-hunk";
-		html += `<div class="unified-diff-line ${cls}">${esc(line)}</div>`;
-	}
-	html += "</div>";
-	return html;
-}
-
-// ── Back-link + error-back-link helpers (server-side best guess from `from`;
-//    refined client-side by document.referrer, see the <script> below) ──
-function backLinkFor(from: string | null, id: string | null): { href: string; label: string } {
-	if (from === "cambios") return { href: "/cambios/recientes/", label: "← Volver a cambios recientes" };
-	if (from === "mis-cambios") return { href: "/cambios/para-mi/", label: "← Volver a mis cambios" };
-	if (from === "omnibus" || from === "law") {
-		return { href: id ? `/leyes/${encodeURIComponent(id)}/` : "/cambios/recientes/", label: "← Volver a la ley" };
-	}
-	return { href: "/cambios/recientes/", label: "← Volver" };
-}
-function errorBackLinkFor(from: string | null, id: string | null): { href: string; label: string } {
-	if (from === "cambios") return { href: "/cambios/recientes/", label: "Volver a cambios recientes" };
-	if (from === "omnibus" || from === "law") {
-		return { href: id ? `/leyes/${encodeURIComponent(id)}/` : "/cambios/recientes/", label: "Volver a la ley" };
-	}
-	return { href: "/cambios/para-mi/", label: "Volver a mis cambios" };
-}
-
-// ── Read params server-side ──
-const searchParams = Astro.url.searchParams;
-const normId = searchParams.get("id");
-const date = searchParams.get("date");
-const fromParam = searchParams.get("from");
-const topicParam = searchParams.get("topic");
-const topicIndex = topicParam !== null ? Number.parseInt(topicParam, 10) : Number.NaN;
-const fromOmnibus = fromParam === "omnibus";
-
-// Skip rate-limits on the public API when a bypass key is configured for this
-// Pages Function's runtime. `Astro.locals.runtime.env` was removed in Astro v6
-// for this adapter — the replacement is the `cloudflare:workers` module, which
-// only resolves inside the Cloudflare/workerd runtime, hence the try/catch.
-let bypassKey: string | undefined;
-try {
-	const cf = await import("cloudflare:workers");
-	bypassKey = (cf.env as Record<string, string | undefined> | undefined)?.API_BYPASS_KEY;
-} catch {
-	bypassKey = undefined;
-}
-const apiHeaders: HeadersInit = bypassKey ? { "x-bypass-key": bypassKey } : {};
-
-type PageResult =
-	| {
-			ok: true;
-			data: ReformDetailResponse;
-			topicInfo: OmnibusTopic | null;
-			topicBlockIds: string[] | null;
-			blocks: AffectedBlock[];
-			unifiedDiffHtml: string | null;
-	  }
-	| { ok: false; message: string };
-
-let result: PageResult;
-
-if (!normId || !date) {
-	Astro.response.status = 404;
-	result = { ok: false, message: "Faltan parámetros." };
-} else {
-	try {
-		const reformRes = await fetch(`${API_BASE}/v1/reforms/${encodeURIComponent(normId)}/${encodeURIComponent(date)}`, {
-			headers: apiHeaders,
-			signal: AbortSignal.timeout(8000),
-		});
-		if (!reformRes.ok) {
-			// Mirror the upstream status (404/403/429/503…) so crawlers get an
-			// honest signal; fall back to 500 for anything outside 4xx/5xx.
-			Astro.response.status = reformRes.status >= 400 && reformRes.status < 600 ? reformRes.status : 500;
-			result = { ok: false, message: "No se pudo cargar la reforma." };
-		} else {
-			const data = (await reformRes.json()) as ReformDetailResponse;
-
-			let topicInfo: OmnibusTopic | null = null;
-			let topicBlockIds: string[] | null = null;
-			if (fromOmnibus && !Number.isNaN(topicIndex)) {
-				try {
-					const omnibusRes = await fetch(`${API_BASE}/v1/omnibus/${encodeURIComponent(normId)}`, { headers: apiHeaders, signal: AbortSignal.timeout(8000) });
-					if (omnibusRes.ok) {
-						const omnibusData = (await omnibusRes.json()) as OmnibusResponse;
-						topicInfo = omnibusData.topics?.[topicIndex] ?? null;
-						if (topicInfo && Array.isArray(topicInfo.block_ids) && topicInfo.block_ids.length > 0) {
-							topicBlockIds = topicInfo.block_ids;
-						}
-					}
-				} catch {
-					// Omnibus enrichment is best-effort — the reform itself still renders.
-				}
-			}
-
-			const allBlocks = data.affected_blocks || [];
-			const blockIds = topicBlockIds;
-			const blocks = blockIds ? allBlocks.filter((b) => blockIds.includes(b.block_id)) : allBlocks;
-
-			let unifiedDiffHtml: string | null = null;
-			if (blocks.length === 0 && data.prev_reform_date && !topicBlockIds) {
-				try {
-					const diffRes = await fetch(
-						`${API_BASE}/v1/laws/${encodeURIComponent(normId)}/diff?from=${encodeURIComponent(data.prev_reform_date)}&to=${encodeURIComponent(date)}`,
-						{ headers: apiHeaders, signal: AbortSignal.timeout(8000) },
-					);
-					if (diffRes.ok) {
-						const diffData = (await diffRes.json()) as { diff?: string };
-						unifiedDiffHtml = diffData.diff ? renderUnifiedDiffHtml(diffData.diff) : null;
-					}
-				} catch {
-					unifiedDiffHtml = null;
-				}
-			}
-
-			result = { ok: true, data, topicInfo, topicBlockIds, blocks, unifiedDiffHtml };
-		}
-	} catch {
-		Astro.response.status = 500;
-		result = { ok: false, message: "No se pudo cargar la reforma." };
-	}
-}
-
-// ── Derive display fields (title/description/canonical) only on success ──
-let pageTitle = "Detalle de reforma";
-let pageDescription = "Qué ha cambiado en esta ley y por qué te importa.";
-let canonicalUrl: string | undefined;
-let fechaLegible = "";
-let rankLabel = "";
-let typeLabel = "";
-let headline = "";
-let importance = "";
-
-if (result.ok) {
-	const { reform, law } = result.data;
-	const hasHeadline = !!(reform.headline && reform.headline.length > 0);
-	importance = reform.importance || "";
-	rankLabel = RANK_LABELS[law.rank] ?? law.rank ?? "";
-	const isDerogatingReform = law.status === "derogada" && law.last_reform_date === reform.date;
-	typeLabel = isDerogatingReform ? "Derogación" : (TYPE_LABELS[reform.reform_type ?? ""] ?? "");
-	headline = hasHeadline ? (reform.headline as string) : law.title;
-	fechaLegible = formatDate(reform.date);
-	const shortTitle = law.short_title || law.title;
-	pageTitle = `${headline} — ${shortTitle} (${fechaLegible})`;
-	pageDescription = reform.summary
-		? truncate(reform.summary, 150)
-		: `Qué cambió en ${law.title} el ${fechaLegible}: ${typeLabel || "modificación"}.`;
-	// Canonical intentionally omits `from`/`topic` — those are navigation
-	// context, not a distinct piece of content, and would otherwise create
-	// duplicate-content variants of the same reform for search engines.
-	canonicalUrl = `/cambios/reforma/?id=${encodeURIComponent(normId as string)}&date=${encodeURIComponent(date as string)}`;
-}
-
-const backLink = backLinkFor(fromParam, normId);
-const errorBack = errorBackLinkFor(fromParam, normId);
-
-if (result.ok) {
-	// A reform is immutable once published — cache aggressively. The deploy
-	// pipeline purges the CF zone on every deploy, so a reprocessed reform
-	// (rare) still refreshes promptly.
-	Astro.response.headers.set("Cache-Control", "public, s-maxage=7776000, stale-while-revalidate=86400");
-}
 ---
 
-<Base title={pageTitle} description={pageDescription} ogTitle={`${pageTitle} — Ley Abierta`} canonicalUrl={canonicalUrl} noindex={!result.ok}>
+<Base
+	title="Detalle de reforma"
+	description="Qué ha cambiado en esta ley y por qué te importa."
+	ogTitle="Detalle de reforma — Ley Abierta"
+	noindex
+>
 	<style is:global>
 		.reforma-wrap {
 			max-width: 780px;
@@ -436,11 +45,7 @@ if (result.ok) {
 			font-size: 0.6875rem; font-weight: 600; color: var(--accent);
 			background: var(--accent-bg); padding: 0.1875rem 0.5625rem; border-radius: 4px;
 		}
-		.reforma-topic-badge {
-			font-size: 0.6875rem; font-weight: 600; color: var(--accent);
-			background: var(--accent-bg); padding: 0.125rem 0.5rem; border-radius: 4px;
-		}
-		.reforma-headline {
+		:global(.reforma-headline) {
 			font-family: var(--font-serif); font-size: 1.875rem; font-weight: 700;
 			line-height: 1.2; color: var(--text); margin: 0 0 0.625rem;
 			letter-spacing: -0.02em;
@@ -537,6 +142,13 @@ if (result.ok) {
 		}
 		.reforma-nav a:hover { background: var(--accent-faint); border-color: var(--accent); }
 
+		/* ── Skeleton ── */
+		.skeleton-line {
+			height: 0.875rem; background: var(--border-light); border-radius: 4px;
+			margin-bottom: 0.625rem; animation: pulse 1.5s ease-in-out infinite;
+		}
+		@keyframes pulse { 0%, 100% { opacity: 0.4; } 50% { opacity: 1; } }
+
 		.error-state {
 			text-align: center; padding: 3rem 1.5rem;
 			background: var(--danger-bg); border: 1px solid var(--danger); border-radius: 12px;
@@ -577,134 +189,404 @@ if (result.ok) {
 		}
 
 		@media (max-width: 640px) {
-			.reforma-headline { font-size: 1.625rem; }
+			:global(.reforma-headline) { font-size: 1.625rem; }
 		}
 	</style>
 
 	<div class="reforma-wrap">
-		<a href={backLink.href} class="reforma-back" id="reforma-back">{backLink.label}</a>
+		<a href="/cambios/recientes/" class="reforma-back" id="reforma-back">&larr; Volver</a>
 		<div id="reforma-content">
-			{result.ok ? (
-				<Fragment>
-					<div class="reforma-header">
-						<div class="reforma-date-row">
-							<span class="reforma-date">{fechaLegible}</span>
-							{typeLabel && <span class="reforma-type-badge"> · {typeLabel}</span>}
-							{importance === "high" && <span class="reforma-importance-badge">Cambio importante</span>}
-							{result.topicInfo && <span class="reforma-topic-badge">{result.topicInfo.topic_label}</span>}
-						</div>
-						<h1 class="reforma-headline">{headline}</h1>
-						<div class="reforma-law-info">
-							{rankLabel} · {STATUS_LABELS[result.data.law.status] ?? result.data.law.status} ·{" "}
-							<a href={`/leyes/${encodeURIComponent(result.data.law.id)}/`}>{result.data.law.title}</a>
-						</div>
-					</div>
-
-					{result.data.reform.summary && <div class="reforma-summary">{result.data.reform.summary}</div>}
-
-					{result.topicBlockIds && result.blocks.length === 0 && (
-						<Fragment>
-							<p style="color:var(--text-muted);font-size:0.9375rem;margin-bottom:0.5rem">
-								Los {result.topicBlockIds.length} artículo{result.topicBlockIds.length !== 1 ? "s" : ""} de este tema no se modificaron en esta reforma.
-							</p>
-							<p style="font-size:0.875rem">
-								<a
-									href={`/cambios/reforma/?id=${encodeURIComponent(result.data.law.id)}&date=${encodeURIComponent(result.data.reform.date)}&from=omnibus`}
-									style="color:var(--accent)"
-								>
-									Ver todos los cambios de esta reforma →
-								</a>
-							</p>
-						</Fragment>
-					)}
-
-					{result.blocks.length > 0 && (
-						<section class="reforma-changes">
-							<h2>Qué ha cambiado <span class="reforma-changes-count">({result.blocks.length} artículo{result.blocks.length !== 1 ? "s" : ""})</span></h2>
-							{result.blocks.map((b, i) => {
-								const isNew = !b.before_text;
-								const isOpen = i < 5;
-								const isNotaInicial = b.block_type === "nota_inicial" || b.block_id === "no";
-								const blockLabel = isNotaInicial ? "Nota oficial del BOE" : b.title || b.block_id;
-								const diffHtml = isNew ? "" : renderBlockDiffHtml(b.before_text as string, b.after_text);
-								return (
-									<div class="block-change">
-										<div class="block-change-header" data-idx={i}>
-											<span>{blockLabel}</span>
-											<span style="font-size:0.75rem;color:var(--text-muted)">{isOpen ? "▾" : "▸"}</span>
-										</div>
-										<div class={`block-change-body${isOpen ? " open" : ""}`} id={`block-${i}`}>
-											{isNew ? (
-												<div class="new-block">
-													<div class="version-label">{isNotaInicial ? "Aviso oficial" : "Artículo nuevo"}</div>
-													<div class="version-text">{b.after_text}</div>
-												</div>
-											) : (
-												<div set:html={diffHtml} />
-											)}
-										</div>
-									</div>
-								);
-							})}
-						</section>
-					)}
-
-					{result.blocks.length === 0 && result.data.prev_reform_date && !result.topicBlockIds && (
-						<section class="reforma-changes">
-							<h2>Qué ha cambiado</h2>
-							{result.unifiedDiffHtml ? (
-								<div set:html={result.unifiedDiffHtml} />
-							) : (
-								<p style="color:var(--text-muted);font-size:0.875rem">No se encontraron diferencias para esta reforma.</p>
-							)}
-						</section>
-					)}
-
-					<nav class="reforma-nav">
-						<a href={`/leyes/${encodeURIComponent(result.data.law.id)}/?from=reforma`}>Ver ley completa →</a>
-						<a href={result.data.source_url} target="_blank" rel="noopener">Ver en BOE ↗</a>
-					</nav>
-				</Fragment>
-			) : (
-				<div class="error-state">
-					<p>{result.message}</p>
-					<a href={errorBack.href} style="color:var(--accent)">{errorBack.label}</a>
-				</div>
-			)}
+			<div class="reforma-header">
+				<div class="skeleton-line" style="width:30%"></div>
+				<div class="skeleton-line" style="width:80%;height:1.5rem"></div>
+				<div class="skeleton-line" style="width:60%"></div>
+			</div>
+			<div class="skeleton-line" style="width:100%;height:4rem;border-radius:10px"></div>
+			<br>
+			<div class="skeleton-line" style="width:40%"></div>
+			<div class="skeleton-line" style="width:100%;height:6rem;border-radius:10px"></div>
 		</div>
 	</div>
 
 	<script is:inline>
 		(function () {
-			// Progressive enhancement only — all content above is already in the
-			// server-rendered HTML. This script just adds collapse/expand toggles
-			// and refines the back link using document.referrer (unknown server-side).
-			var backLink = document.getElementById("reforma-back");
-			if (backLink && document.referrer && document.referrer.indexOf(location.origin) === 0) {
-				var refPath = new URL(document.referrer).pathname;
-				if (refPath === "/cambios/recientes/" || refPath === "/cambios/") {
-					backLink.innerHTML = "&larr; Volver a cambios recientes";
-				} else if (refPath === "/cambios/para-mi/") {
-					backLink.innerHTML = "&larr; Volver a mis cambios";
-				} else if (refPath.indexOf("/leyes/") === 0) {
-					backLink.innerHTML = "&larr; Volver a la ley";
+			// Generic LCS-based sequence diff (works for both token arrays and paragraph arrays)
+			function seqDiff(a, b, eq) {
+				var n = a.length, m = b.length;
+				// For large sequences use a size cap to avoid O(n*m) blowup
+				if (n * m > 200000) {
+					// Fallback: treat everything as replaced
+					var ops = [];
+					for (var x = 0; x < n; x++) ops.push({ t: "del", v: a[x] });
+					for (var y = 0; y < m; y++) ops.push({ t: "add", v: b[y] });
+					return ops;
 				}
-				backLink.addEventListener("click", function (e) {
-					e.preventDefault();
-					history.back();
-				});
+				var dp = [];
+				for (var xi = 0; xi <= n; xi++) {
+					dp[xi] = new Int32Array(m + 1);
+				}
+				for (var i = n - 1; i >= 0; i--) {
+					for (var j = m - 1; j >= 0; j--) {
+						dp[i][j] = eq(a[i], b[j]) ? dp[i+1][j+1] + 1 : Math.max(dp[i+1][j], dp[i][j+1]);
+					}
+				}
+				var result = [];
+				var pi = 0, pj = 0;
+				while (pi < n && pj < m) {
+					if (eq(a[pi], b[pj])) { result.push({ t: "eq", v: a[pi] }); pi++; pj++; }
+					else if (dp[pi+1][pj] >= dp[pi][pj+1]) { result.push({ t: "del", v: a[pi] }); pi++; }
+					else { result.push({ t: "add", v: b[pj] }); pj++; }
+				}
+				while (pi < n) { result.push({ t: "del", v: a[pi++] }); }
+				while (pj < m) { result.push({ t: "add", v: b[pj++] }); }
+				return result;
 			}
 
-			document.querySelectorAll(".block-change-header").forEach(function (hdr) {
-				hdr.addEventListener("click", function () {
-					var idx = this.getAttribute("data-idx");
-					var body = document.getElementById("block-" + idx);
-					var arrow = this.querySelector("span:last-child");
-					if (!body) return;
-					body.classList.toggle("open");
-					if (arrow) arrow.textContent = body.classList.contains("open") ? "▾" : "▸";
+			function wordDiff(before, after) {
+				var a = before.split(/(\s+)/);
+				var b = after.split(/(\s+)/);
+				return seqDiff(a, b, function(x, y) { return x === y; });
+			}
+
+			function esc(s) { return String(s).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;"); }
+			function formatDate(d) {
+				var dt = new Date(d + "T00:00:00");
+				var months = ["ene", "feb", "mar", "abr", "may", "jun", "jul", "ago", "sep", "oct", "nov", "dic"];
+				return dt.getDate() + " " + months[dt.getMonth()] + " " + dt.getFullYear();
+			}
+
+			function buildWordDiffHtml(beforePara, afterPara) {
+				var ops = wordDiff(beforePara, afterPara);
+				var beforeHtml = '<span class="diff-label">Antes</span>';
+				var afterHtml = '<span class="diff-label">Ahora</span>';
+				for (var k = 0; k < ops.length; k++) {
+					var o = ops[k];
+					var v = esc(o.v);
+					if (o.t === "eq") {
+						beforeHtml += v;
+						afterHtml += v;
+					} else if (o.t === "del") {
+						beforeHtml += '<span class="diff-word-removed">' + v + '</span>';
+					} else {
+						afterHtml += '<span class="diff-word-added">' + v + '</span>';
+					}
+				}
+				return '<div class="diff-mod-pair">'
+					+ '<div class="diff-para diff-para-removed">' + beforeHtml + '</div>'
+					+ '<div class="diff-para diff-para-added">' + afterHtml + '</div>'
+					+ '</div>';
+			}
+
+			function renderBlockDiff(beforeText, afterText, container) {
+				if (beforeText === afterText) {
+					container.innerHTML = '<div class="diff-content"><p style="color:var(--text-muted);font-size:0.8125rem;padding:0.75rem;font-style:italic">El texto de este artículo no cambió en esta reforma. Es posible que el cambio afecte a su numeración o contexto dentro de la ley.</p></div>';
+					return;
+				}
+				var bParas = beforeText.split(/\n\n/).map(function(p){return p.trim();}).filter(Boolean);
+				var aParas = afterText.split(/\n\n/).map(function(p){return p.trim();}).filter(Boolean);
+
+				// LCS diff at paragraph level — detects insertions/deletions correctly
+				var paraOps = seqDiff(bParas, aParas, function(x, y) { return x === y; });
+
+				// Group consecutive del+add into modification pairs
+				var groups = [];
+				var k = 0;
+				while (k < paraOps.length) {
+					var op = paraOps[k];
+					if (op.t === "del") {
+						// Peek: is the next op an "add"? → modification pair
+						if (k + 1 < paraOps.length && paraOps[k + 1].t === "add") {
+							groups.push({ t: "mod", before: op.v, after: paraOps[k + 1].v });
+							k += 2;
+						} else {
+							groups.push({ t: "del", v: op.v });
+							k++;
+						}
+					} else if (op.t === "add") {
+						groups.push({ t: "add", v: op.v });
+						k++;
+					} else {
+						// eq — skip unchanged paragraphs (they don't need to be shown)
+						k++;
+					}
+				}
+
+				if (groups.length === 0) {
+					container.innerHTML = '<div class="diff-content"><p style="color:var(--text-muted);font-size:0.8125rem;padding:0.75rem;font-style:italic">El texto de este artículo no cambió en esta reforma. Es posible que el cambio afecte a su numeración o contexto dentro de la ley.</p></div>';
+					return;
+				}
+
+				var html = '<div class="diff-content">';
+				for (var gi = 0; gi < groups.length; gi++) {
+					var g = groups[gi];
+					if (g.t === "mod") {
+						html += buildWordDiffHtml(g.before, g.after);
+					} else if (g.t === "add") {
+						html += '<div class="new-block" style="margin:0 0 0.75rem">'
+							+ '<div class="version-label">Párrafo añadido</div>'
+							+ '<div class="version-text">' + esc(g.v) + '</div>'
+							+ '</div>';
+					} else {
+						// del
+						html += '<div class="diff-mod-pair">'
+							+ '<div class="diff-para diff-para-removed"><span class="diff-label">Eliminado</span>'
+							+ '<span class="diff-word-removed">' + esc(g.v) + '</span></div>'
+							+ '</div>';
+					}
+				}
+				html += '</div>';
+				container.innerHTML = html;
+			}
+
+			// Context-aware back link
+			var backLink = document.getElementById("reforma-back");
+			if (backLink) {
+				var params = new URLSearchParams(window.location.search);
+				var from = params.get("from");
+				var normId = params.get("id") || "";
+
+				if (from === "cambios") {
+					backLink.innerHTML = "&larr; Volver a cambios recientes";
+				} else if (from === "mis-cambios") {
+					backLink.innerHTML = "&larr; Volver a mis cambios";
+					backLink.href = "/cambios/para-mi/";
+				} else if (from === "omnibus" || from === "law") {
+					backLink.innerHTML = "&larr; Volver a la ley";
+				} else if (document.referrer && document.referrer.indexOf(location.origin) === 0) {
+					var refPath = new URL(document.referrer).pathname;
+					if (refPath === "/cambios/recientes/" || refPath === "/cambios/") {
+						backLink.innerHTML = "&larr; Volver a cambios recientes";
+					} else if (refPath === "/cambios/para-mi/") {
+						backLink.innerHTML = "&larr; Volver a mis cambios";
+					} else if (refPath.indexOf("/leyes/") === 0) {
+						backLink.innerHTML = "&larr; Volver a la ley";
+					}
+				}
+
+				if (document.referrer && document.referrer.indexOf(location.origin) === 0) {
+					backLink.addEventListener("click", function(e) {
+						e.preventDefault();
+						history.back();
+					});
+				} else if (from === "cambios") {
+					backLink.href = "/cambios/recientes/";
+				} else if ((from === "omnibus" || from === "law") && normId) {
+					backLink.href = "/leyes/" + encodeURIComponent(normId) + "/";
+				}
+			}
+
+			var RANK_LABELS = {
+				constitucion: "Constitución", ley_organica: "Ley Orgánica", ley: "Ley",
+				real_decreto_ley: "Decreto urgente", real_decreto_legislativo: "Decreto legislativo",
+				real_decreto: "Real Decreto", orden: "Orden", resolucion: "Resolución",
+				acuerdo_internacional: "Acuerdo internacional", circular: "Circular",
+				instruccion: "Instrucción", decreto: "Decreto", reglamento: "Reglamento",
+				acuerdo: "Acuerdo"
+			};
+			var STATUS_LABELS = {
+				vigente: "En vigor",
+				derogada: "Ya no está en vigor",
+				parcialmente_derogada: "Parcialmente en vigor"
+			};
+			var TYPE_LABELS = {
+				new_law: "Ley nueva", modification: "Modificación",
+				correction: "Corrección", derogation: "Derogación"
+			};
+
+			var qParams = new URLSearchParams(window.location.search);
+			var normId = qParams.get("id") || "";
+			var date = qParams.get("date");
+			var topicParam = qParams.get("topic");
+			var topicIndex = topicParam !== null ? parseInt(topicParam, 10) : NaN;
+			var fromOmnibus = qParams.get("from") === "omnibus";
+
+			var API = document.documentElement.dataset.api;
+			var contentDiv = document.getElementById("reforma-content");
+
+			if (!normId || !date) {
+				contentDiv.innerHTML = '<div class="error-state"><p>Faltan parámetros.</p></div>';
+				return;
+			}
+
+			var reformUrl = API + "/v1/reforms/" + encodeURIComponent(normId) + "/" + encodeURIComponent(date);
+			var promises = [fetch(reformUrl).then(function(r) { if (!r.ok) throw new Error(r.status); return r.json(); })];
+			if (fromOmnibus && !isNaN(topicIndex)) {
+				promises.push(
+					fetch(API + "/v1/omnibus/" + encodeURIComponent(normId))
+						.then(function(r) { return r.ok ? r.json() : null; })
+						.catch(function() { return null; })
+				);
+			}
+
+			Promise.all(promises)
+				.then(function (results) {
+					var data = results[0];
+					var omnibusData = results[1] || null;
+					var topicInfo = null;
+					var topicBlockIds = null;
+
+					if (omnibusData && omnibusData.topics && !isNaN(topicIndex)) {
+						topicInfo = omnibusData.topics[topicIndex] || null;
+						if (topicInfo && Array.isArray(topicInfo.block_ids) && topicInfo.block_ids.length > 0) {
+							topicBlockIds = topicInfo.block_ids;
+						}
+					}
+
+					var reform = data.reform;
+					var law = data.law;
+					var allBlocks = data.affected_blocks || [];
+					var blocks = topicBlockIds
+						? allBlocks.filter(function(b) { return topicBlockIds.indexOf(b.block_id) !== -1; })
+						: allBlocks;
+					var hasHeadline = reform.headline && reform.headline.length > 0;
+					var importance = reform.importance || "";
+					var rankLabel = RANK_LABELS[law.rank] || law.rank || "";
+
+					var isDerogatingReform = law.status === "derogada" && law.last_reform_date === reform.date;
+					var typeLabel = isDerogatingReform ? "Derogación" : (TYPE_LABELS[reform.reform_type] || "");
+					var headline = hasHeadline ? reform.headline : law.title;
+
+					// ── Header ──
+					var html = '<div class="reforma-header">';
+					html += '<div class="reforma-date-row">';
+					html += '<span class="reforma-date">' + esc(formatDate(reform.date)) + '</span>';
+					if (typeLabel) html += '<span class="reforma-type-badge"> · ' + esc(typeLabel) + '</span>';
+					if (importance === "high") html += '<span class="reforma-importance-badge">Cambio importante</span>';
+					if (topicInfo) html += '<span style="font-size:0.6875rem;font-weight:600;color:var(--accent);background:var(--accent-bg);padding:0.125rem 0.5rem;border-radius:4px">' + esc(topicInfo.topic_label) + '</span>';
+					html += '</div>';
+					html += '<h1 class="reforma-headline">' + esc(headline) + '</h1>';
+					html += '<div class="reforma-law-info">';
+					html += esc(rankLabel) + ' · ' + esc(STATUS_LABELS[law.status] || law.status);
+					html += ' · <a href="/leyes/' + encodeURIComponent(law.id) + '/">' + esc(law.title) + '</a>';
+					html += '</div></div>';
+
+					// ── Summary ──
+					if (reform.summary) {
+						html += '<div class="reforma-summary">' + esc(reform.summary) + '</div>';
+					}
+
+					// ── Empty topic intersection ──
+					if (topicBlockIds && blocks.length === 0) {
+						html += '<p style="color:var(--text-muted);font-size:0.9375rem;margin-bottom:0.5rem">Los ' + topicBlockIds.length + ' artículo' + (topicBlockIds.length !== 1 ? 's' : '') + ' de este tema no se modificaron en esta reforma.</p>';
+						html += '<p style="font-size:0.875rem"><a href="/cambios/reforma/?id=' + encodeURIComponent(law.id) + '&date=' + encodeURIComponent(reform.date) + '&from=omnibus" style="color:var(--accent)">Ver todos los cambios de esta reforma &rarr;</a></p>';
+					}
+
+					// ── Affected blocks ──
+					if (blocks.length > 0) {
+						html += '<section class="reforma-changes">';
+						html += '<h2>Qué ha cambiado <span class="reforma-changes-count">(' + blocks.length + ' artículo' + (blocks.length !== 1 ? 's' : '') + ')</span></h2>';
+
+						for (var i = 0; i < blocks.length; i++) {
+							var b = blocks[i];
+							var isNew = !b.before_text;
+							var isOpen = i < 5;
+
+							html += '<div class="block-change">';
+							var isNotaInicial = b.block_type === "nota_inicial" || b.block_id === "no";
+							var blockLabel = isNotaInicial ? "Nota oficial del BOE" : (b.title || b.block_id);
+
+							html += '<div class="block-change-header" data-idx="' + i + '">';
+							html += '<span>' + esc(blockLabel) + '</span>';
+							html += '<span style="font-size:0.75rem;color:var(--text-muted)">' + (isOpen ? '▾' : '▸') + '</span>';
+							html += '</div>';
+							html += '<div class="block-change-body' + (isOpen ? ' open' : '') + '" id="block-' + i + '">';
+
+							if (isNew) {
+								var newBlockLabel = isNotaInicial ? "Aviso oficial" : "Artículo nuevo";
+								html += '<div class="new-block">';
+								html += '<div class="version-label">' + newBlockLabel + '</div>';
+								html += '<div class="version-text">' + esc(b.after_text) + '</div>';
+								html += '</div>';
+							} else {
+								html += '<div id="diff-block-' + i + '"><div class="diff-content" style="color:var(--text-muted);font-size:0.8125rem;padding:1rem">Cargando diferencias...</div></div>';
+							}
+							html += '</div></div>';
+						}
+						html += '</section>';
+					} else if (data.prev_reform_date && !topicBlockIds) {
+						html += '<section class="reforma-changes">';
+						html += '<h2>Qué ha cambiado</h2>';
+						html += '<div id="unified-diff-container"><div class="diff-content" style="color:var(--text-muted);font-size:0.8125rem;padding:1rem">Cargando diferencias...</div></div>';
+						html += '</section>';
+					}
+
+					// ── Nav ──
+					html += '<nav class="reforma-nav">';
+					html += '<a href="/leyes/' + encodeURIComponent(law.id) + '/?from=reforma">Ver ley completa &rarr;</a>';
+					html += '<a href="' + esc(data.source_url) + '" target="_blank" rel="noopener">Ver en BOE ↗</a>';
+					html += '</nav>';
+
+					contentDiv.innerHTML = html;
+					document.title = headline + ' — Ley Abierta';
+
+					// ── Toggles ──
+					contentDiv.querySelectorAll('.block-change-header').forEach(function (hdr) {
+						hdr.addEventListener('click', function () {
+							var idx = this.getAttribute('data-idx');
+							var body = document.getElementById('block-' + idx);
+							var arrow = this.querySelector('span:last-child');
+							body.classList.toggle('open');
+							arrow.textContent = body.classList.contains('open') ? '▾' : '▸';
+						});
+					});
+
+					// ── Unified diff fallback ──
+					if (blocks.length === 0 && data.prev_reform_date && !topicBlockIds) {
+						var diffUrl = API + "/v1/laws/" + encodeURIComponent(normId) + "/diff?from=" + encodeURIComponent(data.prev_reform_date) + "&to=" + encodeURIComponent(date);
+						fetch(diffUrl)
+							.then(function (r) { return r.ok ? r.json() : null; })
+							.then(function (diffData) {
+								var container = document.getElementById("unified-diff-container");
+								if (!container || !diffData || !diffData.diff) {
+									if (container) container.innerHTML = '<p style="color:var(--text-muted);font-size:0.875rem">No se encontraron diferencias para esta reforma.</p>';
+									return;
+								}
+								var lines = diffData.diff.split("\n");
+								var diffHtml = '<div class="unified-diff">';
+								var skippedHeader = false;
+								for (var j = 0; j < lines.length; j++) {
+									var line = lines[j];
+									if (!skippedHeader) {
+										if (line.indexOf("diff --git") === 0 || line.indexOf("index ") === 0 || line.indexOf("---") === 0 || line.indexOf("+++") === 0) continue;
+										if (line.indexOf("@@") === 0) skippedHeader = true;
+									}
+									var cls = "unified-diff-line-ctx";
+									if (line.indexOf("+") === 0 && line.indexOf("+++") !== 0) cls = "unified-diff-line-add";
+									else if (line.indexOf("-") === 0 && line.indexOf("---") !== 0) cls = "unified-diff-line-del";
+									else if (line.indexOf("@@") === 0) cls = "unified-diff-line-hunk";
+									diffHtml += '<div class="unified-diff-line ' + cls + '">' + esc(line) + '</div>';
+								}
+								diffHtml += '</div>';
+								container.innerHTML = diffHtml;
+							})
+							.catch(function () {
+								var container = document.getElementById("unified-diff-container");
+								if (container) container.innerHTML = '<p style="color:var(--text-muted);font-size:0.875rem">No se pudieron cargar las diferencias.</p>';
+							});
+					}
+
+					// Render word diff for blocks that have before_text
+					if (blocks.length > 0) {
+						for (var bi = 0; bi < blocks.length; bi++) {
+							var blk = blocks[bi];
+							if (!blk.before_text) continue;
+							var container = document.getElementById("diff-block-" + bi);
+							if (container) {
+								renderBlockDiff(blk.before_text, blk.after_text, container);
+							}
+						}
+					}
+				})
+				.catch(function () {
+					var params2 = new URLSearchParams(window.location.search);
+					var from2 = params2.get("from") || "";
+					var errorBackHref = "/cambios/para-mi/";
+					var errorBackLabel = "Volver a mis cambios";
+					if (from2 === "cambios") { errorBackHref = "/cambios/recientes/"; errorBackLabel = "Volver a cambios recientes"; }
+					else if (from2 === "omnibus") { errorBackHref = "/leyes/" + encodeURIComponent(params2.get("id") || "") + "/"; errorBackLabel = "Volver a la ley"; }
+					else if (from2 === "law") { errorBackHref = "/leyes/" + encodeURIComponent(params2.get("id") || "") + "/"; errorBackLabel = "Volver a la ley"; }
+					contentDiv.innerHTML = '<div class="error-state"><p>No se pudo cargar la reforma.</p><a href="' + errorBackHref + '" style="color:var(--accent)">' + errorBackLabel + '</a></div>';
 				});
-			});
 		})();
 	</script>
 </Base>

--- a/packages/web/src/pages/cambios/reforma/index.astro
+++ b/packages/web/src/pages/cambios/reforma/index.astro
@@ -302,9 +302,12 @@ if (!normId || !date) {
 	try {
 		const reformRes = await fetch(`${API_BASE}/v1/reforms/${encodeURIComponent(normId)}/${encodeURIComponent(date)}`, {
 			headers: apiHeaders,
+			signal: AbortSignal.timeout(8000),
 		});
 		if (!reformRes.ok) {
-			Astro.response.status = reformRes.status === 404 ? 404 : 500;
+			// Mirror the upstream status (404/403/429/503…) so crawlers get an
+			// honest signal; fall back to 500 for anything outside 4xx/5xx.
+			Astro.response.status = reformRes.status >= 400 && reformRes.status < 600 ? reformRes.status : 500;
 			result = { ok: false, message: "No se pudo cargar la reforma." };
 		} else {
 			const data = (await reformRes.json()) as ReformDetailResponse;
@@ -313,7 +316,7 @@ if (!normId || !date) {
 			let topicBlockIds: string[] | null = null;
 			if (fromOmnibus && !Number.isNaN(topicIndex)) {
 				try {
-					const omnibusRes = await fetch(`${API_BASE}/v1/omnibus/${encodeURIComponent(normId)}`, { headers: apiHeaders });
+					const omnibusRes = await fetch(`${API_BASE}/v1/omnibus/${encodeURIComponent(normId)}`, { headers: apiHeaders, signal: AbortSignal.timeout(8000) });
 					if (omnibusRes.ok) {
 						const omnibusData = (await omnibusRes.json()) as OmnibusResponse;
 						topicInfo = omnibusData.topics?.[topicIndex] ?? null;
@@ -335,7 +338,7 @@ if (!normId || !date) {
 				try {
 					const diffRes = await fetch(
 						`${API_BASE}/v1/laws/${encodeURIComponent(normId)}/diff?from=${encodeURIComponent(data.prev_reform_date)}&to=${encodeURIComponent(date)}`,
-						{ headers: apiHeaders },
+						{ headers: apiHeaders, signal: AbortSignal.timeout(8000) },
 					);
 					if (diffRes.ok) {
 						const diffData = (await diffRes.json()) as { diff?: string };

--- a/packages/web/src/pages/sitemap-leyes.xml.ts
+++ b/packages/web/src/pages/sitemap-leyes.xml.ts
@@ -1,0 +1,69 @@
+/**
+ * Sitemap: core pages + the ~12k law detail pages, generated from Content
+ * Collections at build time. One of two child sitemaps referenced by the
+ * /sitemap.xml index (see sitemap.xml.ts and sitemap-reformas.xml.ts).
+ */
+
+import { getCollection } from "astro:content";
+import type { APIRoute } from "astro";
+
+export const prerender = true;
+
+const SITE_URL = "https://leyabierta.es";
+
+export const GET: APIRoute = async () => {
+	const laws = await getCollection("laws");
+
+	const secondaryPages = [
+		{ path: "/cambios/", changefreq: "daily", priority: "0.6" },
+		{ path: "/sobre/", changefreq: "monthly", priority: "0.5" },
+		{ path: "/sobre/contribuir/", changefreq: "monthly", priority: "0.4" },
+		{ path: "/sobre/apoyar/", changefreq: "monthly", priority: "0.4" },
+		{ path: "/sobre/api/", changefreq: "monthly", priority: "0.4" },
+		{ path: "/alertas/", changefreq: "monthly", priority: "0.5" },
+		{ path: "/mi-situacion/", changefreq: "monthly", priority: "0.5" },
+		{ path: "/privacidad/", changefreq: "yearly", priority: "0.2" },
+		{ path: "/cookies/", changefreq: "yearly", priority: "0.2" },
+		{ path: "/aviso-legal/", changefreq: "yearly", priority: "0.2" },
+	];
+
+	const urls = [
+		`  <url>
+    <loc>${SITE_URL}/</loc>
+    <changefreq>daily</changefreq>
+    <priority>1.0</priority>
+  </url>`,
+		...secondaryPages.map(
+			(p) => `  <url>
+    <loc>${SITE_URL}${p.path}</loc>
+    <changefreq>${p.changefreq}</changefreq>
+    <priority>${p.priority}</priority>
+  </url>`,
+		),
+	];
+
+	for (const law of laws) {
+		const d = law.data;
+		// Only include lastmod for dates from 1970 onward (Google rejects earlier dates)
+		const lastmod =
+			d.ultima_actualizacion &&
+			/^\d{4}-\d{2}-\d{2}$/.test(d.ultima_actualizacion) &&
+			d.ultima_actualizacion >= "1970-01-01"
+				? `\n    <lastmod>${d.ultima_actualizacion}</lastmod>`
+				: "";
+		urls.push(`  <url>
+    <loc>${SITE_URL}/leyes/${d.identificador}/</loc>${lastmod}
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>`);
+	}
+
+	const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${urls.join("\n")}
+</urlset>`;
+
+	return new Response(xml, {
+		headers: { "Content-Type": "application/xml; charset=utf-8" },
+	});
+};

--- a/packages/web/src/pages/sitemap-reformas.xml.ts
+++ b/packages/web/src/pages/sitemap-reformas.xml.ts
@@ -1,0 +1,58 @@
+/**
+ * Sitemap: reform detail pages (/cambios/reforma/?id=&date=), one <loc> per
+ * reform enumerated from each law's `reformas[]` (excluding the original
+ * version — that's the law page itself, already in sitemap-leyes.xml).
+ *
+ * This is the SEO recovery for the ~44k reform pages that were noindex'd on
+ * 2026-05-04 when the reform page was collapsed into a single client-side
+ * route (see the reform-SSR plan). Restoring a canonical, crawlable URL per
+ * reform plus this sitemap entry is what lets Google re-discover them.
+ *
+ * One of two child sitemaps referenced by the /sitemap.xml index.
+ *
+ * TODO: reformas count (~44k) fits under the 50k-URL sitemap protocol limit
+ * today, but doesn't have much headroom. If it grows past ~48k, split this
+ * file by year (sitemap-reformas-2024.xml, sitemap-reformas-2025.xml, ...)
+ * and update the index in sitemap.xml.ts accordingly.
+ */
+
+import { getCollection } from "astro:content";
+import type { APIRoute } from "astro";
+
+export const prerender = true;
+
+const SITE_URL = "https://leyabierta.es";
+
+export const GET: APIRoute = async () => {
+	const laws = await getCollection("laws");
+
+	const urls: string[] = [];
+
+	for (const law of laws) {
+		const d = law.data;
+		for (const reforma of d.reformas) {
+			// The original version's "reforma" entry shares the law's publication
+			// date — it's not a change, it's the law coming into existence. Skip it;
+			// that content lives at /leyes/<id>/, not /cambios/reforma/.
+			if (reforma.fecha === d.fecha_publicacion) continue;
+			if (!/^\d{4}-\d{2}-\d{2}$/.test(reforma.fecha)) continue;
+
+			const loc = `${SITE_URL}/cambios/reforma/?id=${encodeURIComponent(d.identificador)}&amp;date=${encodeURIComponent(reforma.fecha)}`;
+			urls.push(`  <url>
+    <loc>${loc}</loc>
+    <lastmod>${reforma.fecha}</lastmod>
+    <changefreq>never</changefreq>
+    <priority>0.5</priority>
+  </url>`);
+		}
+	}
+
+	const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${urls.join("\n")}
+</urlset>`;
+
+	return new Response(xml, {
+		headers: { "Content-Type": "application/xml; charset=utf-8" },
+	});
+};

--- a/packages/web/src/pages/sitemap.xml.ts
+++ b/packages/web/src/pages/sitemap.xml.ts
@@ -1,8 +1,11 @@
 /**
- * Sitemap generated from Content Collections at build time.
+ * Sitemap index. Splits into two child sitemaps so each stays comfortably
+ * under the sitemap protocol's 50k-URL-per-file limit:
+ *  - sitemap-leyes.xml    — core pages + ~12k law detail pages
+ *  - sitemap-reformas.xml — ~44k individual reform pages (see that file's
+ *    header comment for why these were missing from the sitemap before).
  */
 
-import { getCollection } from "astro:content";
 import type { APIRoute } from "astro";
 
 export const prerender = true;
@@ -10,56 +13,15 @@ export const prerender = true;
 const SITE_URL = "https://leyabierta.es";
 
 export const GET: APIRoute = async () => {
-	const laws = await getCollection("laws");
-
-	const secondaryPages = [
-		{ path: "/cambios/", changefreq: "daily", priority: "0.6" },
-		{ path: "/sobre/", changefreq: "monthly", priority: "0.5" },
-		{ path: "/sobre/contribuir/", changefreq: "monthly", priority: "0.4" },
-		{ path: "/sobre/apoyar/", changefreq: "monthly", priority: "0.4" },
-		{ path: "/sobre/api/", changefreq: "monthly", priority: "0.4" },
-		{ path: "/alertas/", changefreq: "monthly", priority: "0.5" },
-		{ path: "/mi-situacion/", changefreq: "monthly", priority: "0.5" },
-		{ path: "/privacidad/", changefreq: "yearly", priority: "0.2" },
-		{ path: "/cookies/", changefreq: "yearly", priority: "0.2" },
-		{ path: "/aviso-legal/", changefreq: "yearly", priority: "0.2" },
-	];
-
-	const urls = [
-		`  <url>
-    <loc>${SITE_URL}/</loc>
-    <changefreq>daily</changefreq>
-    <priority>1.0</priority>
-  </url>`,
-		...secondaryPages.map(
-			(p) => `  <url>
-    <loc>${SITE_URL}${p.path}</loc>
-    <changefreq>${p.changefreq}</changefreq>
-    <priority>${p.priority}</priority>
-  </url>`,
-		),
-	];
-
-	for (const law of laws) {
-		const d = law.data;
-		// Only include lastmod for dates from 1970 onward (Google rejects earlier dates)
-		const lastmod =
-			d.ultima_actualizacion &&
-			/^\d{4}-\d{2}-\d{2}$/.test(d.ultima_actualizacion) &&
-			d.ultima_actualizacion >= "1970-01-01"
-				? `\n    <lastmod>${d.ultima_actualizacion}</lastmod>`
-				: "";
-		urls.push(`  <url>
-    <loc>${SITE_URL}/leyes/${d.identificador}/</loc>${lastmod}
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>`);
-	}
-
 	const xml = `<?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-${urls.join("\n")}
-</urlset>`;
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap>
+    <loc>${SITE_URL}/sitemap-leyes.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>${SITE_URL}/sitemap-reformas.xml</loc>
+  </sitemap>
+</sitemapindex>`;
 
 	return new Response(xml, {
 		headers: { "Content-Type": "application/xml; charset=utf-8" },

--- a/packages/web/src/worker/index.ts
+++ b/packages/web/src/worker/index.ts
@@ -60,37 +60,69 @@ function findMatchingDivClose(html: string, contentStart: number): number {
 }
 
 /** Replaces the inner HTML of `<div id="reforma-content">…</div>` (the
- *  client-rendered shell's loading skeleton) with server-rendered content. */
-function injectContent(shellHtml: string, contentHtml: string): string {
+ *  client-rendered shell's loading skeleton) with server-rendered content.
+ *  Returns `null` if the marker/closing tag can't be located — the caller
+ *  MUST then serve the plain (noindex) shell rather than a noindex-stripped
+ *  skeleton, so a shell change fails safe instead of shipping an empty page. */
+function injectContent(shellHtml: string, contentHtml: string): string | null {
 	const marker = '<div id="reforma-content">';
 	const startIdx = shellHtml.indexOf(marker);
-	if (startIdx === -1) return shellHtml;
+	if (startIdx === -1) return null;
 	const contentStart = startIdx + marker.length;
 	const closeIdx = findMatchingDivClose(shellHtml, contentStart);
-	if (closeIdx === -1) return shellHtml;
+	if (closeIdx === -1) return null;
 	return (
 		shellHtml.slice(0, contentStart) + contentHtml + shellHtml.slice(closeIdx)
 	);
 }
 
-/** Rewrites `<title>`, the description meta, adds a self canonical link, and
- *  removes the shell's `noindex` robots meta — turning the generic shell
- *  into a page crawlers can actually index for this specific reform. */
+/** Rewrites `<title>`, description + OG/Twitter metas, adds a self canonical
+ *  link, and removes the shell's `noindex` robots meta — turning the generic
+ *  shell into a page crawlers can actually index for this specific reform.
+ *
+ *  All rewrites use a REPLACER FUNCTION, never a replacement string: in
+ *  String.prototype.replace a `$` in the replacement is special (`$&`, `$'`,
+ *  `$1`…) and `esc()` does not escape `$`, so an API-derived title/description
+ *  containing `$` would otherwise corrupt the document. */
 function injectMeta(
 	shellHtml: string,
 	opts: { title: string; description: string; canonicalPath: string },
 ): string {
 	let html = shellHtml;
 
-	const fullTitle = `${opts.title} — Ley Abierta`;
-	html = html.replace(
-		/<title>[^<]*<\/title>/,
-		`<title>${esc(fullTitle)}</title>`,
-	);
+	const fullTitleVal = esc(`${opts.title} — Ley Abierta`);
+	const bareTitleVal = esc(opts.title);
+	const descVal = esc(opts.description);
+	const canonicalHref = esc(`https://leyabierta.es${opts.canonicalPath}`);
 
 	html = html.replace(
+		/<title>[^<]*<\/title>/,
+		() => `<title>${fullTitleVal}</title>`,
+	);
+	html = html.replace(
 		/<meta name="description" content="[^"]*"\s*\/?>/,
-		`<meta name="description" content="${esc(opts.description)}" />`,
+		() => `<meta name="description" content="${descVal}" />`,
+	);
+	// OG + Twitter so social cards / rich results are per-reform, not generic.
+	html = html.replace(
+		/<meta property="og:title" content="[^"]*"\s*\/?>/,
+		() => `<meta property="og:title" content="${bareTitleVal}" />`,
+	);
+	html = html.replace(
+		/<meta property="og:description" content="[^"]*"\s*\/?>/,
+		() => `<meta property="og:description" content="${descVal}" />`,
+	);
+	html = html.replace(
+		/<meta property="og:url" content="[^"]*"\s*\/?>/,
+		() => `<meta property="og:url" content="${canonicalHref}" />`,
+	);
+	html = html.replace(
+		/<meta name="twitter:title" content="[^"]*"\s*\/?>/,
+		() => `<meta name="twitter:title" content="${bareTitleVal}" />`,
+	);
+	html = html.replace(
+		/<meta name="twitter:description" content="[^"]*"\s*\/?>/,
+		() => `<meta name="twitter:description" content="${descVal}" />`,
 	);
 
 	// Remove the shell's noindex — this response is real content, index it.
@@ -99,17 +131,16 @@ function injectMeta(
 		"",
 	);
 
-	const canonicalHref = `https://leyabierta.es${opts.canonicalPath}`;
-	const canonicalLink = `<link rel="canonical" href="${esc(canonicalHref)}" />`;
+	const canonicalLink = `<link rel="canonical" href="${canonicalHref}" />`;
 	if (html.includes('<link rel="canonical"')) {
 		html = html.replace(
 			/<link rel="canonical" href="[^"]*"\s*\/?>/,
-			canonicalLink,
+			() => canonicalLink,
 		);
 	} else {
 		html = html.replace(
 			'<link rel="icon"',
-			`${canonicalLink}\n\t<link rel="icon"`,
+			() => `${canonicalLink}\n\t<link rel="icon"`,
 		);
 	}
 
@@ -142,7 +173,9 @@ async function renderReformResponse(
 ): Promise<Response | RenderFailure> {
 	const normId = url.searchParams.get("id");
 	const date = url.searchParams.get("date");
-	if (!normId || !date) return { ok: false, status: 404 };
+	// No params → the bare shell is a valid (noindex) page; serve it at 200,
+	// not 404, and let the client-side script show "Faltan parámetros".
+	if (!normId || !date) return { ok: false, status: 200 };
 
 	const apiBase = env.PUBLIC_API_URL || DEFAULT_API_BASE;
 	const headers: HeadersInit = env.API_BYPASS_KEY
@@ -206,24 +239,39 @@ async function renderReformResponse(
 		}
 	}
 
-	const { contentHtml, title, description } = renderReformContent(data, {
-		topicInfo,
-		topicBlockIds,
-		blocks,
-		unifiedDiffHtml,
-	});
+	let html: string;
+	try {
+		// renderReformContent can throw on a malformed 200 (e.g. missing
+		// `law`/`reform`); fetchJson only guards network/parse, not shape.
+		const { contentHtml, title, description } = renderReformContent(data, {
+			topicInfo,
+			topicBlockIds,
+			blocks,
+			unifiedDiffHtml,
+		});
 
-	const shellRes = await env.ASSETS.fetch(new URL(SHELL_PATH, url).toString());
-	if (!shellRes.ok) return { ok: false, status: shellRes.status };
-	const shellHtml = await shellRes.text();
+		const shellRes = await env.ASSETS.fetch(
+			new URL(SHELL_PATH, url).toString(),
+		);
+		if (!shellRes.ok) return { ok: false, status: 200 };
+		const shellHtml = await shellRes.text();
 
-	// Canonical intentionally omits `from`/`topic` — those are navigation
-	// context, not a distinct piece of content, and would otherwise create
-	// duplicate-content variants of the same reform for search engines.
-	const canonicalPath = `/cambios/reforma/?id=${encodeURIComponent(normId)}&date=${encodeURIComponent(date)}`;
+		const injected = injectContent(shellHtml, contentHtml);
+		// Couldn't splice the content in (shell markup changed) → fail safe:
+		// serve the plain noindex shell instead of a noindex-stripped skeleton.
+		if (injected === null) return { ok: false, status: 200 };
 
-	let html = injectContent(shellHtml, contentHtml);
-	html = injectMeta(html, { title, description, canonicalPath });
+		// Canonical intentionally omits `from`/`topic` — those are navigation
+		// context, not a distinct piece of content, and would otherwise create
+		// duplicate-content variants of the same reform for search engines.
+		const canonicalPath = `/cambios/reforma/?id=${encodeURIComponent(normId)}&date=${encodeURIComponent(date)}`;
+
+		html = injectMeta(injected, { title, description, canonicalPath });
+	} catch {
+		// Any render/splice error → serve the static shell (noindex) instead of
+		// a bare 500. The fall-through path resolves status 200 == the shell.
+		return { ok: false, status: 200 };
+	}
 
 	return new Response(html, {
 		status: 200,

--- a/packages/web/src/worker/index.ts
+++ b/packages/web/src/worker/index.ts
@@ -1,0 +1,263 @@
+/// <reference types="@cloudflare/workers-types" />
+// Standalone Cloudflare Worker in front of the pure-static Astro build.
+//
+// Astro builds `output: "static"` with NO adapter — every page (the ~12k law
+// pages included) is a prebuilt file served via the `ASSETS` binding. This
+// Worker's only job is to intercept /cambios/reforma/* requests that carry
+// `?id&date`, fetch the reform data from the API, render the diff content
+// server-side (src/lib/reform-render.ts — pure TS, safe to run in workerd),
+// and splice it into the static shell page (src/pages/cambios/reforma/index.astro)
+// before returning it. Everything else falls straight through to `ASSETS`.
+//
+// This exists because the @astrojs/cloudflare adapter's workerd prerenderer
+// cannot do `fs` reads at render time, so it could only build 81/12k law
+// pages when tried — this decoupled design keeps the static build 100% file
+// based (fast, complete) while still giving crawlers real SSR content on the
+// one route that needs it for SEO.
+
+import type {
+	AffectedBlock,
+	OmnibusResponse,
+	ReformDetailResponse,
+} from "../lib/reform-render.ts";
+import {
+	esc,
+	renderReformContent,
+	renderUnifiedDiffHtml,
+} from "../lib/reform-render.ts";
+
+export interface Env {
+	ASSETS: Fetcher;
+	API_BYPASS_KEY?: string;
+	PUBLIC_API_URL?: string;
+}
+
+const DEFAULT_API_BASE = "https://api.leyabierta.es";
+const REFORM_PATH_PREFIX = "/cambios/reforma/";
+const SHELL_PATH = "/cambios/reforma/";
+
+/** Finds the index of the `</div>` that matches the opening `<div>` whose
+ *  content starts at `contentStart` (depth-aware, so nested divs inside the
+ *  shell's loading skeleton don't confuse the boundary). Returns -1 if
+ *  unbalanced/not found. */
+function findMatchingDivClose(html: string, contentStart: number): number {
+	let pos = contentStart;
+	let depth = 1;
+	while (depth > 0) {
+		const nextOpen = html.indexOf("<div", pos);
+		const nextClose = html.indexOf("</div>", pos);
+		if (nextClose === -1) return -1;
+		if (nextOpen !== -1 && nextOpen < nextClose) {
+			depth++;
+			pos = nextOpen + 4;
+		} else {
+			depth--;
+			if (depth === 0) return nextClose;
+			pos = nextClose + 6;
+		}
+	}
+	return -1;
+}
+
+/** Replaces the inner HTML of `<div id="reforma-content">…</div>` (the
+ *  client-rendered shell's loading skeleton) with server-rendered content. */
+function injectContent(shellHtml: string, contentHtml: string): string {
+	const marker = '<div id="reforma-content">';
+	const startIdx = shellHtml.indexOf(marker);
+	if (startIdx === -1) return shellHtml;
+	const contentStart = startIdx + marker.length;
+	const closeIdx = findMatchingDivClose(shellHtml, contentStart);
+	if (closeIdx === -1) return shellHtml;
+	return (
+		shellHtml.slice(0, contentStart) + contentHtml + shellHtml.slice(closeIdx)
+	);
+}
+
+/** Rewrites `<title>`, the description meta, adds a self canonical link, and
+ *  removes the shell's `noindex` robots meta — turning the generic shell
+ *  into a page crawlers can actually index for this specific reform. */
+function injectMeta(
+	shellHtml: string,
+	opts: { title: string; description: string; canonicalPath: string },
+): string {
+	let html = shellHtml;
+
+	const fullTitle = `${opts.title} — Ley Abierta`;
+	html = html.replace(
+		/<title>[^<]*<\/title>/,
+		`<title>${esc(fullTitle)}</title>`,
+	);
+
+	html = html.replace(
+		/<meta name="description" content="[^"]*"\s*\/?>/,
+		`<meta name="description" content="${esc(opts.description)}" />`,
+	);
+
+	// Remove the shell's noindex — this response is real content, index it.
+	html = html.replace(
+		/<meta name="robots" content="noindex, follow"\s*\/?>\s*/,
+		"",
+	);
+
+	const canonicalHref = `https://leyabierta.es${opts.canonicalPath}`;
+	const canonicalLink = `<link rel="canonical" href="${esc(canonicalHref)}" />`;
+	if (html.includes('<link rel="canonical"')) {
+		html = html.replace(
+			/<link rel="canonical" href="[^"]*"\s*\/?>/,
+			canonicalLink,
+		);
+	} else {
+		html = html.replace(
+			'<link rel="icon"',
+			`${canonicalLink}\n\t<link rel="icon"`,
+		);
+	}
+
+	return html;
+}
+
+async function fetchJson<T>(
+	url: string,
+	headers: HeadersInit,
+): Promise<
+	{ ok: true; status: number; data: T } | { ok: false; status: number }
+> {
+	try {
+		const res = await fetch(url, {
+			headers,
+			signal: AbortSignal.timeout(8000),
+		});
+		if (!res.ok) return { ok: false, status: res.status };
+		return { ok: true, status: res.status, data: (await res.json()) as T };
+	} catch {
+		return { ok: false, status: 500 };
+	}
+}
+
+type RenderFailure = { ok: false; status: number };
+
+async function renderReformResponse(
+	env: Env,
+	url: URL,
+): Promise<Response | RenderFailure> {
+	const normId = url.searchParams.get("id");
+	const date = url.searchParams.get("date");
+	if (!normId || !date) return { ok: false, status: 404 };
+
+	const apiBase = env.PUBLIC_API_URL || DEFAULT_API_BASE;
+	const headers: HeadersInit = env.API_BYPASS_KEY
+		? { "x-bypass-key": env.API_BYPASS_KEY }
+		: {};
+
+	const reformResult = await fetchJson<ReformDetailResponse>(
+		`${apiBase}/v1/reforms/${encodeURIComponent(normId)}/${encodeURIComponent(date)}`,
+		headers,
+	);
+	if (!reformResult.ok) {
+		// Mirror the upstream status (404/403/429/503…) so crawlers get an
+		// honest signal; fall back to 500 for anything outside 4xx/5xx.
+		const status =
+			reformResult.status >= 400 && reformResult.status < 600
+				? reformResult.status
+				: 500;
+		return { ok: false, status };
+	}
+
+	const data = reformResult.data;
+
+	const topicParam = url.searchParams.get("topic");
+	const fromOmnibus = url.searchParams.get("from") === "omnibus";
+	const topicIndex =
+		topicParam !== null ? Number.parseInt(topicParam, 10) : Number.NaN;
+
+	let topicInfo: OmnibusResponse["topics"][number] | null = null;
+	let topicBlockIds: string[] | null = null;
+	if (fromOmnibus && !Number.isNaN(topicIndex)) {
+		const omnibusResult = await fetchJson<OmnibusResponse>(
+			`${apiBase}/v1/omnibus/${encodeURIComponent(normId)}`,
+			headers,
+		);
+		if (omnibusResult.ok) {
+			topicInfo = omnibusResult.data.topics?.[topicIndex] ?? null;
+			if (
+				topicInfo &&
+				Array.isArray(topicInfo.block_ids) &&
+				topicInfo.block_ids.length > 0
+			) {
+				topicBlockIds = topicInfo.block_ids;
+			}
+		}
+		// Omnibus enrichment is best-effort — the reform itself still renders.
+	}
+
+	const allBlocks = data.affected_blocks || [];
+	const blocks: AffectedBlock[] = topicBlockIds
+		? allBlocks.filter((b) => topicBlockIds?.includes(b.block_id))
+		: allBlocks;
+
+	let unifiedDiffHtml: string | null = null;
+	if (blocks.length === 0 && data.prev_reform_date && !topicBlockIds) {
+		const diffResult = await fetchJson<{ diff?: string }>(
+			`${apiBase}/v1/laws/${encodeURIComponent(normId)}/diff?from=${encodeURIComponent(data.prev_reform_date)}&to=${encodeURIComponent(date)}`,
+			headers,
+		);
+		if (diffResult.ok && diffResult.data.diff) {
+			unifiedDiffHtml = renderUnifiedDiffHtml(diffResult.data.diff);
+		}
+	}
+
+	const { contentHtml, title, description } = renderReformContent(data, {
+		topicInfo,
+		topicBlockIds,
+		blocks,
+		unifiedDiffHtml,
+	});
+
+	const shellRes = await env.ASSETS.fetch(new URL(SHELL_PATH, url).toString());
+	if (!shellRes.ok) return { ok: false, status: shellRes.status };
+	const shellHtml = await shellRes.text();
+
+	// Canonical intentionally omits `from`/`topic` — those are navigation
+	// context, not a distinct piece of content, and would otherwise create
+	// duplicate-content variants of the same reform for search engines.
+	const canonicalPath = `/cambios/reforma/?id=${encodeURIComponent(normId)}&date=${encodeURIComponent(date)}`;
+
+	let html = injectContent(shellHtml, contentHtml);
+	html = injectMeta(html, { title, description, canonicalPath });
+
+	return new Response(html, {
+		status: 200,
+		headers: {
+			"content-type": "text/html; charset=utf-8",
+			// A reform is immutable once published — cache aggressively. The
+			// deploy pipeline purges the CF zone on every deploy, so a
+			// reprocessed reform (rare) still refreshes promptly.
+			"cache-control": "public, s-maxage=7776000, stale-while-revalidate=86400",
+		},
+	});
+}
+
+export default {
+	async fetch(request: Request, env: Env): Promise<Response> {
+		const url = new URL(request.url);
+
+		if (url.pathname.startsWith(REFORM_PATH_PREFIX)) {
+			const result = await renderReformResponse(env, url);
+			if (result instanceof Response) return result;
+
+			// Missing params or API failure (404/upstream error) → serve the
+			// static shell as-is (keeps its `noindex`, lets the existing
+			// client-side fetch script take over), mirroring the resolved
+			// status onto the response.
+			const shellRes = await env.ASSETS.fetch(request);
+			if (result.status === shellRes.status) return shellRes;
+			return new Response(shellRes.body, {
+				status: result.status,
+				statusText: shellRes.statusText,
+				headers: shellRes.headers,
+			});
+		}
+
+		return env.ASSETS.fetch(request);
+	},
+};

--- a/packages/web/src/worker/index.ts
+++ b/packages/web/src/worker/index.ts
@@ -179,7 +179,7 @@ async function renderReformResponse(
 
 	const apiBase = env.PUBLIC_API_URL || DEFAULT_API_BASE;
 	const headers: HeadersInit = env.API_BYPASS_KEY
-		? { "x-bypass-key": env.API_BYPASS_KEY }
+		? { "x-api-key": env.API_BYPASS_KEY }
 		: {};
 
 	const reformResult = await fetchJson<ReformDetailResponse>(

--- a/packages/web/wrangler.jsonc
+++ b/packages/web/wrangler.jsonc
@@ -1,25 +1,18 @@
 {
-	// Cloudflare Workers config for the @astrojs/cloudflare adapter (v14, the
-	// only version compatible with our Astro 6.1.9 — see the caveat this file
-	// is deliberately not resolving, spelled out below and in the PR notes).
-	"name": "leyabierta-web",
-	"compatibility_date": "2026-07-01",
-	// astro build with the cloudflare adapter uses some Node.js builtins
-	// (e.g. via markdown-it/sanitize-html) that need this flag on Workers.
-	"compatibility_flags": ["nodejs_compat"],
+	// Cloudflare Workers config for the @astrojs/cloudflare adapter (v14, paired
+	// with Astro 7). Deployed with `wrangler deploy` (NOT `wrangler pages deploy`
+	// — the adapter dropped Pages support in v13+).
 	//
-	// KNOWN GAP — do not resolve without sign-off (see PR description):
-	// @astrojs/cloudflare v13+ (required by Astro 6) dropped Cloudflare Pages
-	// support entirely; it only targets Cloudflare Workers with static assets
-	// (`wrangler deploy`, not `wrangler pages deploy`). deploy.yml still runs
-	// `wrangler pages deploy dist --project-name=leyabierta` unchanged in this
-	// PR, because switching to Workers deploy requires a one-time, manual
-	// Cloudflare Dashboard step (attaching the leyabierta.es custom domain to
-	// a Workers script instead of the existing Pages project) that this PR
-	// cannot safely make unattended. Until that cutover happens, this adapter
-	// technically cannot ship the on-demand reform route to production via
-	// the current deploy pipeline — see the PR/report for options.
+	// The ~12k prebuilt law pages are served as static assets (the `assets`
+	// binding, under the 20k-file Workers Free limit); the reform-detail route
+	// (`prerender = false`) is rendered on-demand by the Worker and is not a file.
+	"name": "leyabierta-web",
+	"main": "@astrojs/cloudflare/entrypoints/server",
+	"compatibility_date": "2026-07-01",
+	// markdown-it / sanitize-html pull in node: builtins at the edge.
+	"compatibility_flags": ["nodejs_compat"],
 	"assets": {
-		"directory": "./dist"
+		"directory": "./dist",
+		"binding": "ASSETS"
 	}
 }

--- a/packages/web/wrangler.jsonc
+++ b/packages/web/wrangler.jsonc
@@ -1,0 +1,25 @@
+{
+	// Cloudflare Workers config for the @astrojs/cloudflare adapter (v14, the
+	// only version compatible with our Astro 6.1.9 — see the caveat this file
+	// is deliberately not resolving, spelled out below and in the PR notes).
+	"name": "leyabierta-web",
+	"compatibility_date": "2026-07-01",
+	// astro build with the cloudflare adapter uses some Node.js builtins
+	// (e.g. via markdown-it/sanitize-html) that need this flag on Workers.
+	"compatibility_flags": ["nodejs_compat"],
+	//
+	// KNOWN GAP — do not resolve without sign-off (see PR description):
+	// @astrojs/cloudflare v13+ (required by Astro 6) dropped Cloudflare Pages
+	// support entirely; it only targets Cloudflare Workers with static assets
+	// (`wrangler deploy`, not `wrangler pages deploy`). deploy.yml still runs
+	// `wrangler pages deploy dist --project-name=leyabierta` unchanged in this
+	// PR, because switching to Workers deploy requires a one-time, manual
+	// Cloudflare Dashboard step (attaching the leyabierta.es custom domain to
+	// a Workers script instead of the existing Pages project) that this PR
+	// cannot safely make unattended. Until that cutover happens, this adapter
+	// technically cannot ship the on-demand reform route to production via
+	// the current deploy pipeline — see the PR/report for options.
+	"assets": {
+		"directory": "./dist"
+	}
+}

--- a/packages/web/wrangler.jsonc
+++ b/packages/web/wrangler.jsonc
@@ -1,13 +1,14 @@
 {
-	// Cloudflare Workers config for the @astrojs/cloudflare adapter (v14, paired
-	// with Astro 7). Deployed with `wrangler deploy` (NOT `wrangler pages deploy`
-	// — the adapter dropped Pages support in v13+).
-	//
-	// The ~12k prebuilt law pages are served as static assets (the `assets`
-	// binding, under the 20k-file Workers Free limit); the reform-detail route
-	// (`prerender = false`) is rendered on-demand by the Worker and is not a file.
+	// Standalone Cloudflare Worker — NOT an Astro adapter. Astro builds a pure
+	// static site (`output: "static"`, no adapter) to dist/; this Worker sits
+	// in front of it and only intervenes for /cambios/reforma/* requests that
+	// carry ?id&date, where it SSRs the diff content server-side (see
+	// src/worker/index.ts + src/lib/reform-render.ts) before handing back the
+	// static shell page. Everything else falls straight through to the
+	// `ASSETS` binding. Deployed with `wrangler deploy` (wrangler bundles the
+	// TS worker itself — no separate build step needed for it).
 	"name": "leyabierta-web",
-	"main": "@astrojs/cloudflare/entrypoints/server",
+	"main": "src/worker/index.ts",
 	"compatibility_date": "2026-07-01",
 	// markdown-it / sanitize-html pull in node: builtins at the edge.
 	"compatibility_flags": ["nodejs_compat"],

--- a/packages/web/wrangler.jsonc
+++ b/packages/web/wrangler.jsonc
@@ -14,6 +14,13 @@
 	"compatibility_flags": ["nodejs_compat"],
 	"assets": {
 		"directory": "./dist",
-		"binding": "ASSETS"
+		"binding": "ASSETS",
+		// Without this, static-asset matching runs BEFORE the Worker, so
+		// /cambios/reforma/index.html would be served straight from ASSETS and
+		// the SSR/meta-injection in src/worker/index.ts would never run (every
+		// reform would stay the noindex shell — defeating the whole point).
+		// Run the Worker first only for reform URLs; everything else is served
+		// directly from assets (no Worker invocation → preserves the request budget).
+		"run_worker_first": ["/cambios/reforma/*"]
 	}
 }


### PR DESCRIPTION
## Por qué
El 2026-05-04 (commit `235800f`) las páginas de reforma se colapsaron en una página cliente única con `noindex`. Eran el **activo SEO nº1**: cientos rankeando en página 1. Resultado: **impresiones ×10 abajo, posición media 14 → 54** en 90 días. Este PR las recupera como páginas **indexables server-rendered**.

## Qué hace
- **Ruta `/cambios/reforma/` → SSR on-demand** (`prerender = false`): fetch server-side del API público (`/v1/reforms/:id/:date` + fallbacks omnibus/diff), word-diff portado a servidor, **títulos/descripciones únicos**, canonical sin `from`, **quita `noindex`**, `Cache-Control: s-maxage=90d`, 404 en params faltantes.
- **Sitemap index** (`sitemap.xml` → `sitemap-leyes.xml` + `sitemap-reformas.xml`, una URL por reforma).
- **Upgrade a Astro 7.1.1** + `@astrojs/react` 6 + adapter `@astrojs/cloudflare` 14 → **migración de Cloudflare Pages a Workers** (el adapter dejó de soportar Pages). Las 12k fichas siguen estáticas (assets); la reforma la sirve el Worker on-demand (no cuenta contra el límite de 20k ficheros). **Coste 0€** (Workers Free, 100k req/día; tráfico real ~10k/día).
- Quita `experimental.queuedRendering` (estabilizado en A7) y el alias `entities` (rompía el bundler rolldown de A7).

## Revisión adversarial (2× Opus)
- **SSR**: sin blockers — escaping OK en todo (sin XSS), diff LCS equivalente al original, 404/noindex correctos, guard de `cloudflare:workers` bien. Minors corregidos: timeout en fetch + espejar status upstream.
- **Config Workers**: `main`/`assets binding` correctos, `_redirects`/`_headers` se conservan en Workers, deploy → `wrangler deploy`.

## ⚠️ Validación pendiente ANTES de mergear
1. **Build**: localmente pasan config + bundler + compilador de Astro 7, y la reforma sale on-demand. Pero el build completo de 12k páginas NO se validó local (el prerenderer workerd del adapter sandbox-ea fs/fetch y falla contra un `../leyes` hermano + miniflare parcial). **`pr-checks` (contenido in-repo + API + bypass) es el gate real** — si falla ahí, decouplamos el Worker de reforma del build estático.
2. **Preview**: deploy a `leyabierta-web.workers.dev` y probar en vivo: reforma renderiza HTML server-side, sin noindex, cache 90d, 404, omnibus, y que `/reforma→/cambios/reforma`, `/laws→/leyes` siguen redirigiendo.
3. **Cutover** (manual, 1 vez): adjuntar el dominio `leyabierta.es` al Worker `leyabierta-web` (reversible).

## Acción manual pendiente
- `API_BYPASS_KEY` como env var runtime del proyecto Worker (para saltar rate-limits; funciona sin ella).
- Vigilar en el preview los bindings que el adapter auto-activa (Cloudflare Images `IMAGES`, Sessions KV `SESSION`) — si no se usan, desactivar en el adapter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)