### PR TITLE
feat(web): Markdown for Agents (agent-readiness L3) + coherent robots.txt AI policy

### DIFF
--- a/packages/api/src/__tests__/routes.test.ts
+++ b/packages/api/src/__tests__/routes.test.ts
@@ -413,6 +413,37 @@ describe("GET /v1/laws/:id/analisis", () => {
 // GET /v1/laws/:id/graph
 // ---------------------------------------------------------------------------
 
+describe("GET /v1/laws/:id/markdown", () => {
+	it("returns 404 for non-existent law", async () => {
+		const res = await req("/v1/laws/NOPE/markdown");
+		expect(res.status).toBe(404);
+	});
+
+	it("serves the canonical Markdown as text/markdown", async () => {
+		insertNorm();
+		const original = gitStub.getFileLatest;
+		gitStub.getFileLatest = async () =>
+			"---\ntitulo: CE\n---\n\n# Constitucion";
+		try {
+			const res = await req("/v1/laws/BOE-A-1978-31229/markdown");
+			expect(res.status).toBe(200);
+			expect(res.headers.get("content-type")).toBe(
+				"text/markdown; charset=utf-8",
+			);
+			expect(await res.text()).toContain("# Constitucion");
+		} finally {
+			gitStub.getFileLatest = original;
+		}
+	});
+
+	it("returns 404 when the law has no Markdown file", async () => {
+		insertNorm();
+		// gitStub.getFileLatest returns null by default → no file on disk.
+		const res = await req("/v1/laws/BOE-A-1978-31229/markdown");
+		expect(res.status).toBe(404);
+	});
+});
+
 describe("GET /v1/laws/:id/graph", () => {
 	it("returns 404 for non-existent law", async () => {
 		const { status, body } = await json("/v1/laws/NOPE/graph");

--- a/packages/api/src/routes/laws.ts
+++ b/packages/api/src/routes/laws.ts
@@ -322,6 +322,41 @@ export function lawRoutes(
 				},
 			)
 
+			// 5b. GET /v1/laws/:id/markdown — current canonical Markdown (agent-friendly)
+			.get(
+				"/laws/:id/markdown",
+				async ({ params, set }) => {
+					const law = dbService.getLaw(params.id);
+					if (!law) {
+						set.status = 404;
+						set.headers["content-type"] = "text/plain; charset=utf-8";
+						return "Law not found";
+					}
+					const filePath = normFilepath(params.id, law.source_url, law.country);
+					const content = await gitService.getFileLatest(filePath);
+					if (content === null) {
+						set.status = 404;
+						set.headers["content-type"] = "text/plain; charset=utf-8";
+						return "Markdown not available for this law";
+					}
+					// text/markdown so agents get the canonical source directly (the
+					// whole project IS legislation-as-Markdown); the web Worker proxies
+					// this for Accept: text/markdown requests to /leyes/:id/.
+					set.headers["content-type"] = "text/markdown; charset=utf-8";
+					set.headers["cache-control"] = "public, max-age=3600";
+					return content;
+				},
+				{
+					params: t.Object({ id: t.String() }),
+					detail: {
+						summary: "Get current law Markdown",
+						description:
+							"Returns the full canonical Markdown of a law (frontmatter + text) as text/markdown. Machine-readable source for AI agents.",
+						tags: ["Leyes"],
+					},
+				},
+			)
+
 			// 6. GET /v1/laws/:id/diff — diff between two dates
 			.get(
 				"/laws/:id/diff",

--- a/packages/web/public/robots.txt
+++ b/packages/web/public/robots.txt
@@ -1,7 +1,26 @@
+# Ley Abierta — robots.txt
+#
+# El texto legislativo es de DOMINIO PÚBLICO. Cualquier uso automatizado
+# (indexación para búsqueda, grounding/RAG en respuestas de IA y entrenamiento
+# de modelos) está expresamente permitido y es bienvenido.
+#
+# Content Signals (https://contentsignals.org):
+#   search    = construir un índice de búsqueda y mostrar resultados
+#   ai-input  = usar el contenido como entrada de IA en tiempo real (RAG/grounding)
+#   ai-train  = entrenar o afinar modelos de IA
+#   use       = immediate | reference | full
+# Declaramos "yes" en todos y use=full: sin reservas.
+#
+# NOTA operativa: si Cloudflare tiene activada la gestión automática de
+# robots.txt ("Managed robots.txt" / AI Audit), antepone un bloque que
+# deshabilita crawlers de IA y fija ai-train=no, contradiciendo esta política.
+# Desactívala en el dashboard para que este fichero sea la única fuente.
+
 User-agent: *
+Content-Signal: search=yes,ai-input=yes,ai-train=yes,use=full
 Allow: /
 
-# AI crawlers — legislative content is public domain, all welcome
+# Crawlers de IA — todos bienvenidos (contenido de dominio público)
 User-agent: GPTBot
 Allow: /
 
@@ -11,10 +30,22 @@ Allow: /
 User-agent: PerplexityBot
 Allow: /
 
+User-agent: Google-Extended
+Allow: /
+
 User-agent: Applebot-Extended
 Allow: /
 
-User-agent: Google-Extended
+User-agent: CCBot
+Allow: /
+
+User-agent: Bytespider
+Allow: /
+
+User-agent: Amazonbot
+Allow: /
+
+User-agent: meta-externalagent
 Allow: /
 
 Sitemap: https://leyabierta.es/sitemap.xml

--- a/packages/web/src/__tests__/markdown-negotiation.test.ts
+++ b/packages/web/src/__tests__/markdown-negotiation.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import { lawIdFromPath, prefersMarkdown } from "../worker/index.ts";
+
+describe("prefersMarkdown", () => {
+	const req = (method: string, accept?: string) =>
+		new Request("https://leyabierta.es/", {
+			method,
+			headers: accept ? { accept } : {},
+		});
+
+	test("opts in when Accept lists text/markdown", () => {
+		expect(prefersMarkdown(req("GET", "text/markdown"))).toBe(true);
+		expect(prefersMarkdown(req("GET", "text/markdown, text/plain;q=0.9"))).toBe(
+			true,
+		);
+	});
+
+	test("browsers (text/html) are not opted in", () => {
+		expect(
+			prefersMarkdown(
+				req("GET", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*"),
+			),
+		).toBe(false);
+		expect(prefersMarkdown(req("GET", "*/*"))).toBe(false);
+		expect(prefersMarkdown(req("GET"))).toBe(false);
+	});
+
+	test("only GET is eligible", () => {
+		expect(prefersMarkdown(req("POST", "text/markdown"))).toBe(false);
+		expect(prefersMarkdown(req("HEAD", "text/markdown"))).toBe(false);
+	});
+});
+
+describe("lawIdFromPath", () => {
+	test("extracts the norm id from a law page path", () => {
+		expect(lawIdFromPath("/leyes/BOE-A-2023-12203/")).toBe("BOE-A-2023-12203");
+		expect(lawIdFromPath("/leyes/BOE-A-2023-12203")).toBe("BOE-A-2023-12203");
+	});
+
+	test("returns null for non-law paths", () => {
+		expect(lawIdFromPath("/")).toBeNull();
+		expect(lawIdFromPath("/leyes/")).toBeNull();
+		expect(lawIdFromPath("/leyes/BOE-A-2023-12203/reformas/")).toBeNull();
+		expect(lawIdFromPath("/cambios/reforma/")).toBeNull();
+	});
+});

--- a/packages/web/src/worker/index.ts
+++ b/packages/web/src/worker/index.ts
@@ -36,6 +36,73 @@ const DEFAULT_API_BASE = "https://api.leyabierta.es";
 const REFORM_PATH_PREFIX = "/cambios/reforma/";
 const SHELL_PATH = "/cambios/reforma/";
 
+// --- Markdown for Agents ---------------------------------------------------
+// Content negotiation: requests carrying `Accept: text/markdown` get the
+// canonical Markdown instead of HTML. The project IS legislation-as-Markdown,
+// so we serve the real source (via the API's /markdown endpoint) rather than
+// converting rendered HTML — higher fidelity and fewer tokens for agents.
+// This is what lifts the site to Cloudflare's "Agent-Readable" (level 3).
+
+/** True when the client explicitly asks for Markdown (agents), not a browser
+ *  (which sends `text/html,...`). Any mention of `text/markdown` opts in. */
+export function prefersMarkdown(request: Request): boolean {
+	if (request.method !== "GET") return false;
+	const accept = request.headers.get("accept") ?? "";
+	return /text\/markdown/i.test(accept);
+}
+
+/** Extracts a norm id from a law page path (`/leyes/<id>/`), or null. */
+export function lawIdFromPath(pathname: string): string | null {
+	const m = pathname.match(/^\/leyes\/([^/]+)\/?$/);
+	return m ? decodeURIComponent(m[1]!) : null;
+}
+
+function markdownBody(body: string): Response {
+	return new Response(body, {
+		status: 200,
+		headers: {
+			"content-type": "text/markdown; charset=utf-8",
+			// Cache HTML and Markdown variants separately at the edge/clients.
+			vary: "Accept",
+			"cache-control": "public, s-maxage=3600, stale-while-revalidate=86400",
+			"x-content-type-options": "nosniff",
+		},
+	});
+}
+
+/** Produce a Markdown response for the requested path, or null if this path
+ *  has no Markdown representation (caller then falls back to normal HTML). */
+async function markdownResponse(env: Env, url: URL): Promise<Response | null> {
+	// Homepage → the site's llms.txt overview (already a hand-written Markdown
+	// map of the whole site). Served from static assets.
+	if (url.pathname === "/") {
+		const res = await env.ASSETS.fetch(new URL("/llms.txt", url).toString());
+		if (!res.ok) return null;
+		return markdownBody(await res.text());
+	}
+
+	// Law page → canonical Markdown of the norm, straight from the API.
+	const id = lawIdFromPath(url.pathname);
+	if (id) {
+		const apiBase = env.PUBLIC_API_URL || DEFAULT_API_BASE;
+		const headers: HeadersInit = env.API_BYPASS_KEY
+			? { "x-api-key": env.API_BYPASS_KEY }
+			: {};
+		try {
+			const res = await fetch(
+				`${apiBase}/v1/laws/${encodeURIComponent(id)}/markdown`,
+				{ headers, signal: AbortSignal.timeout(8000) },
+			);
+			if (!res.ok) return null;
+			return markdownBody(await res.text());
+		} catch {
+			return null;
+		}
+	}
+
+	return null;
+}
+
 /** Finds the index of the `</div>` that matches the opening `<div>` whose
  *  content starts at `contentStart` (depth-aware, so nested divs inside the
  *  shell's loading skeleton don't confuse the boundary). Returns -1 if
@@ -288,6 +355,14 @@ async function renderReformResponse(
 export default {
 	async fetch(request: Request, env: Env): Promise<Response> {
 		const url = new URL(request.url);
+
+		// Markdown for Agents: honor `Accept: text/markdown` on pages that have
+		// a Markdown representation. If we can't produce one, fall through to the
+		// normal HTML handling below.
+		if (prefersMarkdown(request)) {
+			const md = await markdownResponse(env, url);
+			if (md) return md;
+		}
 
 		if (url.pathname.startsWith(REFORM_PATH_PREFIX)) {
 			const result = await renderReformResponse(env, url);

--- a/packages/web/wrangler.jsonc
+++ b/packages/web/wrangler.jsonc
@@ -19,8 +19,13 @@
 		// /cambios/reforma/index.html would be served straight from ASSETS and
 		// the SSR/meta-injection in src/worker/index.ts would never run (every
 		// reform would stay the noindex shell — defeating the whole point).
-		// Run the Worker first only for reform URLs; everything else is served
-		// directly from assets (no Worker invocation → preserves the request budget).
-		"run_worker_first": ["/cambios/reforma/*"]
+		// Run the Worker first for:
+		//  - reform URLs (SSR the diff into the shell, as before)
+		//  - the homepage and law pages, so the Worker can do `Accept:
+		//    text/markdown` content negotiation (Markdown for Agents). For normal
+		//    HTML requests these paths just fall straight through to ASSETS, so
+		//    the only added cost is one passthrough Worker invocation on them.
+		// Everything else (assets, other pages) still skips the Worker entirely.
+		"run_worker_first": ["/", "/leyes/*", "/cambios/reforma/*"]
 	}
 }


### PR DESCRIPTION
## Qué

Sube el sitio del **nivel 2 "Bot-Aware" al nivel 3 "Agent-Readable"** del scanner de Cloudflare (`isitagentready.com`). El único check que faltaba era **Markdown content negotiation**. De paso resuelve la contradicción del `robots.txt`.

### Markdown for Agents (`Accept: text/markdown`)
- **API**: nuevo `GET /v1/laws/:id/markdown` → devuelve el Markdown canónico de la norma (frontmatter + texto) como `text/markdown`, vía `gitService.getFileLatest`. Servimos la **fuente real** (el proyecto entero es *legislation-as-Markdown*) en vez de convertir HTML renderizado → más fidelidad y menos tokens para agentes.
- **Worker**: negociación de contenido. `/` → el `llms.txt` (mapa del sitio ya escrito a mano); `/leyes/:id/` → proxy del Markdown de la API. Cualquier ruta sin representación Markdown cae al HTML normal. `Vary: Accept` para cachear las variantes por separado.
- **wrangler**: `run_worker_first` ahora cubre también `/` y `/leyes/*` (las peticiones HTML normales solo hacen passthrough).

### robots.txt
Política ahora **coherente y permisiva** — contenido legislativo de dominio público, toda IA bienvenida: `Content-Signal: search=yes,ai-input=yes,ai-train=yes,use=full` + `Allow` explícito para los crawlers de IA principales.

> ⚠️ **Acción de dashboard pendiente**: el bloque contradictorio que se ve en prod (Disallow ClaudeBot/GPTBot + `ai-train=no`) lo **inyecta Cloudflare** (Managed robots.txt / AI Audit), no el repo. Hay que **desactivar esa gestión automática** en el dashboard para que este fichero sea la única fuente.

## Tests
- API: `/v1/laws/:id/markdown` (200 `text/markdown`, 404 sin ley, 404 sin fichero).
- Worker: helpers de negociación (`prefersMarkdown`, `lawIdFromPath`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)