### PR TITLE
Pipeline hardening: materias, prod tag, backstop, cold search, umami

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -451,12 +451,128 @@ jobs:
           new-status: "${{ job.status == 'success' && format('✅ **web** — Deployed ({0})', steps.duration.outputs.text) || job.status == 'cancelled' && '⚪ **web** — Cancelled' || format('❌ **web** — Failed ({0})', steps.duration.outputs.text) }}"
 
   # ============================================
+  # Bump the `prod` tag
+  #
+  # KonarServer's cron self-updates its checkout at /opt/leyabierta/code with
+  # `git fetch origin +refs/tags/prod:refs/tags/prod && git reset --hard
+  # refs/tags/prod` before every run (scripts/daily-pipeline.sh:16-28).
+  # Nothing moved that tag automatically before this job existed, so it only
+  # advanced when someone remembered to move it by hand: on 2026-07-22 it was
+  # still at c009110 (13-jul), 18 commits behind main, which is why the Step 10
+  # vector-index rebuild added by #110 had never run in production — neither
+  # scripts/rebuild-vector-index.sh nor the Step 10 block existed in the tree
+  # the server was actually executing.
+  #
+  # Deliberately NOT gated on changed paths. The prod tag governs the whole
+  # host checkout, and several things outside scripts/ and packages/pipeline/
+  # are read from it: docker-compose.yml (the volume mounts and the 8G memory
+  # cap), Dockerfile, and anything a future orchestrator step decides to read.
+  # Keeping the tag == last green main is one invariant instead of a path list
+  # that has to be kept in sync with the bash by hand.
+  #
+  # NOTE on what the tag does NOT control: everything under `data/` (including
+  # data/auxiliar/materias.json) is gitignored — `/data` in .gitignore — and
+  # lives in the `./data:/data` bind mount, not in git. `git reset --hard`
+  # never touches those files. Fixes to that data are DB/volume operations,
+  # not tag moves.
+  # ============================================
+
+  bump-prod-tag:
+    name: Bump prod tag
+    needs: [detect-changes, lint, deploy-api, deploy-web]
+    # workflow_dispatch can be launched against any branch from the "Run
+    # workflow" picker, so github.ref is checked first; the ancestry check in
+    # the step below is the real enforcement (github.ref alone would not stop
+    # a tag move to a commit that had been force-pushed off main).
+    if: |
+      always() &&
+      github.ref == 'refs/heads/main' &&
+      needs.lint.result == 'success' &&
+      (needs.deploy-api.result == 'success' || needs.deploy-api.result == 'skipped') &&
+      (needs.deploy-web.result == 'success' || needs.deploy-web.result == 'skipped')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          # Full history: the ancestry guard below needs real merge-base data,
+          # which a shallow clone cannot provide.
+          fetch-depth: 0
+
+      # The `lint` job runs `bun run check` (Biome) and `bun test || true` —
+      # Biome does not parse shell and the test failures are swallowed, so
+      # nothing in CI currently validates the bash that KonarServer executes.
+      # Since this job makes main auto-propagate to production, a syntax error
+      # in daily-pipeline.sh would silently kill the 08:30 run (it is
+      # `set -euo pipefail`) and with it that day's subscriber emails. This is
+      # the cheapest gate that makes that impossible.
+      - name: Validate the shell the server will execute
+        run: |
+          set -euo pipefail
+          fail=0
+          while IFS= read -r -d '' f; do
+            if bash -n "$f"; then
+              echo "  ok  $f"
+            else
+              echo "::error file=$f::bash syntax error — refusing to move the prod tag"
+              fail=1
+            fi
+          done < <(find scripts -name '*.sh' -type f -print0)
+          [ "$fail" -eq 0 ]
+
+      - name: Force-move prod tag to this green SHA
+        run: |
+          set -euo pipefail
+          SHA='${{ github.sha }}'
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Guard: only ever point prod at a commit that is on origin/main.
+          git fetch --quiet origin main
+          if ! git merge-base --is-ancestor "$SHA" origin/main; then
+            echo "::error::$SHA is not an ancestor of origin/main — refusing to move prod"
+            exit 1
+          fi
+
+          # Guard: never move prod backwards. Concurrent runs (a push and a
+          # leyes-updated repository_dispatch can both be in flight) would
+          # otherwise be able to rewind the server to an older tree.
+          CURRENT=$(git ls-remote origin refs/tags/prod | head -1 | cut -f1)
+          if [ -n "$CURRENT" ] \
+             && git cat-file -e "${CURRENT}^{commit}" 2>/dev/null \
+             && git merge-base --is-ancestor "$SHA" "$CURRENT"; then
+            echo "prod already at or ahead of $SHA ($CURRENT) — nothing to do"
+            exit 0
+          fi
+
+          # Fully-qualified refspec + force: `prod` alone is ambiguous if a
+          # branch of that name ever appears, and daily-pipeline.sh fetches
+          # with "+refs/tags/prod:refs/tags/prod", so the remote tag has to be
+          # force-updated (a plain push of a moved tag is rejected as
+          # non-fast-forward).
+          git tag -f prod "$SHA"
+          git push --force origin refs/tags/prod:refs/tags/prod
+          echo "prod tag now points to $SHA"
+
+      - name: Notify — prod tag bumped
+        if: always()
+        continue-on-error: true
+        uses: TriloHQ/notify-action@4db9f20562607d77b83ee78e6a6c2ff7184ece3f # v1
+        with:
+          token: ${{ secrets.TRILO_BOT_TOKEN }}
+          project-id: ${{ secrets.TRILO_PROJECT_ID }}
+          action: send
+          message: |
+            ${{ job.status == 'success' && '🏷️' || '❌' }} **prod tag** → `${{ github.sha }}` (${{ job.status }}) — KonarServer picks this up on its next daily-pipeline.sh run.
+
+  # ============================================
   # Final notification
   # ============================================
 
   notify-result:
     name: Notify result
-    needs: [detect-changes, deploy-api, deploy-web]
+    needs: [detect-changes, deploy-api, deploy-web, bump-prod-tag]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -469,4 +585,4 @@ jobs:
           action: send
           message: |
             ${{ (needs.deploy-api.result == 'success' || needs.deploy-api.result == 'skipped') && (needs.deploy-web.result == 'success' || needs.deploy-web.result == 'skipped') && '✅' || '❌' }} **Deploy complete** · `${{ github.sha }}`
