### PR TITLE
fix(web): source law materias from the DB-backed build manifest

### DIFF
--- a/packages/api/src/__tests__/build-manifest.test.ts
+++ b/packages/api/src/__tests__/build-manifest.test.ts
@@ -36,6 +36,13 @@ function insertCitizenTag(normId: string, tag: string, blockId = "") {
 	]);
 }
 
+function insertMateria(normId: string, materia: string) {
+	db.run("INSERT INTO materias (norm_id, materia) VALUES (?, ?)", [
+		normId,
+		materia,
+	]);
+}
+
 function insertOmnibusTopic(normId: string, index: number, label: string) {
 	db.run(
 		`INSERT INTO omnibus_topics (norm_id, topic_index, topic_label, headline, summary, article_count, is_sneaked, related_materias, block_ids, model)
@@ -88,6 +95,27 @@ describe("getBuildManifest()", () => {
 		expect(result.citizens["BOE-A-2024-001"]).toEqual({
 			summary: "",
 			tags: ["empresario"],
+			materias: [],
+		});
+	});
+
+	it("includes DB materias per norm, creating an entry when needed", () => {
+		insertNorm("BOE-A-2024-001", "Summary");
+		insertMateria("BOE-A-2024-001", "Vivienda");
+		insertMateria("BOE-A-2024-001", "Alquiler");
+		// materias-only norm (no summary, no tags) still gets an entry
+		insertNorm("BOE-A-2024-002", "");
+		insertMateria("BOE-A-2024-002", "Empleo");
+
+		const result = svc.getBuildManifest();
+		expect(result.citizens["BOE-A-2024-001"].materias).toEqual([
+			"Alquiler",
+			"Vivienda",
+		]);
+		expect(result.citizens["BOE-A-2024-002"]).toEqual({
+			summary: "",
+			tags: [],
+			materias: ["Empleo"],
 		});
 	});
 

--- a/packages/api/src/services/db.ts
+++ b/packages/api/src/services/db.ts
@@ -1657,7 +1657,10 @@ export class DbService {
 	 * Used by the web build to avoid 12K individual API calls.
 	 */
 	getBuildManifest(): {
-		citizens: Record<string, { summary: string; tags: string[] }>;
+		citizens: Record<
+			string,
+			{ summary: string; tags: string[]; materias: string[] }
+		>;
 		omnibus: Record<
 			string,
 			Array<{
@@ -1684,6 +1687,16 @@ export class DbService {
 			)
 			.all();
 
+		// 2b. All materias, keyed by norm. Sourced from the DB (authoritative)
+		// rather than the leyes .md frontmatter, which the published repo does not
+		// always carry — this is what powers the ficha's materia tags and the
+		// "Normas relacionadas" topical internal-linking block at build time.
+		const materiaRows = this.db
+			.query<{ norm_id: string; materia: string }, []>(
+				"SELECT norm_id, materia FROM materias ORDER BY norm_id, materia",
+			)
+			.all();
+
 		// 3. All omnibus topics
 		const topicRows = this.db
 			.query<
@@ -1704,15 +1717,28 @@ export class DbService {
 			.all();
 
 		// Assemble citizens map
-		const citizens: Record<string, { summary: string; tags: string[] }> = {};
+		const citizens: Record<
+			string,
+			{ summary: string; tags: string[]; materias: string[] }
+		> = {};
 		for (const row of summaryRows) {
-			citizens[row.id] = { summary: row.citizen_summary, tags: [] };
+			citizens[row.id] = {
+				summary: row.citizen_summary,
+				tags: [],
+				materias: [],
+			};
 		}
 		for (const row of tagRows) {
 			if (!citizens[row.norm_id]) {
-				citizens[row.norm_id] = { summary: "", tags: [] };
+				citizens[row.norm_id] = { summary: "", tags: [], materias: [] };
 			}
 			citizens[row.norm_id]!.tags.push(row.tag);
+		}
+		for (const row of materiaRows) {
+			if (!citizens[row.norm_id]) {
+				citizens[row.norm_id] = { summary: "", tags: [], materias: [] };
+			}
+			citizens[row.norm_id]!.materias.push(row.materia);
 		}
 
 		// Assemble omnibus map

--- a/packages/web/src/lib/manifest.ts
+++ b/packages/web/src/lib/manifest.ts
@@ -14,7 +14,10 @@ import { readFileSync } from "node:fs";
 import type { OmnibusTopic } from "./api.ts";
 
 export interface BuildManifest {
-	citizens: Record<string, { summary: string; tags: string[] }>;
+	citizens: Record<
+		string,
+		{ summary: string; tags: string[]; materias: string[] }
+	>;
 	omnibus: Record<string, OmnibusTopic[]>;
 }
 

--- a/packages/web/src/pages/leyes/[id].astro
+++ b/packages/web/src/pages/leyes/[id].astro
@@ -61,6 +61,14 @@ export async function getStaticPaths() {
 	const laws = await getCollection("laws");
 	const allIds = new Set(laws.map((e) => e.data.identificador));
 
+	// Materias come from the build manifest (DB-sourced), not the .md frontmatter:
+	// the published leyes repo does not carry `materias`, so relying on frontmatter
+	// left every ficha with empty materias — no tags and no "Normas relacionadas"
+	// block. Fall back to frontmatter for local dev where no manifest is present.
+	const manifest = loadManifest();
+	const materiasFor = (identificador: string, fm: string[] | undefined) =>
+		manifest?.citizens[identificador]?.materias ?? fm ?? [];
+
 	// ── SEO: topical internal linking ──────────────────────────────────────
 	// Leaf law pages otherwise only link to explicit references (many of which
 	// are not in-corpus, so they render as plain text). That leaves ~12k pages
@@ -81,7 +89,7 @@ export async function getStaticPaths() {
 			titulo: d.titulo,
 			jurisdiccion: d.jurisdiccion,
 			estado: d.estado,
-			materias: d.materias ?? [],
+			materias: materiasFor(d.identificador, d.materias),
 		});
 	}
 	const materiaIndex = new Map<string, string[]>();
@@ -134,7 +142,11 @@ export async function getStaticPaths() {
 		props: {
 			entry,
 			allIds,
-			related: relatedFor(entry.data.identificador, entry.data.materias ?? [], entry.data.jurisdiccion),
+			related: relatedFor(
+				entry.data.identificador,
+				materiasFor(entry.data.identificador, entry.data.materias),
+				entry.data.jurisdiccion,
+			),
 		},
 	}));
 }
@@ -241,7 +253,9 @@ function capitalize(s: string): string {
 }
 
 const reforms = (law.reformas ?? []).slice().reverse();
-const materias = law.materias ?? [];
+// Prefer DB-sourced materias from the manifest (the published leyes frontmatter
+// may not carry them); fall back to frontmatter for local dev without a manifest.
+const materias = manifest?.citizens[id!]?.materias ?? law.materias ?? [];
 const notas = law.notas ?? [];
 const refsAnt = law.referencias_anteriores ?? [];
 const refsPost = law.referencias_posteriores ?? [];


### PR DESCRIPTION
## Problema

El repo publicado `leyabierta/leyes` **no lleva `materias:` en el frontmatter**. El build web de CI lee el frontmatter → todas las fichas se construían **sin materias**: sin materia-tags y **sin el bloque #108 "Normas relacionadas"**. Justo el problema de *"Crawled, not indexed"* que combatimos. (Descubierto comparando `leyabierta.es` vs `workers.dev` — no era cache; y el repo publicado da grep=0 en `^materias:`.)

## Fix

Las materias **sí están en la BD** (las 12.348 normas, vía `ingest-analisis`), igual que los resúmenes ciudadanos. Se añaden al `/v1/build-manifest` y la ficha las lee de ahí:
- `db.ts` `getBuildManifest()`: nuevo campo `materias` por norma.
- `leyes/[id].astro`: usa las materias del manifest tanto para los **materia-tags** como para el **índice topical de #108** (`relatedFor`). Fallback al frontmatter en dev local sin manifest.

DB es la fuente autoritativa de materias → esto **desacopla el build de la completitud del frontmatter**.

## Orden de despliegue

La API debe desplegarse **antes** de que un build web recoja el nuevo campo. El cambio web es **retrocompatible** (si el manifest no trae materias, cae a frontmatter vacío = status quo, sin regresión). Tras mergear, re-lanzaré el deploy web cuando la API esté viva.

## Tests

- `build-manifest.test.ts`: caso nuevo que cubre materias (incl. norma solo-materias sin resumen). 7/7 pasa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)