### PR TITLE
feat(ai): migrate summary generators from OpenRouter/Gemini to NaN gemma4

### DIFF
--- a/packages/api/src/scripts/generate-omnibus-topics.ts
+++ b/packages/api/src/scripts/generate-omnibus-topics.ts
@@ -5,15 +5,16 @@
  * and uses an LLM to produce per-topic summaries + "medida encubierta" flags.
  *
  * Usage:
- *   OPENROUTER_API_KEY=... bun run packages/api/src/scripts/generate-omnibus-topics.ts
- *   OPENROUTER_API_KEY=... bun run packages/api/src/scripts/generate-omnibus-topics.ts --limit 10
- *   OPENROUTER_API_KEY=... bun run packages/api/src/scripts/generate-omnibus-topics.ts --since 2026-01-01
- *   OPENROUTER_API_KEY=... bun run packages/api/src/scripts/generate-omnibus-topics.ts --dry-run
- *   OPENROUTER_API_KEY=... bun run packages/api/src/scripts/generate-omnibus-topics.ts --force
+ *   NAN_API_KEY=... bun run packages/api/src/scripts/generate-omnibus-topics.ts
+ *   NAN_API_KEY=... bun run packages/api/src/scripts/generate-omnibus-topics.ts --limit 10
+ *   NAN_API_KEY=... bun run packages/api/src/scripts/generate-omnibus-topics.ts --since 2026-01-01
+ *   NAN_API_KEY=... bun run packages/api/src/scripts/generate-omnibus-topics.ts --dry-run
+ *   NAN_API_KEY=... bun run packages/api/src/scripts/generate-omnibus-topics.ts --force
  */
 
 import { BASE_MATERIAS } from "../data/materia-mappings.ts";
-import { callOpenRouter, OpenRouterError } from "../services/openrouter.ts";
+import { callNan } from "../services/nan.ts";
+import { OpenRouterError } from "../services/openrouter.ts";
 import { getArg, getMaterias, hasFlag, setupDb } from "./shared.ts";
 
 const OMNIBUS_THRESHOLD = 15;
@@ -22,15 +23,13 @@ const OMNIBUS_THRESHOLD = 15;
 
 const limitArg = Number(getArg("limit") ?? 20);
 const sinceArg = getArg("since");
-const modelId = getArg("model") ?? "google/gemini-2.5-flash-lite";
+const modelId = getArg("model") ?? "gemma4";
 const dryRun = hasFlag("dry-run");
 const force = hasFlag("force");
 
-const apiKey = process.env.OPENROUTER_API_KEY;
+const apiKey = process.env.NAN_API_KEY;
 if (!apiKey && !dryRun) {
-	console.error(
-		"Set OPENROUTER_API_KEY env variable (or use --dry-run to skip AI)",
-	);
+	console.error("Set NAN_API_KEY env variable (or use --dry-run to skip AI)");
 	process.exit(1);
 }
 
