### PR TITLE
fix(ci): drop broken Astro content-store cache that served stale fichas

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -285,12 +285,17 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Cache Astro content store
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-        with:
-          path: packages/web/.astro
-          key: astro-data-${{ hashFiles('content/laws/**/*.md') }}
-          restore-keys: astro-data-
+      # NOTE: no Astro content-store cache here on purpose. A previous
+      # `actions/cache` step keyed the .astro store on
+      # hashFiles('content/laws/**/*.md') — a path that does not exist (the law
+      # markdown lives in the separate `leyes` repo, checked out elsewhere). The
+      # hash was therefore constant, so CI always restored the SAME stale
+      # content store and never re-ran the loader. The result: fichas built with
+      # empty `materias` — no materia tags, no "Categorías", and (once #108
+      # shipped) no "Normas relacionadas" internal-linking block — silently
+      # degrading SEO on every daily deploy. The loader is already fast (it
+      # stores the markdown path, not the parsed body — see loaders/laws.ts), so
+      # a clean content build each run costs little and is always correct.
 
       - name: Notify — Building
         continue-on-error: true


### PR DESCRIPTION
## Problema

El deploy diario de web llevaba sirviendo fichas de ley **degradadas**: sin materias, sin "Categorías" y sin el bloque "Normas relacionadas" (#108). Impacto SEO directo — justo lo contrario de lo que #108 pretendía.

## Causa raíz

```yaml
- name: Cache Astro content store
  path: packages/web/.astro
  key: astro-data-${{ hashFiles('content/laws/**/*.md') }}   # ⚠️ ruta inexistente
  restore-keys: astro-data-
```

El markdown de las leyes vive en el repo **`leyes`** (checkout aparte), no en `content/laws/`. `hashFiles()` no matchea nada → key **constante** → CI restaura **siempre el mismo `.astro` viejo** y no re-ejecuta el loader → fichas con `materias` vacías en cada build.

## Fix

Elimino el paso de caché. El loader (`loaders/laws.ts`) ya guarda la **ruta** del markdown (no el body parseado), así que un build limpio del content store cada vez es barato y **siempre correcto**.

## Verificación

- Producción restaurada con un redeploy manual del build correcto → fichas vuelven a mostrar materia-tags + "Normas relacionadas" (Código Penal: 47 enlaces internos a /leyes/).
- Este PR evita que el cron diario vuelva a introducir la regresión.

🤖 Generated with [Claude Code](https://claude.com/claude-code)