### PR TITLE
fix(web): align reform headline typography with the law ficha title

### DIFF
--- a/packages/web/src/pages/cambios/reforma/index.astro
+++ b/packages/web/src/pages/cambios/reforma/index.astro
@@ -45,10 +45,12 @@ import Base from "../../../layouts/Base.astro";
 			font-size: 0.6875rem; font-weight: 600; color: var(--accent);
 			background: var(--accent-bg); padding: 0.1875rem 0.5625rem; border-radius: 4px;
 		}
+		/* Match the law ficha's .law-title (leyes/[id].astro) so the headline
+		   typography is consistent across the two page types. */
 		:global(.reforma-headline) {
-			font-family: var(--font-serif); font-size: 1.875rem; font-weight: 700;
-			line-height: 1.2; color: var(--text); margin: 0 0 0.625rem;
-			letter-spacing: -0.02em;
+			font-family: var(--font-serif); font-size: 1.375rem; font-weight: 700;
+			line-height: 1.35; color: var(--text); margin: 0 0 0.625rem;
+			letter-spacing: -0.01em;
 		}
 		.reforma-law-info { font-size: 0.875rem; color: var(--text-muted); line-height: 1.55; }
 		.reforma-law-info a { color: var(--accent); text-decoration: underline; }
@@ -186,10 +188,6 @@ import Base from "../../../layouts/Base.astro";
 		}
 		.unified-diff-line-ctx {
 			color: var(--text-muted);
-		}
-
-		@media (max-width: 640px) {
-			:global(.reforma-headline) { font-size: 1.625rem; }
 		}
 	</style>
 


### PR DESCRIPTION
El título de la página de reforma (`.reforma-headline`, 1.875rem) tenía un tamaño visiblemente distinto al de la ficha de ley (`.law-title`, 1.375rem) — misma familia serif pero otra escala, lo que hacía inconsistente navegar entre ambos tipos de página.

Se alinea al de la ficha (tipo de página canónica y mucho más numerosa): 1.375rem, line-height 1.35, letter-spacing -0.01em. Se elimina el override móvil (1.625rem) que ya sobra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)