### PR TITLE
fix(seo): drop invalid dates from reformas sitemap (GSC "Invalid date")

### DIFF
--- a/packages/web/src/__tests__/sitemap-dates.test.ts
+++ b/packages/web/src/__tests__/sitemap-dates.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+import { clampLastmod, isPlausibleReformDate } from "../lib/sitemap-dates.ts";
+
+const MAX_YEAR = 2027;
+
+describe("isPlausibleReformDate", () => {
+	test("accepts real dates in range", () => {
+		expect(isPlausibleReformDate("1978-12-29", MAX_YEAR)).toBe(true);
+		expect(isPlausibleReformDate("2024-02-17", MAX_YEAR)).toBe(true);
+		expect(isPlausibleReformDate("1835-01-01", MAX_YEAR)).toBe(true);
+	});
+
+	test("rejects the corrupt year-2929 pipeline bug", () => {
+		expect(isPlausibleReformDate("2929-11-19", MAX_YEAR)).toBe(false);
+	});
+
+	test("rejects out-of-range years", () => {
+		expect(isPlausibleReformDate("1799-12-31", MAX_YEAR)).toBe(false);
+		expect(isPlausibleReformDate("3000-01-01", MAX_YEAR)).toBe(false);
+	});
+
+	test("rejects malformed shapes and non-dates", () => {
+		expect(isPlausibleReformDate("2024-2-1", MAX_YEAR)).toBe(false);
+		expect(isPlausibleReformDate("not-a-date", MAX_YEAR)).toBe(false);
+		expect(isPlausibleReformDate("", MAX_YEAR)).toBe(false);
+	});
+
+	test("rejects calendar rollovers Date silently normalizes", () => {
+		expect(isPlausibleReformDate("2024-02-30", MAX_YEAR)).toBe(false);
+		expect(isPlausibleReformDate("2024-13-01", MAX_YEAR)).toBe(false);
+	});
+});
+
+describe("clampLastmod", () => {
+	test("passes through past dates unchanged", () => {
+		expect(clampLastmod("2020-05-01", "2026-07-22")).toBe("2020-05-01");
+	});
+
+	test("clamps future dates to today", () => {
+		expect(clampLastmod("2027-01-01", "2026-07-22")).toBe("2026-07-22");
+	});
+});

--- a/packages/web/src/lib/sitemap-dates.ts
+++ b/packages/web/src/lib/sitemap-dates.ts
@@ -1,0 +1,29 @@
+/**
+ * Date sanitation for the reformas sitemap.
+ *
+ * Reform dates come from the pipeline and can be corrupt (e.g. `2929-11-19`,
+ * a date-parse bug). A plain `/^\d{4}-\d{2}-\d{2}$/` shape check lets those
+ * through, and Google then rejects the entire reformas sitemap with "Invalid
+ * date" errors — which kept ~35k reform URLs out of the index. These helpers
+ * drop the corrupt entries and keep every `<lastmod>` non-future.
+ */
+
+// The Spanish consolidated corpus starts ~1835; anything before 1800 is a bug.
+export const MIN_REFORM_YEAR = 1800;
+
+/** A reform date must be a REAL calendar date within [MIN_REFORM_YEAR, maxYear].
+ *  Rejects shape mismatches, non-dates, silent rollovers (2024-02-30), and
+ *  implausible years. `maxYear` is passed in (build year + 1) for testability. */
+export function isPlausibleReformDate(s: string, maxYear: number): boolean {
+	if (!/^\d{4}-\d{2}-\d{2}$/.test(s)) return false;
+	const d = new Date(`${s}T00:00:00Z`);
+	if (Number.isNaN(d.getTime())) return false;
+	if (!d.toISOString().startsWith(s)) return false;
+	const year = d.getUTCFullYear();
+	return year >= MIN_REFORM_YEAR && year <= maxYear;
+}
+
+/** Clamp a lastmod to today: Google flags future lastmod values as invalid. */
+export function clampLastmod(fecha: string, todayIso: string): string {
+	return fecha > todayIso ? todayIso : fecha;
+}

--- a/packages/web/src/pages/sitemap-reformas.xml.ts
+++ b/packages/web/src/pages/sitemap-reformas.xml.ts
@@ -18,10 +18,13 @@
 
 import { getCollection } from "astro:content";
 import type { APIRoute } from "astro";
+import { clampLastmod, isPlausibleReformDate } from "../lib/sitemap-dates.ts";
 
 export const prerender = true;
 
 const SITE_URL = "https://leyabierta.es";
+const TODAY_ISO = new Date().toISOString().slice(0, 10);
+const MAX_YEAR = new Date().getUTCFullYear() + 1;
 
 export const GET: APIRoute = async () => {
 	const laws = await getCollection("laws");
@@ -35,12 +38,17 @@ export const GET: APIRoute = async () => {
 			// date — it's not a change, it's the law coming into existence. Skip it;
 			// that content lives at /leyes/<id>/, not /cambios/reforma/.
 			if (reforma.fecha === d.fecha_publicacion) continue;
-			if (!/^\d{4}-\d{2}-\d{2}$/.test(reforma.fecha)) continue;
+			// Drop corrupt pipeline dates (e.g. year 2929) — Google rejected the
+			// whole sitemap over 160 such "Invalid date" lastmods, keeping ~35k
+			// reform URLs out of the index.
+			if (!isPlausibleReformDate(reforma.fecha, MAX_YEAR)) continue;
 
+			// lastmod must never be in the future (Google flags it as invalid).
+			const lastmod = clampLastmod(reforma.fecha, TODAY_ISO);
 			const loc = `${SITE_URL}/cambios/reforma/?id=${encodeURIComponent(d.identificador)}&amp;date=${encodeURIComponent(reforma.fecha)}`;
 			urls.push(`  <url>
     <loc>${loc}</loc>
-    <lastmod>${reforma.fecha}</lastmod>
+    <lastmod>${lastmod}</lastmod>
     <changefreq>never</changefreq>
     <priority>0.5</priority>
   </url>`);


### PR DESCRIPTION
## Problema
GSC rechaza `sitemap-reformas.xml` con **"Invalid date" (160 instances)** → las ~35k URLs de reformas **no entran en el índice** (el índice solo descubre las 12.3k leyes).

## Causa
El generador validaba el **formato** (`/^\d{4}-\d{2}-\d{2}$/`) pero no la **validez** de la fecha. Fechas corruptas del pipeline se colaban en `<lastmod>`:
- año fuera de rango (`2929-11-19`, un parse bug)
- calendario imposible (`2012-06-31` — junio tiene 30 días)
- fechas futuras (Google marca cualquier `lastmod` futuro como inválido)

## Fix
Nuevo `src/lib/sitemap-dates.ts`:
- `isPlausibleReformDate()` — fecha real de calendario en `[1800, buildYear+1]`; rechaza formato malo, no-fechas, rollovers silenciosos (`2024-02-30`) y años fuera de rango. Las entradas corruptas se **descartan** (una URL con `date=` basura apunta a una reforma rota).
- `clampLastmod()` — nunca emite un `lastmod` futuro.

Resultado: **cero fechas inválidas** en el sitemap. Tras el deploy, *resubmit* en GSC borra el error y las reformas se descubren.

## Nota
Esto sanea el **sitemap**. Las fechas corruptas de origen (`2929-11-19`, `2012-06-31`) son un **bug de datos aparte** en el parser de fechas del pipeline — merece follow-up.

## Tests
`isPlausibleReformDate` + `clampLastmod` cubriendo válidas/corruptas/rollover/futuras (7 casos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)