-            API: ${{ needs.deploy-api.result }} · Web: ${{ needs.deploy-web.result }}
+            API: ${{ needs.deploy-api.result }} · Web: ${{ needs.deploy-web.result }} · prod tag: ${{ needs.bump-prod-tag.result }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -243,9 +243,16 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      # `ref: main` is explicit on purpose. The backstop compares against
+      # `repos/leyabierta/leyes/commits/main`; actions/checkout without `ref`
+      # follows whatever the leyes default branch happens to be. They agree
+      # today, but if they ever diverge the SHA recorded at the end of this job
+      # could never equal the backstop's, and the backstop would see permanent
+      # drift and rebuild the whole site every 30 minutes.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           repository: leyabierta/leyes
+          ref: main
           path: content/laws
           fetch-depth: 1
 
@@ -380,6 +387,49 @@ jobs:
             exit 0
           fi
           echo "✓ cache purged"
+
+      # Keeps the leyes-rebuild-backstop.yml cache marker (`last-leyes-sha-*`)
+      # in sync whenever THIS job is the one that actually rebuilt the site, no
+      # matter what triggered it (push, workflow_dispatch, or the primary
+      # repository_dispatch from leyes' notify-leyabierta.yml).
+      #
+      # Without this, the backstop is the only writer of that cache entry, so a
+      # primary-path deploy leaves it stale: on a later tick the backstop
+      # restores the stale marker, sees drift against a leyes HEAD that is
+      # already live, and fires a second, redundant full rebuild (~12k pages).
+      #
+      # The SHA comes from the `content/laws` checkout above — that is the tree
+      # this build actually consumed — never from the dispatch payload.
+      #
+      # Both steps are continue-on-error: the site is already deployed and
+      # purged by the time we get here, so a cache hiccup must not turn the job
+      # red (the Trilo notification below reads job.status).
+      # NOTE: the default shell here is `bash -e {0}`, not `-euo pipefail`, so
+      # the stricter flags are set explicitly.
+      - name: Record leyes HEAD SHA as built
+        id: leyes-sha
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          SHA=$(git -C content/laws rev-parse HEAD)
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+          echo "$SHA" > .last-leyes-sha
+
+      # The `sha != ''` guard is load-bearing. If the step above failed, the
+      # output is empty and the key collapses to the literal `last-leyes-sha-`,
+      # which is exactly the backstop's restore-keys prefix. That entry would
+      # then be the newest prefix match forever, the backstop would read an
+      # empty last-built SHA, see permanent drift, and rebuild the entire site
+      # every 30 minutes. Cache keys cannot be overwritten, so it would not
+      # self-heal. `success() &&` is kept because an explicit `if` otherwise
+      # replaces the implicit success() gate.
+      - name: Sync backstop cache marker
+        if: success() && steps.leyes-sha.outputs.sha != ''
+        continue-on-error: true
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: .last-leyes-sha
+          key: last-leyes-sha-${{ steps.leyes-sha.outputs.sha }}
 
       - name: Calculate duration
         if: always()

--- a/.github/workflows/leyes-rebuild-backstop.yml
+++ b/.github/workflows/leyes-rebuild-backstop.yml
@@ -13,6 +13,11 @@ name: Leyes rebuild backstop
 #   3. If different → fires `repository_dispatch` to deploy.yml (same code path
 #      as the primary trigger) and refreshes the cache with the new SHA.
 #
+# The marker is ALSO written by deploy.yml's deploy-web job ("Sync backstop
+# cache marker") on every successful web deploy, whatever triggered it.
+# Otherwise a primary-path deploy never advances the marker and this workflow
+# re-dispatches a rebuild that already happened.
+#
 # Cache-based storage chosen because the default GITHUB_TOKEN cannot mutate
 # repo variables. Cache entries idle-evict after 7 days; we run every 30 min
 # so the entry stays warm indefinitely.
@@ -25,6 +30,7 @@ on:
 permissions:
   contents: read   # GITHUB_TOKEN only used to read leyes (public repo)
                    # Dispatch uses LEYABIERTA_DISPATCH_TOKEN (PAT), not GITHUB_TOKEN
+  actions: read    # list in-flight deploy.yml runs (see "Check for in-flight deploy")
 
 concurrency:
   group: leyes-backstop
@@ -54,6 +60,39 @@ jobs:
           restore-keys: |
             last-leyes-sha-
 
+      # Writing the marker at the END of deploy-web (correct: only a finished
+      # build may claim a SHA) leaves a ~6 min window in which the marker is
+      # legitimately stale. This job runs every 30 min, so roughly one leyes
+      # push in five lands inside that window: we would see "drift", dispatch,
+      # and `concurrency: cancel-in-progress` on deploy-main would kill the
+      # healthy in-flight build to start the same one again. If a deploy is
+      # already running, stand down and re-check on the next tick — the marker
+      # is deliberately left untouched, so nothing is marked built prematurely.
+      #
+      # Bounded to runs younger than 30 min so a wedged run cannot blind the
+      # backstop indefinitely. Any failure here (missing scope, API blip)
+      # falls back to 0 == "not busy", i.e. exactly today's behaviour.
+      - name: Check for in-flight deploy
+        id: inflight
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -uo pipefail
+          RUNS=$(gh run list --repo "${{ github.repository }}" \
+            --workflow deploy.yml --status in_progress --limit 30 \
+            --json createdAt \
+            --jq '[.[] | select((now - (.createdAt | fromdateiso8601)) < 1800)] | length' \
+            2>/dev/null) || RUNS=""
+          case "$RUNS" in
+            ''|*[!0-9]*) RUNS=0 ;;
+          esac
+          echo "In-flight deploy runs: $RUNS"
+          if [ "$RUNS" -gt 0 ]; then
+            echo "busy=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "busy=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Compare and dispatch if drifted
         id: decide
         env:
@@ -64,6 +103,7 @@ jobs:
           # the same PAT that notify-leyabierta.yml uses on the leyes side.
           GH_TOKEN: ${{ secrets.LEYABIERTA_DISPATCH_TOKEN }}
           REMOTE_SHA: ${{ steps.remote.outputs.sha }}
+          DEPLOY_BUSY: ${{ steps.inflight.outputs.busy }}
         run: |
           set -euo pipefail
 
@@ -72,6 +112,12 @@ jobs:
             LAST_SHA=$(cat .last-leyes-sha)
           fi
           echo "Last built SHA: ${LAST_SHA:-<none>}"
+
+          if [ "$DEPLOY_BUSY" = "true" ]; then
+            echo "⏸ a deploy is already in flight — standing down, re-checking in 30 min"
+            echo "drifted=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
           if [ "$REMOTE_SHA" = "$LAST_SHA" ]; then
             echo "✓ in sync — no rebuild needed"

--- a/bun.lock
+++ b/bun.lock
@@ -28,7 +28,7 @@
         "@resvg/resvg-js": "^2.6.2",
         "@types/js-yaml": "4.0.9",
         "elysia": "1.4.28",
-        "js-yaml": "4.1.1",
+        "js-yaml": "4.3.0",
         "opik": "^2.0.1",
         "resend": "6.10.0",
         "satori": "^0.26.0",