@@ -334,21 +333,18 @@ async function main() {
 		const { system, user } = buildPrompt(norm, blocks, materias);
 
 		try {
-			const result = await callOpenRouter<{ topics: TopicResponse[] }>(
-				apiKey!,
-				{
-					model: modelId,
-					messages: [
-						{ role: "system", content: system },
-						{ role: "user", content: user },
-					],
-					temperature: 0.2,
-					jsonSchema: {
-						name: "omnibus_topics",
-						schema: TOPIC_SCHEMA,
-					},
+			const result = await callNan<{ topics: TopicResponse[] }>(apiKey!, {
+				model: modelId,
+				messages: [
+					{ role: "system", content: system },
+					{ role: "user", content: user },
+				],
+				temperature: 0.2,
+				jsonSchema: {
+					name: "omnibus_topics",
+					schema: TOPIC_SCHEMA,
 				},
-			);
+			});
 
 			const { result: topics, reason } = validateTopics(result.data);
 			if (!topics) {

--- a/packages/api/src/scripts/generate-reform-summaries.ts
+++ b/packages/api/src/scripts/generate-reform-summaries.ts
@@ -2,22 +2,23 @@
  * Generate AI reform summaries for reforms missing them.
  *
  * Generates headline, summary, reform_type, and importance for each reform
- * using OpenRouter (Gemini Flash Lite). Results cached in reform_summaries table.
+ * using the NaN stack (gemma4). Results cached in reform_summaries table.
  *
  * Usage:
- *   OPENROUTER_API_KEY=... bun run packages/api/src/scripts/generate-reform-summaries.ts
- *   OPENROUTER_API_KEY=... bun run packages/api/src/scripts/generate-reform-summaries.ts --weeks 4
- *   OPENROUTER_API_KEY=... bun run packages/api/src/scripts/generate-reform-summaries.ts --limit 50
- *   OPENROUTER_API_KEY=... bun run packages/api/src/scripts/generate-reform-summaries.ts --dry-run
- *   OPENROUTER_API_KEY=... bun run packages/api/src/scripts/generate-reform-summaries.ts --force
- *   OPENROUTER_API_KEY=... bun run packages/api/src/scripts/generate-reform-summaries.ts --model google/gemini-2.0-flash-001
+ *   NAN_API_KEY=... bun run packages/api/src/scripts/generate-reform-summaries.ts
+ *   NAN_API_KEY=... bun run packages/api/src/scripts/generate-reform-summaries.ts --weeks 4
+ *   NAN_API_KEY=... bun run packages/api/src/scripts/generate-reform-summaries.ts --limit 50
+ *   NAN_API_KEY=... bun run packages/api/src/scripts/generate-reform-summaries.ts --dry-run
+ *   NAN_API_KEY=... bun run packages/api/src/scripts/generate-reform-summaries.ts --force
+ *   NAN_API_KEY=... bun run packages/api/src/scripts/generate-reform-summaries.ts --model gemma4
  */
 
 import { Database } from "bun:sqlite";
 import { join } from "node:path";
 import { createSchema } from "@leyabierta/pipeline";
 import { DbService } from "../services/db.ts";
-import { callOpenRouter, OpenRouterError } from "../services/openrouter.ts";
+import { callNan } from "../services/nan.ts";
+import { OpenRouterError } from "../services/openrouter.ts";
 
 // ── CLI ──
 
@@ -30,16 +31,14 @@ const hasFlag = (name: string) => args.includes(`--${name}`);
 
 const weeks = Number(getArg("weeks") ?? 4);
 const limitArg = Number(getArg("limit") ?? 200);
-const modelId = getArg("model") ?? "google/gemini-2.5-flash-lite";
+const modelId = getArg("model") ?? "gemma4";
 const dryRun = hasFlag("dry-run");
 const force = hasFlag("force");
 const omnibusOnly = hasFlag("omnibus-only");
 
-const apiKey = process.env.OPENROUTER_API_KEY;
+const apiKey = process.env.NAN_API_KEY;
 if (!apiKey && !dryRun) {
-	console.error(
-		"Set OPENROUTER_API_KEY env variable (or use --dry-run to skip AI)",
-	);
+	console.error("Set NAN_API_KEY env variable (or use --dry-run to skip AI)");
 	process.exit(1);
 }
 
@@ -406,7 +405,7 @@ async function main() {
 		);
 
 		try {
-			const result = await callOpenRouter<SummaryResponse>(apiKey!, {
+			const result = await callNan<SummaryResponse>(apiKey!, {
 				model: modelId,
 				messages: [
 					{ role: "system", content: system },

--- a/packages/pipeline/src/scripts/generate-citizen-tags.ts
+++ b/packages/pipeline/src/scripts/generate-citizen-tags.ts
@@ -34,7 +34,7 @@ const MONOREPO_ROOT = resolve(SCRIPT_DIR, "..", "..", "..", "..");
 const WORKSPACE_ROOT = MONOREPO_ROOT;
 
 const envPath = join(MONOREPO_ROOT, ".env");
-let apiKey = process.env.OPENROUTER_API_KEY;
+let apiKey = process.env.NAN_API_KEY;
 
 try {
 	const envContent = await Bun.file(envPath).text();
@@ -47,7 +47,7 @@ try {
 			.slice(eqIdx + 1)
 			.trim()
 			.replace(/^["']|["']$/g, "");
-		if (key === "OPENROUTER_API_KEY" && !apiKey) {
+		if (key === "NAN_API_KEY" && !apiKey) {
 			apiKey = value;
 		}
 	}
@@ -56,14 +56,18 @@ try {
 }
 
 if (!apiKey) {
-	console.error("OPENROUTER_API_KEY not found in environment or .env file");
+	console.error("NAN_API_KEY not found in environment or .env file");
 	process.exit(1);
 }
 
 // ── Constants ──
 
-const MODEL = "google/gemini-2.5-flash-lite";
-const API_URL = "https://openrouter.ai/api/v1/chat/completions";
+// gemma4 on the free NaN stack (api.nan.builders). Chosen over Gemini/OpenRouter
+// after an A/B on the law-level citizen summary: gemma4 matched Gemini quality,
+// was the most consistent (0 parse errors, respected the ≤150-char target), and
+// costs $0. See the model A/B (2026-07). OpenRouter is no longer used here.
+const MODEL = "gemma4";
+const API_URL = "https://api.nan.builders/v1/chat/completions";
 const DELAY_MS = 0;
 const TIMEOUT_MS = 30_000;
 const MAX_RETRIES = 3;


### PR DESCRIPTION
Migra los 3 generadores IA del pipeline diario de **OpenRouter (Gemini, de pago/vetado)** al stack gratuito **NaN (`api.nan.builders`)** con modelo **gemma4**:

- `generate-citizen-tags.ts` — resumen ciudadano de ley + tags
- `generate-reform-summaries.ts` — resúmenes de reforma
- `generate-omnibus-topics.ts` — temas omnibus

## Por qué gemma4

A/B sobre el resumen ciudadano de ley con los 4 modelos de texto de NaN (qwen3.6, gemma4, deepseek-v4-flash, mimo-v2.5) vs Gemini como baseline, mismo prompt de producción, 6 leyes de rangos distintos:
- **gemma4**: igualó a Gemini en calidad, **el más consistente** (0 errores de parseo, respetó el objetivo ≤150 car), $0.
- qwen3.6: bueno pero 1 error de parseo; deepseek: lento (3-11s) y se pasa de largo; mimo: coló una palabra en inglés.

## Cambio

Los scripts de reforma/omnibus ya tenían un cliente NaN drop-in (`callNan`, mismo `OpenRouterResult` + `OpenRouterError`), así que el cambio es proveedor + modelo + env key (`NAN_API_KEY`, ya presente en el contenedor). Los article summaries y el RAG ya estaban en NaN. OpenRouter deja de usarse en el pipeline.

## Smoke

`--dry-run` de reform-summaries y omnibus-topics arrancan con `Model: gemma4` correctamente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)