@@ -47,7 +47,7 @@
       "version": "0.1.0",
       "devDependencies": {
         "@types/js-yaml": "^4.0.9",
-        "js-yaml": "^4.1.1",
+        "js-yaml": "^4.3.0",
       },
     },
     "packages/web": {
@@ -58,7 +58,7 @@
         "@lottiefiles/dotlottie-react": "^0.19.2",
         "astro": "^7.1.1",
         "diff2html": "3.4.56",
-        "js-yaml": "4.1.1",
+        "js-yaml": "4.3.0",
         "markdown-it": "^14.1.1",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
@@ -916,7 +916,7 @@
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
-    "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+    "js-yaml": ["js-yaml@4.3.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q=="],
 
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
@@ -1286,6 +1286,8 @@
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
+    "@astrojs/internal-helpers/js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
@@ -1305,6 +1307,8 @@
     "ansi-align/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "anymatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
+
+    "astro/js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
     "buffer/base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,20 @@
+# Log rotation is set per service rather than globally in /etc/docker/daemon.json:
+# the daemon-level setting needs a Docker restart, which would bounce every
+# container on the host (including other projects). These blocks only need the
+# leyabierta containers recreated. Without any limit, json-file logs grow
+# unbounded — traefik has been up for 3 months, the opik containers for 2.
+x-logging: &default-logging
+  driver: json-file
+  options:
+    max-size: "10m"
+    max-file: "3"
+
 services:
   api:
     image: ghcr.io/leyabierta/api:latest
     build: . # Fallback for local development
     restart: unless-stopped
+    logging: *default-logging
     ports:
       - "127.0.0.1:3000:3000"
     volumes:
@@ -38,6 +50,7 @@ services:
   watchtower:
     image: containrrr/watchtower
     restart: unless-stopped
+    logging: *default-logging
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     environment:
@@ -61,6 +74,7 @@ services:
   umami:
     image: ghcr.io/umami-software/umami:postgresql-v2
     restart: unless-stopped
+    logging: *default-logging
     ports:
       - "127.0.0.1:3001:3000"
     env_file:
@@ -100,6 +114,7 @@ services:
   umami-db:
     image: postgres:17-alpine
     restart: unless-stopped
+    logging: *default-logging
     env_file:
       - path: .env.prod
         required: false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,7 +79,10 @@ services:
       umami-db:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://localhost:3000/api/heartbeat"]
+      # 127.0.0.1, not localhost: the image resolves localhost to ::1 first and
+      # next-server only binds IPv4 0.0.0.0:3000, so wget got ECONNREFUSED and
+      # the container sat "unhealthy" for 8 days while serving traffic fine.
+      test: ["CMD", "wget", "--spider", "-q", "http://127.0.0.1:3000/api/heartbeat"]
       interval: 30s
       timeout: 5s
       retries: 3

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
 		"pipeline": "bun run packages/pipeline/src/cli.ts",
 		"ingest": "bun run packages/pipeline/src/ingest-cli.ts",
 		"ingest-analisis": "bun run packages/pipeline/src/ingest-analisis-cli.ts",
+		"download-auxiliar": "bun run packages/pipeline/src/download-auxiliar-cli.ts",
 		"api": "bun run packages/api/src/index.ts",
 		"api:dev": "bun --watch run packages/api/src/index.ts",
 		"web": "bun run --cwd packages/web astro dev --port 4321",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -12,7 +12,7 @@
 		"@resvg/resvg-js": "^2.6.2",
 		"@types/js-yaml": "4.0.9",
 		"elysia": "1.4.28",
-		"js-yaml": "4.1.1",
+		"js-yaml": "4.3.0",
 		"opik": "^2.0.1",
 		"resend": "6.10.0",
 		"satori": "^0.26.0"

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -22,10 +22,12 @@ import { DbService } from "./services/db.ts";
 import { GitService } from "./services/git.ts";
 import { HybridSearcherImpl } from "./services/hybrid-search.ts";
 import { startMemProbe } from "./services/mem-probe.ts";
+import { bm25HybridSearch } from "./services/rag/blocks-fts.ts";
 import { RagPipeline } from "./services/rag/pipeline.ts";
 import { EMBEDDING_MODEL_KEY } from "./services/rag/retrieval.ts";
 import { flushTraces } from "./services/rag/tracing.ts";
 import { getSharedVectorIndex } from "./services/rag/vector-index-singleton.ts";
+import { vectorSearchPooled } from "./services/rag/vector-pool.ts";
 import { createRateLimiter, getClientIp } from "./services/rate-limiter.ts";
 
 const DB_PATH = process.env.DB_PATH ?? "./data/leyabierta.db";
@@ -333,11 +335,16 @@ app
 // mode as the OOM restart, but without killing the container.
 // Gate: only preload when the API key is present (same gate as ragPipeline
 // / hybridSearcher) and RAG_PRELOAD is not explicitly disabled.
+let preloadedIndex: Awaited<ReturnType<typeof getSharedVectorIndex>> = null;
 if (OPENROUTER_API_KEY && process.env.RAG_PRELOAD !== "false") {
 	const t0 = performance.now();
 	console.log("[preload] loading vector index…");
 	try {
-		await getSharedVectorIndex(db, EMBEDDING_MODEL_KEY, RAG_DATA_DIR);
+		preloadedIndex = await getSharedVectorIndex(
+			db,
+			EMBEDDING_MODEL_KEY,
+			RAG_DATA_DIR,
+		);
 		const ms = Math.round(performance.now() - t0);
 		console.log(`[preload] vector index ready in ${ms}ms`);
 	} catch (err) {
@@ -352,5 +359,87 @@ app.listen(PORT);
 
 console.log(`Ley Abierta API running on http://localhost:${PORT}`);
 console.log(`Swagger docs: http://localhost:${PORT}/swagger`);
+
+// ── Vector pool + FTS warmup (fire-and-forget) ───────────────────────
+// The preload above only maps `vectors-int8.bin` into SharedArrayBuffers.
+// It does NOT start the Bun Worker pool that actually *serves* KNN
+// queries (`vector-pool.ts`): that pool is built lazily inside
+// `vectorSearchPooled` on the first real `/v1/laws` or `/v1/ask` request
+// — dlopen(vector-simd) + spawning RAG_VECTOR_POOL_WORKERS workers, each
+// opening its own readonly SQLite handle. On top of that, the FTS5
+// indexes are cold in the OS page cache right after a container restart
+// (PRAGMA mmap_size/cache_size only set the budget, they force no I/O).
+// Doing both here moves that one-off cost off the first citizen request.
+//
+// Runs after app.listen() and is not awaited: the port is bound and
+// /health answers before this starts. It reuses the index the preload
+// already loaded — it never re-enters getSharedVectorIndex, so a failed
+// preload cannot trigger a second (possibly index-rebuilding) load while
+// the container is already serving traffic, nor burn the singleton's
+// circuit-breaker budget.
+//
+// Everything is safe-to-fail and each step is isolated: a failure just
+// means the first real request pays that part of the cold start, exactly
+// as it does today.
+if (preloadedIndex) {
+	const idx = preloadedIndex;
+	(async () => {
+		// 1. Vector pool: dlopen + spawn workers + one full SIMD scan.
+		//    The query must NOT be a zero vector: `cosine_topk_int8` in
+		//    vector-simd.c bails out with `if (... || query_norm == 0.0f)
+		//    return 0;` before touching the corpus, so a zero vector would
+		//    warm the pool but skip the scan entirely. A deterministic
+		//    non-zero vector exercises the real FFI + heap + memory-walk
+		//    path without spending an embedding-API call.
+		const vecT0 = performance.now();
+		try {
+			const probeQuery = new Float32Array(idx.dims);
+			let seed = 0x9e3779b9;
+			for (let i = 0; i < idx.dims; i++) {
+				seed = (seed * 1664525 + 1013904223) >>> 0;
+				probeQuery[i] = seed / 0xffffffff - 0.5;
+			}
+			const hits = await vectorSearchPooled(
+				probeQuery,
+				idx.meta,
+				idx.vectors,
+				idx.dims,
+				200,
+			);
+			console.log(
+				`[warmup] vector pool ready in ${Math.round(performance.now() - vecT0)}ms (${hits.length} throwaway hits)`,
+			);
+		} catch (err) {
+			process.stderr.write(
+				`[warmup] vector pool warmup skipped: ${err instanceof Error ? err.message : err}\n`,
+			);
+		}
+
+		// 2. FTS pages. Two different indexes serve the two search paths and
+		//    warming one does nothing for the other:
+		//      - `/v1/laws?q=` → DbService.bm25RankedNormIds → `norms_fts`
+		//        (+ the `norms` title LIKE pass). This is the path that
+		//        produced the 30-40s cold outlier.
+		//      - `/v1/ask` → dispatchBm25Stages → `blocks_fts` (article
+		//        level). BM25 no longer goes through the worker pool
+		//        (bm25-dispatch.ts, 2026-05-15), so it is warmed directly.
+		//    Both calls are synchronous SQLite work on the main thread, so
+		//    keep the queries narrow: avoid corpus-wide tokens like "ley"
+		//    (docfreq 310k/435k in blocks_fts) which trigger the expensive
+		//    OR traversal the token pruning exists to avoid.
+		const ftsT0 = performance.now();
+		try {
+			dbService.searchLaws("permiso de paternidad", {}, 5, 0);
+			bm25HybridSearch(db, "permiso de paternidad", ["baja", "paternidad"], 20);
+			console.log(
+				`[warmup] FTS pages warm in ${Math.round(performance.now() - ftsT0)}ms`,
+			);
+		} catch (err) {
+			process.stderr.write(
+				`[warmup] FTS warmup skipped: ${err instanceof Error ? err.message : err}\n`,
+			);
+		}
+	})();
+}
 
 export type App = typeof app;

--- a/packages/pipeline/package.json
+++ b/packages/pipeline/package.json
@@ -7,6 +7,6 @@
 	},
 	"devDependencies": {
 		"@types/js-yaml": "^4.0.9",
-		"js-yaml": "^4.1.1"
+		"js-yaml": "^4.3.0"
 	}
 }

--- a/packages/pipeline/src/download-auxiliar-cli.ts
+++ b/packages/pipeline/src/download-auxiliar-cli.ts
@@ -1,8 +1,22 @@
 /**
  * Download all BOE auxiliary data (reference tables).
  *
- * Usage: bun run packages/pipeline/src/download-auxiliar-cli.ts
+ * The exit code is meaningful: 0 = every endpoint produced a usable file,
+ * 1 = at least one did not. The daily pipeline (Step 2.5) branches on it, so
+ * this must NOT swallow failures the way it used to — a downloader that always
+ * exits 0 turns every caller-side fallback into dead code.
+ *
+ * Writes are atomic (tmp + rename) and validated before promotion, so a 500
+ * page, a truncated body or an empty payload can never clobber a good cached
+ * copy. Losing that cache is what produced the 2026-07-22 materias incident.
+ *
+ * Usage:
+ *   bun run packages/pipeline/src/download-auxiliar-cli.ts
+ *   bun run packages/pipeline/src/download-auxiliar-cli.ts --check
+ *     ↳ downloads nothing; exits 0 iff the on-disk materias.json is usable.
  */
+
+import { rename } from "node:fs/promises";
 
 const BASE = "https://www.boe.es/datosabiertos/api";
 const OUT_DIR = "./data/auxiliar";
@@ -17,35 +31,90 @@ const ENDPOINTS = [
 	"datos-auxiliares/relaciones-posteriores",
 ] as const;
 
+/** Usable = `data` is a non-empty object (code → name) or a non-empty array. */
+function payloadSize(json: unknown): number {
+	const data = (json as { data?: unknown } | null)?.data;
+	if (Array.isArray(data)) return data.length;
+	if (data && typeof data === "object") return Object.keys(data).length;
+	return 0;
+}
+
+async function checkCache(): Promise<number> {
+	const path = `${OUT_DIR}/materias.json`;
+	try {
+		if (!(await Bun.file(path).exists())) {
+			console.error(`--check: ${path} does not exist`);
+			return 1;
+		}
+		const size = payloadSize(await Bun.file(path).json());
+		if (size === 0) {
+			console.error(`--check: ${path} has no usable "data" payload`);
+			return 1;
+		}
+		console.log(`--check: ${path} OK (${size} materias)`);
+		return 0;
+	} catch (err) {
+		const msg = err instanceof Error ? err.message : String(err);
+		console.error(`--check: ${path} unreadable (${msg})`);
+		return 1;
+	}
+}
+
 async function main() {
+	if (process.argv.includes("--check")) {
+		process.exit(await checkCache());
+	}
+
 	await Bun.write(`${OUT_DIR}/.gitkeep`, "");
+
+	let failed = 0;
 
 	for (const endpoint of ENDPOINTS) {
 		const name = endpoint.split("/")[1]!;
 		const url = `${BASE}/${endpoint}`;
+		const path = `${OUT_DIR}/${name}.json`;
 		console.log(`Downloading ${name}...`);
 
 		try {
 			const res = await fetch(url, {
 				headers: { Accept: "application/json" },
+				signal: AbortSignal.timeout(60_000),
 			});
 			if (!res.ok) {
-				console.error(`  ERROR: ${res.status}`);
+				console.error(`  ERROR: HTTP ${res.status} — keeping existing ${path}`);
+				failed++;
 				continue;
 			}
 			const json = await res.json();
-			const path = `${OUT_DIR}/${name}.json`;
-			await Bun.write(path, JSON.stringify(json, null, 2));
+			const count = payloadSize(json);
+			if (count === 0) {
+				console.error(`  ERROR: empty/unexpected payload — keeping ${path}`);
+				failed++;
+				continue;
+			}
 
-			const count = Array.isArray(json.data) ? json.data.length : "?";
+			// Atomic promote: never leave a half-written reference table behind,
+			// and never destroy the previous good copy on a partial write.
+			const tmp = `${path}.tmp`;
+			await Bun.write(tmp, JSON.stringify(json, null, 2));
+			await rename(tmp, path);
+
 			console.log(`  OK: ${count} items → ${path}`);
 		} catch (err) {
 			const msg = err instanceof Error ? err.message : String(err);
-			console.error(`  ERROR: ${msg}`);
+			console.error(`  ERROR: ${msg} — keeping existing ${path}`);
+			failed++;
 		}
 	}
 
+	if (failed > 0) {
+		console.error(`\nDone with ${failed}/${ENDPOINTS.length} failure(s).`);
+		process.exit(1);
+	}
 	console.log("\nDone.");
 }
 
-main();
+main().catch((err) => {
+	console.error("Fatal:", err);
+	process.exit(1);
+});

--- a/packages/pipeline/src/ingest-analisis-cli.ts
+++ b/packages/pipeline/src/ingest-analisis-cli.ts
@@ -26,13 +26,34 @@ async function main() {
 	const db = new Database(dbPath);
 	createSchema(db);
 
-	// Load materias lookup (code → name)
+	// Load materias lookup (code → name).
+	//
+	// 2026-07-22 incident: nothing in the pipeline ever downloaded this file, so
+	// on the server it never existed and every ELI materia code was written to
+	// the DB as a fabricated "[código NNNN]" string. The fix has two halves:
+	//   1. Step 2.5 of scripts/daily-pipeline.sh now refreshes the file.
+	//   2. This script NEVER fabricates a name (see processNorm below).
+	// Note we deliberately do NOT abort when the lookup is missing: the daily
+	// pipeline runs under `set -euo pipefail`, so exiting non-zero here would
+	// also kill Steps 4-8 (reform summaries, citizen tags, subscriber emails).
+	// A degraded run that adds no new materias is recoverable and self-heals on
+	// the next run; a pipeline that stops before the emails is not.
 	let materiaLookup: Record<string, string> = {};
 	try {
 		const raw = await Bun.file(materiasPath).json();
 		materiaLookup = raw.data ?? {};
 	} catch {
-		console.warn("Warning: could not load materias lookup from", materiasPath);
+		// fall through to the empty-lookup warning below
+	}
+	const lookupSize = Object.keys(materiaLookup).length;
+	if (lookupSize === 0) {
+		console.warn(
+			`WARNING: no usable materias lookup at ${materiasPath}. ELI materia ` +
+				"codes cannot be resolved to names this run, so materias fall back to " +
+				"the partial /analisis list. Existing rows are untouched (nothing is " +
+				"deleted) and the next run repairs this. Fix by running " +
+				"`bun run download-auxiliar` (Step 2.5 of the daily pipeline).",
+		);
 	}
 
 	const norms = db
@@ -55,6 +76,7 @@ async function main() {
 
 	let done = 0;
 	let errors = 0;
+	const missingCodes = new Set<string>();
 	const startTime = Date.now();
 
 	async function processNorm(
@@ -63,10 +85,19 @@ async function main() {
 	): Promise<{ materias: number; refs: number }> {
 		const analisis = await boe.getAnalisis(normId);
 		const materiaCodes = await boe.getMateriaCodes(normId);
-		const fullMaterias =
-			materiaCodes.length > 0
-				? materiaCodes.map((code) => materiaLookup[code] ?? `[código ${code}]`)
-				: analisis.materias;
+		// Never fabricate a name for a code the lookup doesn't cover: a fake
+		// "[código 4322]" is wrong data published to citizens, while a missing
+		// tag is a silent, self-healing gap (BOE adds codes faster than it
+		// republishes the reference table). Unresolved codes are dropped and
+		// tallied; if NONE of the codes resolve we fall back to the partial but
+		// real names from the /analisis endpoint rather than storing nothing.
+		const resolved: string[] = [];
+		for (const code of materiaCodes) {
+			const name = materiaLookup[code];
+			if (name) resolved.push(name);
+			else missingCodes.add(code);
+		}
+		const fullMaterias = resolved.length > 0 ? resolved : analisis.materias;
 
 		// DB writes are synchronous and fast — no contention issue
 		db.transaction(() => {
@@ -143,6 +174,15 @@ async function main() {
 	console.log("\n─── Analisis Fetch Summary ───");
 	console.log(`Done:   ${done}`);
 	console.log(`Errors: ${errors}`);
+	if (missingCodes.size > 0) {
+		const sample = [...missingCodes].sort().slice(0, 50).join(", ");
+		console.warn(
+			`Unresolved materia codes (omitted, never placeholdered): ${missingCodes.size} distinct` +
+				(lookupSize === 0
+					? " — lookup was empty, see the WARNING above"
+					: ` — e.g. ${sample}${missingCodes.size > 50 ? ", …" : ""}`),
+		);
+	}
 	console.log(
 		`Time:   ${Math.floor(fetchElapsed / 60)}m ${fetchElapsed % 60}s`,
 	);

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -12,7 +12,7 @@
 		"@lottiefiles/dotlottie-react": "^0.19.2",
 		"astro": "^7.1.1",
 		"diff2html": "3.4.56",
-		"js-yaml": "4.1.1",
+		"js-yaml": "4.3.0",
 		"markdown-it": "^14.1.1",
 		"react": "^19.2.5",
 		"react-dom": "^19.2.5",

--- a/scripts/ad-hoc/purge-materia-placeholders.ts
+++ b/scripts/ad-hoc/purge-materia-placeholders.ts
@@ -1,0 +1,130 @@
+/**
+ * Cleanup for the 2026-07-22 materias incident.
+ *
+ * Why it was needed: nothing in the pipeline ever ran download-auxiliar, so
+ * data/auxiliar/materias.json never existed on the server and
+ * ingest-analisis-cli.ts wrote a fabricated "[código NNNN]" string for every
+ * ELI materia code it could not resolve. Those strings reached the `materias`
+ * table, the JSON cache (data/json/<id>.json -> analisis.materias) and, via
+ * `bun run pipeline rebuild`, the frontmatter of the published leyes repo.
+ *
+ * Root cause fixed in the same change:
+ *   - scripts/daily-pipeline.sh Step 2.5 refreshes the lookup every run.
+ *   - packages/pipeline/src/download-auxiliar-cli.ts now exits non-zero on
+ *     failure and writes atomically, so the cache can't be silently lost.
+ *   - packages/pipeline/src/ingest-analisis-cli.ts never fabricates a name.
+ *
+ * This script only removes the contamination that already landed. It does NOT
+ * write to the leyes repo (CLAUDE.md, "Rules for ad-hoc scripts that write to
+ * leyes"): run `bun run pipeline rebuild` afterwards so the markdown is
+ * regenerated from the cleaned JSON cache.
+ *
+ * Idempotent: a second run matches 0 rows and 0 files.
+ *
+ * HOW TO RUN IN PRODUCTION — `scripts/` is not part of the Docker image
+ * (the Dockerfile only copies packages/ + tsconfig.json), and /data is owned
+ * by uid 1001 inside the container, so do not run this from the host against
+ * the bind mount. Copy it in and exec it:
+ *
+ *   docker cp scripts/ad-hoc/purge-materia-placeholders.ts code-api-1:/tmp/
+ *   docker exec code-api-1 bun run /tmp/purge-materia-placeholders.ts \
+ *     /data/leyabierta.db --json /data/json --dry-run
+ *   # then re-run without --dry-run, and finally:
+ *   docker exec code-api-1 bun run pipeline rebuild
+ *
+ * Usage: purge-materia-placeholders.ts [db-path] [--json DIR] [--dry-run]
+ */
+
+import { Database } from "bun:sqlite";
+
+// SQL pattern and JS pattern must stay in sync. In SQLite LIKE, `[` is a
+// literal (unlike GLOB, where it opens a character class), so this is safe.
+const SQL_PATTERN = "[código %]";
+const PLACEHOLDER_RE = /^\[código \d+\]$/u;
+
+const dbPath =
+	process.argv[2] && !process.argv[2].startsWith("--")
+		? process.argv[2]
+		: "./data/leyabierta.db";
+const dryRun = process.argv.includes("--dry-run");
+const jsonDir = process.argv.includes("--json")
+	? process.argv[process.argv.indexOf("--json") + 1]!
+	: "./data/json";
+
+async function main() {
+	const db = new Database(dbPath);
+
+	// -- 1. The materias table --
+	// Only the affected norm_ids are pulled into memory (the container is
+	// RAM-capped); the delete itself is a single set-based statement.
+	const affected = db
+		.query<{ norm_id: string }, [string]>(
+			"SELECT DISTINCT norm_id FROM materias WHERE materia LIKE ?",
+		)
+		.all(SQL_PATTERN)
+		.map((r) => r.norm_id);
+
+	const count = db
+		.query<{ n: number }, [string]>(
+			"SELECT COUNT(*) AS n FROM materias WHERE materia LIKE ?",
+		)
+		.get(SQL_PATTERN)!.n;
+
+	console.log(
+		`materias table: ${count} placeholder rows across ${affected.length} norms` +
+			(dryRun ? " (dry-run, not deleting)" : ""),
+	);
+
+	if (!dryRun && count > 0) {
+		db.run("DELETE FROM materias WHERE materia LIKE ?", [SQL_PATTERN]);
+	}
+
+	db.close();
+
+	// -- 2. The JSON cache --
+	let jsonScanned = 0;
+	let jsonChanged = 0;
+
+	for (const normId of affected) {
+		const jsonPath = `${jsonDir}/${normId}.json`;
+		const file = Bun.file(jsonPath);
+		if (!(await file.exists())) continue;
+		jsonScanned++;
+
+		const data = await file.json();
+		const materias: unknown = data?.analisis?.materias;
+		if (!Array.isArray(materias)) continue;
+
+		const cleaned = materias.filter(
+			(m) => typeof m !== "string" || !PLACEHOLDER_RE.test(m),
+		);
+		if (cleaned.length === materias.length) continue;
+
+		jsonChanged++;
+		if (dryRun) continue;
+
+		// Keep the `analisis` key even if materias ends up empty: that is the
+		// same shape ingest-analisis produces for a norm with notas/refs only,
+		// and deleting the key would change the contract for every consumer of
+		// the JSON cache for no benefit.
+		data.analisis.materias = cleaned;
+		await Bun.write(jsonPath, JSON.stringify(data, null, 2));
+	}
+
+	console.log(
+		`JSON cache: ${jsonChanged}/${jsonScanned} files cleaned` +
+			(dryRun ? " (dry-run, not writing)" : ""),
+	);
+
+	if (!dryRun && (count > 0 || jsonChanged > 0)) {
+		console.log(
+			"\nDone. Run `bun run pipeline rebuild` to regenerate the leyes " +
+				"markdown frontmatter from the cleaned JSON cache.",
+		);
+	}
+}
+
+main().catch((err) => {
+	console.error("Fatal:", err);
+	process.exit(1);
+});

--- a/scripts/daily-pipeline.sh
+++ b/scripts/daily-pipeline.sh
@@ -4,52 +4,63 @@
 #
 # Usage: /opt/leyabierta/scripts/daily-pipeline.sh
 # Cron:  30 8 * * * /opt/leyabierta/scripts/daily-pipeline.sh
+#
+# Logging — under cron this script takes ownership of $LOG with a single
+# `exec >> "$LOG" 2>&1` and log() is a plain echo. Before, log() piped through
+# `tee -a "$LOG"`: it wrote the line to the file AND to stdout, which
+# /etc/cron.d/leyabierta independently appends to the same file
+# (`... >> /opt/leyabierta/logs/daily-pipeline.log 2>&1`, see
+# docs/infrastructure.md) — so every log() line landed twice. Both handles are
+# O_APPEND, so leaving the cron redirect in place is harmless; removing it is
+# optional cleanup, not required. The redirect is skipped when stdout is a TTY
+# so an operator running this by hand over SSH still sees output instead of a
+# silent terminal.
 
-# ── Self-update: pull latest version from the prod tag before doing anything ──
-# Runs BEFORE set -euo pipefail and BEFORE the lockfile so that even a stale
-# on-disk copy of this script can bootstrap itself to the current version.
-# LEYABIERTA_SELF_UPDATED=1 breaks the re-exec loop (set by child after update).
 SCRIPT_PATH="$(readlink -f "$0")"
 REPO_DIR=/opt/leyabierta/code
 SCRIPT_IN_REPO="$REPO_DIR/scripts/daily-pipeline.sh"
-
-if [ -z "${LEYABIERTA_SELF_UPDATED:-}" ] && [ -d "$REPO_DIR/.git" ]; then
-  # Fetch the prod tag with explicit refspec so a force-updated remote tag
-  # always overrides the local one. `git fetch --tags` (without --force) is
-  # NOT enough — it silently keeps an existing local tag pointing to an old
-  # commit, so self-update would never advance.
-  if git -C "$REPO_DIR" fetch --quiet origin "+refs/tags/prod:refs/tags/prod" 2>/dev/null \
-     && git -C "$REPO_DIR" reset --hard refs/tags/prod >/dev/null 2>&1; then
-    if [ -f "$SCRIPT_IN_REPO" ] && ! cmp -s "$SCRIPT_PATH" "$SCRIPT_IN_REPO"; then
-      export LEYABIERTA_SELF_UPDATED=1
-      exec "$SCRIPT_IN_REPO" "$@"
-    fi
-  fi
-fi
-
 LOG=/opt/leyabierta/logs/daily-pipeline.log
 CONTAINER=code-api-1
 ENV_FILE=/opt/leyabierta/code/.env.prod
 LEYES_DIR_CONTAINER=/data/leyes
 DIVERGENCE_CEILING=200  # abort push if local is ahead by more than this; alert + investigate
+# How old the deployed commit (refs/tags/prod) may get before we alert.
+# Measured in DAYS, deliberately not in "commits behind origin/main": main
+# takes web/SEO/API commits every day that never touch this script, so a commit
+# count would alert every week and train everyone to ignore it.
+STALE_DEPLOY_MAX_AGE_DAYS=${STALE_DEPLOY_MAX_AGE_DAYS:-14}
+# Hard wall-clock cap on the network git calls made before the lock is taken.
+GIT_NET_TIMEOUT=${GIT_NET_TIMEOUT:-120}
 
-# Ensure the log directory exists BEFORE any code that might log (the lock
-# guard below being the first such case on a fresh server).
+# Ensure the log directory exists BEFORE any code that might log (the
+# `exec` below and the lock guard being the first such cases on a fresh server).
 mkdir -p "$(dirname "$LOG")"
 
-# ── Single-instance lock ────────────────────────────────────────────────────
-# Prevents concurrent runs from racing on the leyes git working tree
-# (root cause of duplicate commits seen in production before 2026-04-27).
-LOCKFILE=/var/lock/leyabierta-pipeline.lock
-exec 9>"$LOCKFILE"
-if ! flock -n 9; then
-  echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] another pipeline run is in progress — skipping" >> "$LOG"
-  exit 0
+# Own the log file for the rest of the run — see the header comment above.
+if [ ! -t 1 ]; then
+  exec >> "$LOG" 2>&1
 fi
 
-set -euo pipefail
+log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $1"; }
 
-log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $1" | tee -a "$LOG"; }
+# scrub TEXT — mask embedded credentials and cap length before git output is
+# shipped to a webhook. A git remote can legitimately carry a token in its URL
+# (the same pattern this script uses for the leyes remote below) and git prints
+# the remote URL on auth failures, so raw stderr must never be forwarded.
+scrub() {
+  local s
+  s=$(printf '%s' "$1" | tr '\n' ' ' | sed -E 's#(https?://)[^/@[:space:]]+@#\1***@#g' 2>/dev/null) || s="$1"
+  printf '%s' "${s:0:400}"
+}
+
+# git_net ARGS... — git with a hard timeout, for anything that touches network.
+git_net() {
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$GIT_NET_TIMEOUT" git "$@"
+  else
+    git "$@"
+  fi
+}
 
 # build_alert_json TITLE BODY — emits a valid JSON object on stdout.
 # Prefers python3 (always present on Ubuntu/Debian VPS) for correct escaping
@@ -70,18 +81,102 @@ build_alert_json() {
 }
 
 # send_alert TITLE BODY — POST a JSON alert to ALERT_WEBHOOK_URL (non-fatal).
-# Falls back silently if ALERT_WEBHOOK_URL is unset or curl fails.
+# Defined before the self-update guard (and before ENV_FILE is parsed further
+# down) so a failed self-update can alert just as loudly as a failed step.
+# Uses ALERT_WEBHOOK_URL when already exported, otherwise reads it straight out
+# of ENV_FILE. Falls back silently if neither yields a URL or curl fails.
 send_alert() {
   local title="$1" body="$2"
-  if [ -n "${ALERT_WEBHOOK_URL:-}" ]; then
+  local webhook="${ALERT_WEBHOOK_URL:-}"
+  if [ -z "$webhook" ] && [ -r "$ENV_FILE" ]; then
+    webhook=$(grep -E '^ALERT_WEBHOOK_URL=' "$ENV_FILE" | head -1 | cut -d= -f2- || true)
+  fi
+  if [ -n "$webhook" ]; then
     local json
     json=$(build_alert_json "$title" "$body")
-    curl -fsS --max-time 10 -X POST "$ALERT_WEBHOOK_URL" \
+    curl -fsS --max-time 10 -X POST "$webhook" \
       -H "Content-Type: application/json" \
       -d "$json" \
       >/dev/null 2>&1 || true
   fi
 }
+
+# ── Self-update: pull latest version from the prod tag before doing anything ──
+# Runs BEFORE set -euo pipefail and BEFORE the lockfile so that even a stale
+# on-disk copy of this script can bootstrap itself to the current version.
+# LEYABIERTA_SELF_UPDATED=1 breaks the re-exec loop (set by child after update).
+#
+# Both branches used to swallow stderr (`2>/dev/null`, `>/dev/null 2>&1`) with
+# no else-branch, so a broken fetch or reset silently left whatever copy was on
+# disk running forever. Every failure is now logged and alerted.
+if [ -z "${LEYABIERTA_SELF_UPDATED:-}" ] && [ -d "$REPO_DIR/.git" ]; then
+  self_update_ok=0
+  # Fetch the prod tag with explicit refspec so a force-updated remote tag
+  # always overrides the local one. `git fetch --tags` (without --force) is
+  # NOT enough — it silently keeps an existing local tag pointing to an old
+  # commit, so self-update would never advance.
+  su_err=$(git_net -C "$REPO_DIR" fetch --quiet origin "+refs/tags/prod:refs/tags/prod" 2>&1) && su_status=0 || su_status=$?
+  if [ "$su_status" -ne 0 ]; then
+    log "  ✗ self-update: fetch refs/tags/prod failed (exit $su_status): $(scrub "$su_err")"
+    send_alert "leyabierta self-update failed" "git fetch refs/tags/prod failed (exit $su_status): $(scrub "$su_err")"
+  else
+    su_err=$(git -C "$REPO_DIR" reset --hard refs/tags/prod 2>&1) && su_status=0 || su_status=$?
+    if [ "$su_status" -ne 0 ]; then
+      log "  ✗ self-update: reset --hard refs/tags/prod failed (exit $su_status): $(scrub "$su_err")"
+      send_alert "leyabierta self-update failed" "git reset --hard refs/tags/prod failed (exit $su_status): $(scrub "$su_err")"
+    else
+      self_update_ok=1
+      if [ -f "$SCRIPT_IN_REPO" ] && ! cmp -s "$SCRIPT_PATH" "$SCRIPT_IN_REPO"; then
+        log "  → self-update: newer daily-pipeline.sh at refs/tags/prod — re-exec'ing"
+        export LEYABIERTA_SELF_UPDATED=1
+        exec "$SCRIPT_IN_REPO" "$@"
+      fi
+    fi
+  fi
+  if [ "$self_update_ok" -ne 1 ]; then
+    log "  ⚠ self-update: continuing with the on-disk copy at $SCRIPT_PATH — version may be stale"
+  fi
+fi
+
+# ── Single-instance lock ────────────────────────────────────────────────────
+# Prevents concurrent runs from racing on the leyes git working tree
+# (root cause of duplicate commits seen in production before 2026-04-27).
+LOCKFILE=/var/lock/leyabierta-pipeline.lock
+exec 9>"$LOCKFILE"
+if ! flock -n 9; then
+  log "another pipeline run is in progress — skipping"
+  exit 0
+fi
+
+# ── Record which commit is actually running, and how old it is ──────────────
+# Runs AFTER the lock so a run that immediately bails out never fires a
+# staleness alert. Needs no network: the deployed commit's own date is enough.
+#
+# The heartbeat at the bottom only ever meant "the script that happened to run
+# finished". It said nothing about WHICH version ran, so it stayed green for
+# weeks while refs/tags/prod sat on an old commit and Step 10 (PR #110) never
+# executed. Logging the SHA every run makes that visible; an old deploy raises
+# its own alert.
+#
+# Deliberately NOT wired into the heartbeat. The heartbeat is the liveness
+# signal for steps 1-8 (including the daily emails). Suppressing it for a
+# stale-but-working pipeline would page for the wrong thing, keep the monitor
+# permanently red (nothing moves the prod tag automatically today, so it would
+# stay red until a human acts), and make a genuinely dead pipeline
+# indistinguishable from an un-moved tag. Staleness gets its own channel.
+PIPELINE_SHA=$(git -C "$REPO_DIR" rev-parse HEAD 2>/dev/null || echo unknown)
+DEPLOY_AGE_DAYS=unknown
+deploy_ts=$(git -C "$REPO_DIR" log -1 --format=%ct HEAD 2>/dev/null || true)
+if [ -n "${deploy_ts:-}" ]; then
+  DEPLOY_AGE_DAYS=$(( ( $(date -u +%s) - deploy_ts ) / 86400 ))
+fi
+log "running pipeline SHA=$PIPELINE_SHA deploy-age=${DEPLOY_AGE_DAYS}d (max=${STALE_DEPLOY_MAX_AGE_DAYS}d)"
+if [ "$DEPLOY_AGE_DAYS" != "unknown" ] && [ "$DEPLOY_AGE_DAYS" -gt "$STALE_DEPLOY_MAX_AGE_DAYS" ]; then
+  log "  ⚠ deployed commit is ${DEPLOY_AGE_DAYS} days old — refs/tags/prod has not moved; newer pipeline steps may not be running"
+  send_alert "leyabierta prod tag is stale" "running SHA=$PIPELINE_SHA is ${DEPLOY_AGE_DAYS} days old (max ${STALE_DEPLOY_MAX_AGE_DAYS}d) — move refs/tags/prod forward"
+fi
+
+set -euo pipefail
 
 # Extract ONLY the LEYES_PUSH_TOKEN from .env.prod for the push step. Avoid
 # `set -a; source ...` because that exports every secret in the file
@@ -302,8 +397,11 @@ fi
 log "=== Daily pipeline completed ==="
 
 # ── Heartbeat: signal successful completion to uptime monitor ────────────────
+# Unconditional on purpose: this is the liveness signal for steps 1-8 (the
+# daily emails included), NOT a deploy-freshness signal. Deploy staleness is
+# alerted separately near the top of this script — see the comment there.
 if [ -n "${BETTERSTACK_HEARTBEAT_URL:-}" ]; then
   curl -fsS --max-time 10 "$BETTERSTACK_HEARTBEAT_URL" >/dev/null 2>&1 \
-    && log "  ✓ heartbeat sent" \
+    && log "  ✓ heartbeat sent (SHA=$PIPELINE_SHA)" \
     || log "  ⚠ heartbeat failed (non-fatal)"
 fi

--- a/scripts/daily-pipeline.sh
+++ b/scripts/daily-pipeline.sh
@@ -36,6 +36,20 @@ GIT_NET_TIMEOUT=${GIT_NET_TIMEOUT:-120}
 # `exec` below and the lock guard being the first such cases on a fresh server).
 mkdir -p "$(dirname "$LOG")"
 
+# ── Rotate the log if it has grown past the cap ─────────────────────────────
+# Done here rather than via /etc/logrotate.d because that needs root on the
+# server and lives outside this repo — this is one moving part instead of two,
+# and it ships with the script. Rotation happens BEFORE the exec below so the
+# run always appends to a freshly rotated file. One generation is plenty: the
+# interesting history is in this log's own output, not in months of archive.
+LOG_MAX_BYTES=${LOG_MAX_BYTES:-52428800}  # 50 MB
+if [ -f "$LOG" ]; then
+  log_size=$(stat -c%s "$LOG" 2>/dev/null || echo 0)
+  if [ "$log_size" -gt "$LOG_MAX_BYTES" ]; then
+    mv -f "$LOG" "$LOG.1" 2>/dev/null || true
+  fi
+fi
+
 # Own the log file for the rest of the run — see the header comment above.
 if [ ! -t 1 ]; then
   exec >> "$LOG" 2>&1
@@ -376,6 +390,25 @@ if [ "$push_status" -ne 0 ]; then
     log "  ⚠ retry also failed. Will retry on next daily run. Investigate logs."
     send_alert "leyes push retry also failed" "exit=$retry_status — investigate logs at /opt/leyabierta/logs/daily-pipeline.log"
   fi
+fi
+
+# ── Step 9.5: Checkpoint the WAL ────────────────────────────────────────────
+# The day's ingest + AI steps push a lot through the write-ahead log, and
+# `wal_autocheckpoint` (1000 pages ≈ 4 MB) only fires when no reader holds the
+# database — the API always does, so in practice it never truncates. Observed
+# 2026-07-22: 277 MB of WAL still on disk with every writer long finished.
+# TRUNCATE reclaims the file; the data was already in the DB, so nothing is
+# lost if this is a no-op. Non-fatal, and placed before the index rebuild so it
+# runs while the API is still up (the rebuild restarts it).
+log "→ Step 9.5: Checkpoint SQLite WAL"
+set +e
+docker exec "$CONTAINER" bun -e 'const {Database}=require("bun:sqlite");const db=new Database(process.env.DB_PATH??"/data/leyabierta.db");console.log(JSON.stringify(db.query("PRAGMA wal_checkpoint(TRUNCATE)").get()));' >> "$LOG" 2>&1
+checkpoint_status=$?
+set -e
+if [ "$checkpoint_status" -ne 0 ]; then
+  log "  ⚠ WAL checkpoint returned $checkpoint_status (non-fatal)"
+else
+  log "  ✓ WAL checkpoint done"
 fi
 
 # ── Step 10: Rebuild the vector search index if new embeddings were added ────

--- a/scripts/daily-pipeline.sh
+++ b/scripts/daily-pipeline.sh
@@ -202,6 +202,33 @@ log "→ Step 2: Ingest"
 docker exec "$CONTAINER" bun run ingest >> "$LOG" 2>&1
 log "  ✓ Ingest done"
 
+# ── Step 2.5: Refresh BOE auxiliary reference tables (materias, ...) ────────
+# ingest-analisis (Step 3) maps BOE materia codes to names via
+# data/auxiliar/materias.json. NOTHING ever downloaded that file, so on this
+# server it never existed and Step 3 wrote fabricated "[código NNNN]" strings
+# for every materia of every norm (2026-07-22 incident).
+#
+# Non-fatal by design. Step 3 degrades safely without the lookup (it omits
+# unresolved codes and never fabricates), and this script runs under
+# `set -euo pipefail`, so aborting here would also skip Steps 4-8 — including
+# the subscriber emails. Stale/missing reference data for one day is cheaper
+# than a day with no product output. (`if` already suppresses `set -e` for the
+# command it tests, so no branch below can abort the run.)
+#
+# Writes to ./data/auxiliar inside the container, which resolves through
+# /app/data -> /data (Dockerfile) into the `./data:/data` bind mount
+# (docker-compose.yml), so the file survives restarts and Watchtower rolls.
+log "→ Step 2.5: Refresh BOE auxiliary tables (materias, departamentos, ...)"
+if docker exec "$CONTAINER" bun run download-auxiliar >> "$LOG" 2>&1; then
+  log "  ✓ Auxiliary tables refreshed"
+elif docker exec "$CONTAINER" bun run download-auxiliar --check >> "$LOG" 2>&1; then
+  log "  ⚠ download-auxiliar failed — falling back to the existing (possibly stale) materias.json"
+  send_alert "download-auxiliar failed" "Falling back to the cached materias.json. Check BOE datosabiertos availability."
+else
+  log "  ⚠ download-auxiliar failed and no usable materias.json cache exists — Step 3 will run degraded (materias omitted, never placeholdered)"
+  send_alert "download-auxiliar failed, no cache" "ingest-analisis will not resolve materia codes this run. Data is not corrupted, but new materias are missing until this is fixed."
+fi
+
 # ── Step 3: Ingest analisis (materias, notas, refs from BOE) ────────────────
 log "→ Step 3: Ingest analisis"
 docker exec "$CONTAINER" bun run ingest-analisis >> "$LOG" 2>&1


### PR DESCRIPTION
Fixes for everything found in today's post-rebuild review. Each commit stands
alone with its own reasoning; this is the short version.

## What was actually broken

**Citizens were being shown fabricated data.** 94,480 `[código NNNN]` strings
across 12,099 of 12,349 norms. `ingest-analisis` maps BOE materia codes to
names via `data/auxiliar/materias.json`; nothing in the pipeline ever
downloaded that file, so on the server it never existed, and the loader
warned and carried on — inventing a label for every code. `INSERT OR IGNORE`
meant they piled up next to the real materias instead of replacing them, and
the enrichment pass mirrored them into the JSON cache, from where
`pipeline rebuild` would have baked them into the published leyes frontmatter.
PR #120 pointing the web build at the DB is what finally made them visible.

**Production was running a 9-day-old orchestrator.** `refs/tags/prod` was at
`c009110` (13-jul) and nothing moves it automatically. The server re-execs the
script from that tag, so Step 10 — the vector index rebuild from #110 — had
never run. The index was short by exactly the embeddings added since it was
last rebuilt by hand, and the gap grew daily. The pipeline logged "completed"
every morning because the script it ran had no Step 10 to skip.

**Every leyes push triggered two full site builds.** The backstop was the only
writer of its own cache marker, and only when it was the one dispatching, so a
normal deploy left the marker stale and the next tick rebuilt ~12k pages that
were already live.

**First search after a restart took 39.9s.** The preload maps the index but
doesn't start the worker pool or warm the FTS pages; the first citizen to
search paid for both.

**Umami had been "unhealthy" for 8 days** while serving traffic fine — the
healthcheck probed `localhost`, which resolves to `::1`, and next-server only
binds IPv4.

## Notes for review

- `ingest-analisis` deliberately does **not** fail-fast on a missing lookup.
  The pipeline is `set -euo pipefail`, so exiting non-zero would skip reform
  summaries, citizen tags, omnibus and the subscriber emails. It degrades
  instead. This also keeps the new image safe to deploy before the prod tag
  ships Step 2.5 — Watchtower rolls the container in ~30s, the orchestrator
  only updates at 08:30.
- The prod tag bump is not path-gated: the tag governs the whole host
  checkout, including `docker-compose.yml` and the Dockerfile.
- `bash -n` over `scripts/*.sh` is now a gate. Biome doesn't parse shell and
  `bun test || true` swallows failures, so nothing validated the bash the
  server executes — and it now auto-propagates from main.

## Already done on the server

- `materias.json` downloaded; 94,480 + 292 placeholder rows purged from the DB
  (backup kept in `materias_placeholder_backup_20260722`), 12,099 + 278 JSON
  cache files cleaned, `ingest-analisis` re-run: 12,349 norms, 0 errors, 0
  norms left without materias
- `refs/tags/prod` moved to `f8f329d`
- 2 GB of superseded vector-index backups removed

The leyes markdown repo was verified clean — the contamination never reached
the published frontmatter, so no `pipeline rebuild` is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)