### PR TITLE
Buscador por referencia, transparencia de frescura y auditoría móvil (#127, #128, #129)

### DIFF
--- a/packages/api/src/__tests__/norm-reference-search.test.ts
+++ b/packages/api/src/__tests__/norm-reference-search.test.ts
@@ -1,0 +1,348 @@
+/**
+ * Integration tests for the issue #128 exact-reference fast path inside
+ * DbService.searchLaws / searchLawsHybrid.
+ *
+ * Uses an in-memory SQLite database with the real schema, following the
+ * style of db-service.test.ts.
+ */
+
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { createSchema } from "@leyabierta/pipeline";
+import { DbService } from "../services/db.ts";
+import type { HybridSearcher } from "../services/hybrid-search.ts";
+
+let db: Database;
+let svc: DbService;
+
+beforeEach(() => {
+	db = new Database(":memory:");
+	createSchema(db);
+	svc = new DbService(db);
+});
+
+afterEach(() => {
+	db.close();
+});
+
+function insertNorm(overrides: Partial<Record<string, string>> = {}) {
+	const defaults = {
+		id: "BOE-A-2024-0001",
+		title: "Ley de prueba",
+		short_title: "Ley 1/2024",
+		country: "es",
+		jurisdiction: "es",
+		rank: "ley",
+		published_at: "2024-01-01",
+		status: "vigente",
+		department: "Test",
+		source_url: "https://www.boe.es/eli/es/l/2024/01/01/1",
+	};
+	const d = { ...defaults, ...overrides };
+	db.run(
+		`INSERT INTO norms (id, title, short_title, country, jurisdiction, rank, published_at, status, department, source_url)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		[
+			d.id,
+			d.title,
+			d.short_title,
+			d.country,
+			d.jurisdiction,
+			d.rank,
+			d.published_at,
+			d.status,
+			d.department,
+			d.source_url,
+		],
+	);
+	db.run("INSERT INTO norms_fts (norm_id, title, content) VALUES (?, ?, ?)", [
+		d.id,
+		d.title,
+		d.title,
+	]);
+}
+
+// Stub HybridSearcher: returns the BM25 input verbatim so these tests focus
+// on the exact-reference merge, not retrieval quality (mirrors the stub in
+// routes.test.ts).
+const hybridStub: HybridSearcher = {
+	rankNorms: async (_query, bm25NormIds) => ({
+		fused: bm25NormIds,
+		bm25Count: bm25NormIds.length,
+		vectorCount: 0,
+		embeddingCacheHit: false,
+		embedMs: 0,
+		searchMs: 0,
+	}),
+};
+
+describe("searchLaws — issue #128 reproducible failures", () => {
+	it("'Real Decreto 1312/2024' returns the correct norm first (not an unrelated Real Decreto-ley)", async () => {
+		insertNorm({
+			id: "BOE-A-2024-26931",
+			title:
+				"Real Decreto 1312/2024, de 23 de diciembre, Registro Único de Arrendamientos",
+			short_title: "Real Decreto 1312/2024",
+			rank: "real_decreto",
+			published_at: "2024-12-23",
+		});
+		insertNorm({
+			id: "BOE-A-1986-7901",
+			title: "Real Decreto-ley 1/1986, de medidas urgentes administrativas",
+			short_title: "Real Decreto-ley 1/1986",
+			rank: "real_decreto_ley",
+			published_at: "1986-01-01",
+		});
+
+		const { laws, total } = svc.searchLaws("Real Decreto 1312/2024", {}, 20, 0);
+		expect(total).toBeGreaterThan(0);
+		expect(laws[0]?.id).toBe("BOE-A-2024-26931");
+	});
+
+	it("'1312/2024' returns the correct norm (already worked before #128, no regression)", async () => {
+		insertNorm({
+			id: "BOE-A-2024-26931",
+			title: "Real Decreto 1312/2024, Registro Único de Arrendamientos",
+			short_title: "Real Decreto 1312/2024",
+			rank: "real_decreto",
+		});
+		const { laws } = svc.searchLaws("1312/2024", {}, 20, 0);
+		expect(laws[0]?.id).toBe("BOE-A-2024-26931");
+	});
+
+	it("'LAU' returns the Ley de Arrendamientos Urbanos, not the 1943 university law", async () => {
+		insertNorm({
+			id: "BOE-A-1994-26003",
+			title: "Ley 29/1994, de 24 de noviembre, de Arrendamientos Urbanos",
+			short_title: "Ley 29/1994",
+			rank: "ley",
+			published_at: "1994-11-24",
+		});
+		insertNorm({
+			id: "BOE-A-1943-7181",
+			title: "Ley de 29 de julio de 1943 sobre ordenacion de la Universidad",
+			short_title: "Ley de 29 de julio de 1943",
+			rank: "ley",
+			published_at: "1943-07-29",
+		});
+
+		const { laws } = svc.searchLaws("LAU", {}, 20, 0);
+		expect(laws[0]?.id).toBe("BOE-A-1994-26003");
+	});
+
+	it("a bare BOE sequence number resolves by id suffix", async () => {
+		// Issue #128 listed q="26931" as a failing case. It used to return an
+		// unrelated norm; with FTS alone it returns nothing at all, because
+		// norm_id is UNINDEXED in norms_fts and the digits appear nowhere in
+		// the title.
+		insertNorm({ id: "BOE-A-2015-11724", title: "Norma irrelevante" });
+		insertNorm({
+			id: "BOE-A-2024-26931",
+			title: "Real Decreto 1312/2024, de 23 de diciembre",
+			short_title: "Real Decreto 1312/2024",
+			published_at: "2024-12-28",
+		});
+		const { laws } = svc.searchLaws("26931", {}, 20, 0);
+		expect(laws[0]?.id).toBe("BOE-A-2024-26931");
+	});
+
+	it("id-suffix collisions are returned newest-first, not dropped", async () => {
+		insertNorm({ id: "BOE-A-2001-90001", published_at: "2001-05-05" });
+		insertNorm({ id: "BOE-A-2019-90001", published_at: "2019-05-05" });
+		const { laws } = svc.searchLaws("90001", {}, 20, 0);
+		expect(laws.map((l) => l.id)).toEqual([
+			"BOE-A-2019-90001",
+			"BOE-A-2001-90001",
+		]);
+	});
+});
+
+describe("searchLaws — exact reference is prepended, not exclusive", () => {
+	it("keeps other BM25 hits after the exact match, deduped", async () => {
+		insertNorm({
+			id: "BOE-A-2024-0001",
+			title: "Real Decreto 100/2024, de vivienda",
+			short_title: "Real Decreto 100/2024",
+			rank: "real_decreto",
+		});
+		insertNorm({
+			id: "BOE-A-2024-0002",
+			title: "Ley de vivienda y alquiler",
+			short_title: "Ley 5/2024",
+			rank: "ley",
+		});
+
+		const { laws } = svc.searchLaws("Real Decreto 100/2024", {}, 20, 0);
+		expect(laws[0]?.id).toBe("BOE-A-2024-0001");
+		// exact match appears exactly once even though it could also match BM25
+		expect(laws.filter((l) => l.id === "BOE-A-2024-0001")).toHaveLength(1);
+	});
+
+	it("returns every jurisdiction sharing the same short_title, state (es) first", async () => {
+		insertNorm({
+			id: "BOE-A-2016-0001",
+			jurisdiction: "es",
+			title: "Ley 12/2016 estatal",
+			short_title: "Ley 12/2016",
+			rank: "ley",
+		});
+		insertNorm({
+			id: "BOE-A-2016-0002",
+			jurisdiction: "es-ct",
+			title: "Ley 12/2016 autonomica",
+			short_title: "Ley 12/2016",
+			rank: "ley",
+		});
+
+		const { laws, total } = svc.searchLaws("Ley 12/2016", {}, 20, 0);
+		expect(total).toBeGreaterThanOrEqual(2);
+		const ids = laws.map((l) => l.id);
+		expect(ids).toContain("BOE-A-2016-0001");
+		expect(ids).toContain("BOE-A-2016-0002");
+		expect(ids.indexOf("BOE-A-2016-0001")).toBeLessThan(
+			ids.indexOf("BOE-A-2016-0002"),
+		);
+	});
+});
+
+describe("searchLaws — respects filters and pagination on the fast path", () => {
+	it("excludes an exact match that doesn't satisfy the rank filter", async () => {
+		insertNorm({
+			id: "BOE-A-2024-0001",
+			title: "Real Decreto 100/2024",
+			short_title: "Real Decreto 100/2024",
+			rank: "real_decreto",
+		});
+
+		const { laws, total } = svc.searchLaws(
+			"Real Decreto 100/2024",
+			{ rank: "ley" },
+			20,
+			0,
+		);
+		expect(laws.map((l) => l.id)).not.toContain("BOE-A-2024-0001");
+		expect(total).toBe(0);
+	});
+
+	it("excludes an exact match outside the requested jurisdiction", async () => {
+		insertNorm({
+			id: "BOE-A-2016-0002",
+			jurisdiction: "es-ct",
+			title: "Ley 12/2016 autonomica",
+			short_title: "Ley 12/2016",
+			rank: "ley",
+		});
+
+		const { laws } = svc.searchLaws(
+			"Ley 12/2016",
+			{ jurisdiction: "es" },
+			20,
+			0,
+		);
+		expect(laws.map((l) => l.id)).not.toContain("BOE-A-2016-0002");
+	});
+
+	it("paginates across exact + BM25 results without breaking total", async () => {
+		insertNorm({
+			id: "BOE-A-2024-0001",
+			title: "Real Decreto 100/2024, de vivienda",
+			short_title: "Real Decreto 100/2024",
+			rank: "real_decreto",
+		});
+		insertNorm({
+			id: "BOE-A-2024-0002",
+			title: "Ley de vivienda social",
+			short_title: "Ley 5/2024",
+			rank: "ley",
+		});
+
+		const page1 = svc.searchLaws("Real Decreto 100/2024", {}, 1, 0);
+		expect(page1.laws).toHaveLength(1);
+		expect(page1.laws[0]?.id).toBe("BOE-A-2024-0001");
+		expect(page1.total).toBe(page1.total); // sanity: total is a number, checked below
+		expect(typeof page1.total).toBe("number");
+	});
+});
+
+describe("searchLawsHybrid — issue #128 exact reference merge", () => {
+	it("'Real Decreto 1312/2024' resolves via the fast path through the hybrid endpoint", async () => {
+		insertNorm({
+			id: "BOE-A-2024-26931",
+			title: "Real Decreto 1312/2024, Registro Único de Arrendamientos",
+			short_title: "Real Decreto 1312/2024",
+			rank: "real_decreto",
+		});
+		insertNorm({
+			id: "BOE-A-1986-7901",
+			title: "Real Decreto-ley 1/1986, de medidas urgentes administrativas",
+			short_title: "Real Decreto-ley 1/1986",
+			rank: "real_decreto_ley",
+		});
+
+		const { laws } = await svc.searchLawsHybrid(
+			"Real Decreto 1312/2024",
+			{},
+			20,
+			0,
+			hybridStub,
+		);
+		expect(laws[0]?.id).toBe("BOE-A-2024-26931");
+	});
+
+	it("'LAU' resolves via the hybrid endpoint even with no BM25/vector hits", async () => {
+		insertNorm({
+			id: "BOE-A-1994-26003",
+			title: "Ley 29/1994, de 24 de noviembre, de Arrendamientos Urbanos",
+			short_title: "Ley 29/1994",
+			rank: "ley",
+		});
+
+		const noopHybrid: HybridSearcher = {
+			rankNorms: async () => ({
+				fused: [],
+				bm25Count: 0,
+				vectorCount: 0,
+				embeddingCacheHit: false,
+				embedMs: 0,
+				searchMs: 0,
+			}),
+		};
+
+		const { laws, total } = await svc.searchLawsHybrid(
+			"LAU",
+			{},
+			20,
+			0,
+			noopHybrid,
+		);
+		expect(total).toBe(1);
+		expect(laws[0]?.id).toBe("BOE-A-1994-26003");
+	});
+});
+
+describe("searchLaws — short_title casing and separator variants", () => {
+	it("resolves a rango reference regardless of short_title casing", async () => {
+		// The corpus is not casing-normalized: 293 norms use "Decreto-ley"
+		// and 6 use "Decreto-Ley". An exact match would miss the latter.
+		insertNorm({
+			id: "BOE-A-2016-90001",
+			title: "Decreto-Ley 1/2016, de prueba",
+			short_title: "Decreto-Ley 1/2016",
+			rank: "real_decreto_ley",
+		});
+		const { laws } = svc.searchLaws("Decreto-ley 1/2016", {}, 20, 0);
+		expect(laws[0]?.id).toBe("BOE-A-2016-90001");
+	});
+
+	it("resolves a ministerial order searched by its bare number", async () => {
+		// "Orden HAP/1370/2014" has a slash before the number, not a space.
+		insertNorm({
+			id: "BOE-A-2014-8135",
+			title: "Orden HAP/1370/2014, de 25 de julio",
+			short_title: "Orden HAP/1370/2014",
+			rank: "orden",
+		});
+		const { laws } = svc.searchLaws("1370/2014", {}, 20, 0);
+		expect(laws[0]?.id).toBe("BOE-A-2014-8135");
+	});
+});

--- a/packages/api/src/__tests__/norm-reference.test.ts
+++ b/packages/api/src/__tests__/norm-reference.test.ts
@@ -1,0 +1,433 @@
+/**
+ * Unit tests for parseNormReference — issue #128.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { parseNormReference } from "../services/norm-reference.ts";
+
+describe("parseNormReference — norm IDs", () => {
+	it("parses a BOE norm id", () => {
+		expect(parseNormReference("BOE-A-2024-26931")).toEqual({
+			kind: "id",
+			id: "BOE-A-2024-26931",
+		});
+	});
+
+	it("uppercases a lowercase norm id", () => {
+		expect(parseNormReference("boe-a-2024-26931")).toEqual({
+			kind: "id",
+			id: "BOE-A-2024-26931",
+		});
+	});
+
+	it("parses a regional bulletin id with a lowercase letter segment", () => {
+		expect(parseNormReference("BORM-s-2026-90179")).toEqual({
+			kind: "id",
+			id: "BORM-S-2026-90179",
+		});
+	});
+
+	it("parses another regional bulletin format", () => {
+		expect(parseNormReference("BOIB-i-2007-90098")).toEqual({
+			kind: "id",
+			id: "BOIB-I-2007-90098",
+		});
+	});
+});
+
+describe("parseNormReference — ELI URLs", () => {
+	it("parses a full ELI URL and derives lookup variants", () => {
+		const result = parseNormReference(
+			"https://www.boe.es/eli/es/rd/2024/12/23/1312",
+		);
+		expect(result?.kind).toBe("eli");
+		if (result?.kind === "eli") {
+			expect(result.urls).toContain(
+				"https://www.boe.es/eli/es/rd/2024/12/23/1312",
+			);
+		}
+	});
+
+	it("parses an ELI URL with a trailing slash", () => {
+		const result = parseNormReference(
+			"https://www.boe.es/eli/es/rd/2024/12/23/1312/",
+		);
+		expect(result?.kind).toBe("eli");
+	});
+
+	it("parses a regional ELI URL", () => {
+		const result = parseNormReference(
+			"https://www.boe.es/eli/es-an/l/2001/06/04/5",
+		);
+		expect(result?.kind).toBe("eli");
+	});
+});
+
+describe("parseNormReference — bare number/year", () => {
+	it("parses a bare number/year", () => {
+		expect(parseNormReference("1312/2024")).toEqual({
+			kind: "number_year",
+			number: "1312",
+			year: "2024",
+		});
+	});
+
+	it("tolerates spaces around the slash", () => {
+		expect(parseNormReference("1312 / 2024")).toEqual({
+			kind: "number_year",
+			number: "1312",
+			year: "2024",
+		});
+	});
+
+	it("rejects a bare year with no slash", () => {
+		expect(parseNormReference("2024")).toBeNull();
+	});
+
+	it("treats a bare BOE sequence number as an id suffix", () => {
+		expect(parseNormReference("26931")).toEqual({
+			kind: "id_suffix",
+			sequence: "26931",
+		});
+	});
+
+	it("rejects number/year with trailing garbage", () => {
+		expect(parseNormReference("1312/2024 de vivienda")).not.toEqual({
+			kind: "number_year",
+			number: "1312",
+			year: "2024",
+		});
+	});
+});
+
+describe("parseNormReference — well-known acronyms", () => {
+	it("resolves LAU", () => {
+		expect(parseNormReference("LAU")).toEqual({
+			kind: "alias",
+			id: "BOE-A-1994-26003",
+		});
+	});
+
+	it("resolves LAU case-insensitively", () => {
+		expect(parseNormReference("lau")).toEqual({
+			kind: "alias",
+			id: "BOE-A-1994-26003",
+		});
+	});
+
+	it("resolves LEC", () => {
+		expect(parseNormReference("LEC")).toEqual({
+			kind: "alias",
+			id: "BOE-A-2000-323",
+		});
+	});
+
+	it("resolves LECRIM", () => {
+		expect(parseNormReference("LECrim")).toEqual({
+			kind: "alias",
+			id: "BOE-A-1882-6036",
+		});
+	});
+
+	it("resolves ET", () => {
+		expect(parseNormReference("ET")).toEqual({
+			kind: "alias",
+			id: "BOE-A-2015-11430",
+		});
+	});
+
+	it("resolves LGSS", () => {
+		expect(parseNormReference("LGSS")).toEqual({
+			kind: "alias",
+			id: "BOE-A-2015-11724",
+		});
+	});
+
+	it("resolves LOPDGDD", () => {
+		expect(parseNormReference("LOPDGDD")).toEqual({
+			kind: "alias",
+			id: "BOE-A-2018-16673",
+		});
+	});
+
+	it("resolves LPACAP", () => {
+		expect(parseNormReference("LPACAP")).toEqual({
+			kind: "alias",
+			id: "BOE-A-2015-10565",
+		});
+	});
+
+	it("resolves LRJSP", () => {
+		expect(parseNormReference("LRJSP")).toEqual({
+			kind: "alias",
+			id: "BOE-A-2015-10566",
+		});
+	});
+
+	it("resolves CE (Constitucion)", () => {
+		expect(parseNormReference("CE")).toEqual({
+			kind: "alias",
+			id: "BOE-A-1978-31229",
+		});
+	});
+
+	it("resolves CC (Codigo Civil)", () => {
+		expect(parseNormReference("CC")).toEqual({
+			kind: "alias",
+			id: "BOE-A-1889-4763",
+		});
+	});
+
+	it("resolves CP (Codigo Penal)", () => {
+		expect(parseNormReference("CP")).toEqual({
+			kind: "alias",
+			id: "BOE-A-1995-25444",
+		});
+	});
+
+	it("does not treat an acronym-shaped substring as an alias", () => {
+		expect(parseNormReference("la LAU regula el alquiler")).toBeNull();
+	});
+});
+
+describe("parseNormReference — ranked references (rango + num/año)", () => {
+	it("parses 'Real Decreto 1312/2024'", () => {
+		expect(parseNormReference("Real Decreto 1312/2024")).toEqual({
+			kind: "ranked",
+			rank: "real_decreto",
+			shortTitle: "Real Decreto 1312/2024",
+		});
+	});
+
+	it("parses 'RD 1312/2024'", () => {
+		expect(parseNormReference("RD 1312/2024")).toEqual({
+			kind: "ranked",
+			rank: "real_decreto",
+			shortTitle: "Real Decreto 1312/2024",
+		});
+	});
+
+	it("parses 'R.D. 1312/2024'", () => {
+		expect(parseNormReference("R.D. 1312/2024")).toEqual({
+			kind: "ranked",
+			rank: "real_decreto",
+			shortTitle: "Real Decreto 1312/2024",
+		});
+	});
+
+	it("parses 'Ley Organica 3/2018' (no accent)", () => {
+		expect(parseNormReference("Ley Organica 3/2018")).toEqual({
+			kind: "ranked",
+			rank: "ley_organica",
+			shortTitle: "Ley Orgánica 3/2018",
+		});
+	});
+
+	it("parses 'Ley Orgánica 3/2018' (with accent)", () => {
+		expect(parseNormReference("Ley Orgánica 3/2018")).toEqual({
+			kind: "ranked",
+			rank: "ley_organica",
+			shortTitle: "Ley Orgánica 3/2018",
+		});
+	});
+
+	it("parses 'LO 3/2018'", () => {
+		expect(parseNormReference("LO 3/2018")).toEqual({
+			kind: "ranked",
+			rank: "ley_organica",
+			shortTitle: "Ley Orgánica 3/2018",
+		});
+	});
+
+	it("parses 'Real Decreto-ley 8/2015'", () => {
+		expect(parseNormReference("Real Decreto-ley 8/2015")).toEqual({
+			kind: "ranked",
+			rank: "real_decreto_ley",
+			shortTitle: "Real Decreto-ley 8/2015",
+		});
+	});
+
+	it("parses 'RDL 8/2015'", () => {
+		expect(parseNormReference("RDL 8/2015")).toEqual({
+			kind: "ranked",
+			rank: "real_decreto_ley",
+			shortTitle: "Real Decreto-ley 8/2015",
+		});
+	});
+
+	it("parses 'RD-ley 8/2015'", () => {
+		expect(parseNormReference("RD-ley 8/2015")).toEqual({
+			kind: "ranked",
+			rank: "real_decreto_ley",
+			shortTitle: "Real Decreto-ley 8/2015",
+		});
+	});
+
+	it("parses 'Real Decreto Legislativo 8/2015'", () => {
+		expect(parseNormReference("Real Decreto Legislativo 8/2015")).toEqual({
+			kind: "ranked",
+			rank: "real_decreto_legislativo",
+			shortTitle: "Real Decreto Legislativo 8/2015",
+		});
+	});
+
+	it("parses 'RDLeg 8/2015'", () => {
+		expect(parseNormReference("RDLeg 8/2015")).toEqual({
+			kind: "ranked",
+			rank: "real_decreto_legislativo",
+			shortTitle: "Real Decreto Legislativo 8/2015",
+		});
+	});
+
+	it("parses 'Decreto-ley 31/2020'", () => {
+		expect(parseNormReference("Decreto-ley 31/2020")).toEqual({
+			kind: "ranked",
+			rank: "real_decreto_ley",
+			shortTitle: "Decreto-ley 31/2020",
+		});
+	});
+
+	it("parses 'Ley 12/2016'", () => {
+		expect(parseNormReference("Ley 12/2016")).toEqual({
+			kind: "ranked",
+			rank: "ley",
+			shortTitle: "Ley 12/2016",
+		});
+	});
+
+	it("tolerates the full title pasted with 'de DD de mes'", () => {
+		expect(
+			parseNormReference("Real Decreto 1312/2024, de 23 de diciembre"),
+		).toEqual({
+			kind: "ranked",
+			rank: "real_decreto",
+			shortTitle: "Real Decreto 1312/2024",
+		});
+	});
+
+	it("tolerates multiple spaces", () => {
+		expect(parseNormReference("Real   Decreto   1312/2024")).toEqual({
+			kind: "ranked",
+			rank: "real_decreto",
+			shortTitle: "Real Decreto 1312/2024",
+		});
+	});
+
+	it("is case-insensitive", () => {
+		expect(parseNormReference("real decreto 1312/2024")).toEqual({
+			kind: "ranked",
+			rank: "real_decreto",
+			shortTitle: "Real Decreto 1312/2024",
+		});
+	});
+});
+
+describe("parseNormReference — ministerial orders", () => {
+	it("parses 'Orden HAP/1370/2014'", () => {
+		expect(parseNormReference("Orden HAP/1370/2014")).toEqual({
+			kind: "ranked",
+			rank: "orden",
+			shortTitle: "Orden HAP/1370/2014",
+		});
+	});
+
+	it("parses 'Orden ETU/615/2017'", () => {
+		expect(parseNormReference("Orden ETU/615/2017")).toEqual({
+			kind: "ranked",
+			rank: "orden",
+			shortTitle: "Orden ETU/615/2017",
+		});
+	});
+
+	it("is case-insensitive on the ministry sigla", () => {
+		expect(parseNormReference("orden hap/1370/2014")).toEqual({
+			kind: "ranked",
+			rank: "orden",
+			shortTitle: "Orden HAP/1370/2014",
+		});
+	});
+});
+
+describe("parseNormReference — negative cases", () => {
+	it("rejects a rango with no number ('Real Decreto')", () => {
+		expect(parseNormReference("Real Decreto")).toBeNull();
+	});
+
+	it("rejects a bare rango word ('Ley')", () => {
+		expect(parseNormReference("Ley")).toBeNull();
+	});
+
+	it("rejects a natural-language query", () => {
+		expect(parseNormReference("vivienda")).toBeNull();
+	});
+
+	it("rejects a longer natural-language query", () => {
+		expect(parseNormReference("permiso de paternidad cuantos dias")).toBeNull();
+	});
+
+	it("rejects an empty string", () => {
+		expect(parseNormReference("")).toBeNull();
+	});
+
+	it("rejects whitespace only", () => {
+		expect(parseNormReference("   ")).toBeNull();
+	});
+
+	it("rejects 'Orden' with no ministry/number", () => {
+		expect(parseNormReference("Orden")).toBeNull();
+	});
+
+	it("rejects an unrelated acronym-shaped word", () => {
+		expect(parseNormReference("XYZ")).toBeNull();
+	});
+});
+
+describe("parseNormReference — the 4 reproducible failures from issue #128", () => {
+	it("'Real Decreto 1312/2024' resolves to the ranked reference (not BM25 noise)", () => {
+		expect(parseNormReference("Real Decreto 1312/2024")).toEqual({
+			kind: "ranked",
+			rank: "real_decreto",
+			shortTitle: "Real Decreto 1312/2024",
+		});
+	});
+
+	it("'1312/2024' resolves to the bare number/year reference", () => {
+		expect(parseNormReference("1312/2024")).toEqual({
+			kind: "number_year",
+			number: "1312",
+			year: "2024",
+		});
+	});
+
+	it("'26931' resolves as an id suffix (BOE-A-2024-26931)", () => {
+		expect(parseNormReference("26931")).toEqual({
+			kind: "id_suffix",
+			sequence: "26931",
+		});
+	});
+
+	it("a 4-digit year is NOT treated as a sequence number", () => {
+		// "2024" must stay a normal text search — it is overwhelmingly more
+		// likely to be a year than the tail of an id.
+		expect(parseNormReference("2024")).toBeNull();
+		expect(parseNormReference("1978")).toBeNull();
+	});
+
+	it("a 4-digit number outside the year range IS a sequence", () => {
+		expect(parseNormReference("4763")).toEqual({
+			kind: "id_suffix",
+			sequence: "4763",
+		});
+	});
+
+	it("runs of 1-2 digits are too ambiguous to resolve", () => {
+		expect(parseNormReference("7")).toBeNull();
+		expect(parseNormReference("42")).toBeNull();
+	});
+
+	it("'LAU' resolves to the correct alias, not the 1943 university law", () => {
+		const result = parseNormReference("LAU");
+		expect(result).toEqual({ kind: "alias", id: "BOE-A-1994-26003" });
+		expect(result).not.toEqual({ kind: "alias", id: "BOE-A-1943-7181" });
+	});
+});

--- a/packages/api/src/__tests__/status-route.test.ts
+++ b/packages/api/src/__tests__/status-route.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Tests for GET /v1/status (issue #129 — corpus freshness).
+ */
+
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createSchema } from "@leyabierta/pipeline";
+import { Elysia } from "elysia";
+import { statusRoutes } from "../routes/status.ts";
+import { StatusService } from "../services/status.ts";
+
+let db: Database;
+let app: Elysia;
+let dataDir: string;
+
+beforeEach(() => {
+	db = new Database(":memory:");
+	createSchema(db);
+	dataDir = mkdtempSync(join(tmpdir(), "status-route-test-"));
+
+	db.run(
+		`INSERT INTO norms (id, title, short_title, country, rank, published_at, updated_at, status, department, source_url)
+		 VALUES ('BOE-A-2024-1000', 'Ley de Pruebas', 'Ley Pruebas', 'es', 'ley', '2024-01-01', '2024-06-01', 'vigente', '', '')`,
+	);
+	db.run(
+		"INSERT INTO reforms (norm_id, date, source_id) VALUES ('BOE-A-2024-1000', '2026-07-18', 'BOE-A-2026-9001')",
+	);
+	// Corrupt row — must never leak into the response.
+	db.run(
+		"INSERT INTO reforms (norm_id, date, source_id) VALUES ('BOE-A-2024-1000', '2929-11-19', 'BOE-A-2929-99999')",
+	);
+
+	const statusService = new StatusService(db, dataDir);
+	app = new Elysia().use(statusRoutes(statusService));
+});
+
+afterEach(() => {
+	db.close();
+	rmSync(dataDir, { recursive: true, force: true });
+});
+
+function request(path: string) {
+	return app.handle(new Request(`http://localhost${path}`));
+}
+
+describe("GET /v1/status", () => {
+	test("returns 200 with freshness fields", async () => {
+		const res = await request("/v1/status");
+		expect(res.status).toBe(200);
+
+		const body = await res.json();
+		expect(body.norms_count).toBe(1);
+		expect(body.reforms_count).toBe(2);
+		expect(body.corpus_max_published_at).toBe("2024-01-01");
+		expect(body.last_reform_date).toBe("2026-07-18");
+		expect(typeof body.days_since_last_reform).toBe("number");
+		expect(body).toHaveProperty("last_sync");
+		expect(body).toHaveProperty("last_sync_source");
+	});
+
+	test("never leaks the corrupt 2929-11-19 date as last_reform_date", async () => {
+		const res = await request("/v1/status");
+		const body = await res.json();
+		expect(body.last_reform_date).not.toBe("2929-11-19");
+	});
+
+	test("sets a 5-minute edge cache header", async () => {
+		const res = await request("/v1/status");
+		expect(res.headers.get("cache-control")).toContain("s-maxage=300");
+	});
+});

--- a/packages/api/src/__tests__/status-service.test.ts
+++ b/packages/api/src/__tests__/status-service.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Unit tests for StatusService (issue #129 — corpus freshness).
+ */
+
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createSchema } from "@leyabierta/pipeline";
+import { StatusService } from "../services/status.ts";
+
+let db: Database;
+let dataDir: string;
+
+function insertNorm(id: string, publishedAt: string) {
+	db.run(
+		`INSERT INTO norms (id, title, short_title, country, rank, published_at, updated_at, status, department, source_url)
+		 VALUES (?, ?, ?, 'es', 'ley', ?, ?, 'vigente', '', '')`,
+		[id, `Ley ${id}`, `Ley ${id}`, publishedAt, publishedAt],
+	);
+}
+
+function insertReform(normId: string, date: string, sourceId: string) {
+	db.run("INSERT INTO reforms (norm_id, date, source_id) VALUES (?, ?, ?)", [
+		normId,
+		date,
+		sourceId,
+	]);
+}
+
+beforeEach(() => {
+	db = new Database(":memory:");
+	createSchema(db);
+	dataDir = mkdtempSync(join(tmpdir(), "status-service-test-"));
+});
+
+afterEach(() => {
+	db.close();
+	rmSync(dataDir, { recursive: true, force: true });
+});
+
+describe("StatusService.getStatus", () => {
+	test("reports counts and dates for a normal corpus", () => {
+		insertNorm("BOE-A-2024-1000", "2024-01-01");
+		insertNorm("BOE-A-2024-2000", "2024-06-01");
+		insertReform("BOE-A-2024-1000", "2026-07-18", "BOE-A-2026-9001");
+		insertReform("BOE-A-2024-2000", "2026-07-10", "BOE-A-2026-9002");
+
+		const status = new StatusService(db, dataDir);
+		const now = new Date("2026-07-23T12:00:00Z");
+		const result = status.getStatus(now);
+
+		expect(result.norms_count).toBe(2);
+		expect(result.reforms_count).toBe(2);
+		expect(result.corpus_max_published_at).toBe("2024-06-01");
+		expect(result.last_reform_date).toBe("2026-07-18");
+		expect(result.days_since_last_reform).toBe(5);
+	});
+
+	test("excludes the known corrupt date 2929-11-19 from last_reform_date", () => {
+		insertNorm("BOE-A-2024-1000", "2024-01-01");
+		insertReform("BOE-A-2024-1000", "2026-07-18", "BOE-A-2026-9001");
+		// Simulates a corrupt row already sitting in the DB (pre-fix data,
+		// or a row inserted before the ingest-time guard existed).
+		insertReform("BOE-A-2024-1000", "2929-11-19", "BOE-A-2929-99999");
+
+		const status = new StatusService(db, dataDir);
+		const now = new Date("2026-07-23T12:00:00Z");
+		const result = status.getStatus(now);
+
+		expect(result.reforms_count).toBe(2);
+		expect(result.last_reform_date).toBe("2026-07-18");
+	});
+
+	test("returns null last_reform_date when there are no reforms", () => {
+		insertNorm("BOE-A-2024-1000", "2024-01-01");
+
+		const status = new StatusService(db, dataDir);
+		const result = status.getStatus(new Date("2026-07-23T12:00:00Z"));
+
+		expect(result.last_reform_date).toBeNull();
+		expect(result.days_since_last_reform).toBeNull();
+	});
+
+	test("reads last_sync from state.json watermark when present", () => {
+		writeFileSync(
+			join(dataDir, "state.json"),
+			JSON.stringify({
+				version: 1,
+				country: "es",
+				lastBoeUpdate: "20260722T061153Z",
+				norms: {},
+			}),
+		);
+
+		const status = new StatusService(db, dataDir);
+		const result = status.getStatus();
+
+		expect(result.last_sync).toBe("20260722T061153Z");
+		expect(result.last_sync_source).toBe("state_watermark");
+	});
+
+	test("falls back to state.json mtime when no watermark is set", () => {
+		writeFileSync(
+			join(dataDir, "state.json"),
+			JSON.stringify({ version: 1, country: "es", norms: {} }),
+		);
+
+		const status = new StatusService(db, dataDir);
+		const result = status.getStatus();
+
+		expect(result.last_sync).not.toBeNull();
+		expect(result.last_sync_source).toBe("state_file_mtime");
+	});
+
+	test("reports unavailable when state.json does not exist", () => {
+		const status = new StatusService(db, join(dataDir, "does-not-exist"));
+		const result = status.getStatus();
+
+		expect(result.last_sync).toBeNull();
+		expect(result.last_sync_source).toBe("unavailable");
+	});
+});

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -16,6 +16,7 @@ import { askRoutes } from "./routes/ask.ts";
 import { lawRoutes, type SearchResponse } from "./routes/laws.ts";
 import { omnibusRoutes } from "./routes/omnibus.ts";
 import { reformRoutes } from "./routes/reforms.ts";
+import { statusRoutes } from "./routes/status.ts";
 import { LruCache } from "./services/cache.ts";
 import { CitizenSummaryService } from "./services/citizen-summary.ts";
 import { DbService } from "./services/db.ts";
@@ -29,6 +30,7 @@ import { flushTraces } from "./services/rag/tracing.ts";
 import { getSharedVectorIndex } from "./services/rag/vector-index-singleton.ts";
 import { vectorSearchPooled } from "./services/rag/vector-pool.ts";
 import { createRateLimiter, getClientIp } from "./services/rate-limiter.ts";
+import { StatusService } from "./services/status.ts";
 
 const DB_PATH = process.env.DB_PATH ?? "./data/leyabierta.db";
 const REPO_PATH = process.env.REPO_PATH ?? "../leyes";
@@ -59,6 +61,7 @@ const citizenSummaryService = new CitizenSummaryService(db);
 // RAG pipeline (optional — only if API key is available)
 const OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY ?? "";
 const RAG_DATA_DIR = process.env.RAG_DATA_DIR ?? "./data";
+const statusService = new StatusService(db, RAG_DATA_DIR);
 const ragPipeline = OPENROUTER_API_KEY
 	? new RagPipeline(db, OPENROUTER_API_KEY, RAG_DATA_DIR)
 	: null;
@@ -266,6 +269,7 @@ app
 	)
 	.use(alertRoutes(dbService))
 	.use(reformRoutes(dbService))
+	.use(statusRoutes(statusService))
 	.use(omnibusRoutes(dbService))
 	.use(askRoutes(ragPipeline))
 	.get(

--- a/packages/api/src/routes/status.ts
+++ b/packages/api/src/routes/status.ts
@@ -1,0 +1,42 @@
+/**
+ * GET /v1/status — corpus freshness (issue #129).
+ *
+ * Public, cacheable endpoint so the frontend can honestly communicate the
+ * BOE-consolidated-legislation lag instead of letting "Cambios recientes"
+ * look abandoned when the source has simply gone quiet for a stretch.
+ */
+
+import { Elysia } from "elysia";
+import type { StatusService } from "../services/status.ts";
+
+export function statusRoutes(statusService: StatusService) {
+	return new Elysia({ prefix: "/v1" }).get(
+		"/status",
+		({ set }) => {
+			// Cache at the edge for 5 min — cheap aggregate queries, but no
+			// need to recompute on every request. Independent of the general
+			// s-maxage=3600 default in index.ts: freshness data is exactly the
+			// kind of thing we don't want stale for an hour.
+			set.headers["Cache-Control"] =
+				"public, max-age=0, s-maxage=300, must-revalidate";
+			return statusService.getStatus();
+		},
+		{
+			detail: {
+				summary: "Corpus freshness status",
+				description:
+					"Reports how fresh the ingested corpus is: total norms/reforms, " +
+					"the most recent reform date actually in the database (excluding " +
+					"implausible/corrupt dates), and days elapsed since it. Exists " +
+					"because Ley Abierta only ingests BOE-consolidated legislation, " +
+					"which lags the daily bulletin by 1-2 weeks — this endpoint lets " +
+					"clients communicate that lag instead of it reading as a stalled " +
+					"or broken site. `last_sync` is best-effort (see " +
+					"`last_sync_source`): there is currently no fully reliable " +
+					"'pipeline last ran' heartbeat for nights where the BOE published " +
+					"nothing new.",
+				tags: ["Sistema"],
+			},
+		},
+	);
+}

--- a/packages/api/src/scripts/ad-hoc/2026-07-23-cleanup-corrupt-reform-dates.js
+++ b/packages/api/src/scripts/ad-hoc/2026-07-23-cleanup-corrupt-reform-dates.js
@@ -1,0 +1,108 @@
+// Ad-hoc, one-shot cleanup of corrupt reform dates in PRODUCTION (issue #129).
+// Self-contained on purpose: the deployed container predates
+// isPlausibleReformDate, so packages/api/src/scripts/list-corrupt-reform-dates.ts
+// cannot run there yet. Same criteria, same delete order, plus a JSON backup of
+// every row it removes — leyabierta.db has no automated backup.
+const { Database } = require("bun:sqlite");
+const fs = require("fs");
+
+const MIN = "1800-01-01";
+const max = (() => {
+	const d = new Date();
+	d.setUTCFullYear(d.getUTCFullYear() + 5);
+	return d.toISOString().slice(0, 10);
+})();
+const plausible = (s) => {
+	if (!/^\d{4}-\d{2}-\d{2}$/.test(s)) return false;
+	const d = new Date(`${s}T00:00:00Z`);
+	if (Number.isNaN(d.getTime())) return false;
+	if (d.toISOString().slice(0, 10) !== s) return false;
+	return s >= MIN && s <= max;
+};
+
+const APPLY = process.argv.includes("--fix");
+const db = APPLY
+	? new Database("/app/data/leyabierta.db")
+	: new Database("/app/data/leyabierta.db", { readonly: true });
+const all = db.query("SELECT norm_id, date, source_id FROM reforms").all();
+const corrupt = all.filter((r) => !plausible(r.date));
+
+console.log(
+	`Scanned ${all.length} reforms — ${corrupt.length} implausible (range [${MIN}, ${max}])`,
+);
+if (corrupt.length === 0) process.exit(0);
+
+const backup = corrupt.map((r) => ({
+	reform: r,
+	blocks: db
+		.query(
+			"SELECT * FROM reform_blocks WHERE norm_id=? AND reform_date=? AND reform_source_id=?",
+		)
+		.all(r.norm_id, r.date, r.source_id),
+	summaries: db
+		.query(
+			"SELECT * FROM reform_summaries WHERE norm_id=? AND reform_date=? AND source_id=?",
+		)
+		.all(r.norm_id, r.date, r.source_id),
+}));
+for (const b of backup) {
+	console.log(
+		`  ${b.reform.norm_id} | ${b.reform.date} | src=${b.reform.source_id} | blocks=${b.blocks.length} summaries=${b.summaries.length}`,
+	);
+}
+
+if (!APPLY) {
+	console.log("\nDRY RUN — nothing deleted. Re-run with --fix.");
+	process.exit(0);
+}
+
+const path = `/opt/leyabierta/backups/corrupt-reforms-backup-${new Date().toISOString().slice(0, 10)}.json`;
+fs.writeFileSync(
+	"/tmp/corrupt-reforms-backup.json",
+	JSON.stringify(backup, null, 2),
+);
+console.log(
+	`\nBackup written inside container: /tmp/corrupt-reforms-backup.json (copy out to ${path})`,
+);
+
+const delB = db.prepare(
+	"DELETE FROM reform_blocks WHERE norm_id=? AND reform_date=? AND reform_source_id=?",
+);
+const delS = db.prepare(
+	"DELETE FROM reform_summaries WHERE norm_id=? AND reform_date=? AND source_id=?",
+);
+const delR = db.prepare(
+	"DELETE FROM reforms WHERE norm_id=? AND date=? AND source_id=?",
+);
+db.transaction(() => {
+	for (const r of corrupt) {
+		delB.run(r.norm_id, r.date, r.source_id);
+		delS.run(r.norm_id, r.date, r.source_id);
+		delR.run(r.norm_id, r.date, r.source_id);
+	}
+})();
+console.log(`Deleted ${corrupt.length} corrupt reform row(s).`);
+const left = db.query("SELECT COUNT(*) c FROM reforms WHERE date > ?").all(max);
+console.log("Remaining implausible-future rows:", JSON.stringify(left));
+
+// ---------------------------------------------------------------------------
+// RUN LOG — executed against production on 2026-07-23.
+//
+//   Scanned 44271 reforms — 2 implausible (range [1800-01-01, 2031-07-23])
+//     BOE-A-1985-26400 | 2929-11-19 | src=BOE-A-2021-2849 | blocks=1 summaries=1
+//     BOE-A-2010-8228  | 2012-06-31 | src=BOE-A-2012-8745 | blocks=1 summaries=0
+//   Deleted 2 corrupt reform row(s).
+//
+// The 2929-11-19 row was the FIRST entry citizens saw under "Cambios
+// recientes"; 2012-06-31 is a 31st of June, a date that does not exist — it
+// passed a naive range check and was only caught by the ISO round-trip.
+//
+// Deleted rows backed up to, on the server:
+//   /opt/leyabierta/backups/corrupt-reforms-backup-20260723.json
+// (leyabierta.db itself has NO automated backup — see the PR description.)
+//
+// Going forward this should not recur: ingest rejects implausible dates and
+// getChangelog is upper-bounded. The maintained equivalent of this script is
+// packages/api/src/scripts/list-corrupt-reform-dates.ts — this ad-hoc copy
+// exists only because the deployed container predated isPlausibleReformDate.
+// ---------------------------------------------------------------------------

--- a/packages/api/src/scripts/ad-hoc/2026-07-23-cleanup-corrupt-reform-dates.js
+++ b/packages/api/src/scripts/ad-hoc/2026-07-23-cleanup-corrupt-reform-dates.js
@@ -4,7 +4,7 @@
 // cannot run there yet. Same criteria, same delete order, plus a JSON backup of
 // every row it removes — leyabierta.db has no automated backup.
 const { Database } = require("bun:sqlite");
-const fs = require("fs");
+const fs = require("node:fs");
 
 const MIN = "1800-01-01";
 const max = (() => {

--- a/packages/api/src/scripts/freshness-alert.ts
+++ b/packages/api/src/scripts/freshness-alert.ts
@@ -1,0 +1,116 @@
+/**
+ * Freshness alert (issue #129).
+ *
+ * Today, a quiet night ("BOE consolidó 0 normas nuevas") and a silently
+ * broken fetch both produce the exact same log line: `0 changed`. This
+ * script gives us a second, independent signal: how many business days
+ * have passed since the last reform actually landed in the `reforms`
+ * table. If that exceeds a threshold, something is worth a human look —
+ * either the source has gone unusually quiet, or the pipeline is broken.
+ *
+ * It does NOT distinguish those two causes (a genuinely quiet BOE and a
+ * broken fetch look identical from inside our own DB), it only tells you
+ * "this has gone on long enough that someone should check". That's
+ * intentional — see open_issues in the PR description for what a fuller
+ * fix would need (a heartbeat written by the cron script on every run,
+ * including zero-change runs, which today only saves data/state.json when
+ * there is something new to persist).
+ *
+ * Exit codes:
+ *   0 — fresh (last reform within the threshold)
+ *   1 — stale (threshold exceeded) — wire this into the daily cron so a
+ *       non-zero exit fails the job / trips an alert
+ *   2 — could not determine (no reforms in DB at all — different problem,
+ *       still worth flagging)
+ *
+ * Usage:
+ *   bun run packages/api/src/scripts/freshness-alert.ts
+ *   bun run packages/api/src/scripts/freshness-alert.ts --max-business-days 5
+ */
+
+import {
+	isPlausibleReformDate,
+	MIN_PLAUSIBLE_REFORM_DATE,
+} from "@leyabierta/pipeline";
+import { getArg, setupDb } from "./shared.ts";
+
+const DEFAULT_MAX_BUSINESS_DAYS = 5;
+
+const maxBusinessDaysArg = getArg("max-business-days");
+const maxBusinessDays = maxBusinessDaysArg
+	? Number(maxBusinessDaysArg)
+	: DEFAULT_MAX_BUSINESS_DAYS;
+
+if (!Number.isFinite(maxBusinessDays) || maxBusinessDays <= 0) {
+	console.error(
+		`Invalid --max-business-days value: ${maxBusinessDaysArg}. Must be a positive number.`,
+	);
+	process.exit(2);
+}
+
+/**
+ * Count business days (Mon-Fri) strictly between `from` and `to`
+ * (exclusive of `from`, inclusive of `to`). No public-holiday calendar —
+ * Spanish national/regional holidays are not accounted for, so this
+ * slightly over-counts around holidays. Good enough for a "should someone
+ * look at this" trigger; not intended as exact SLA accounting.
+ */
+function countBusinessDaysBetween(from: Date, to: Date): number {
+	let count = 0;
+	const cursor = new Date(
+		Date.UTC(from.getUTCFullYear(), from.getUTCMonth(), from.getUTCDate()),
+	);
+	const end = new Date(
+		Date.UTC(to.getUTCFullYear(), to.getUTCMonth(), to.getUTCDate()),
+	);
+	cursor.setUTCDate(cursor.getUTCDate() + 1);
+	while (cursor.getTime() <= end.getTime()) {
+		const day = cursor.getUTCDay(); // 0 = Sunday, 6 = Saturday
+		if (day !== 0 && day !== 6) count++;
+		cursor.setUTCDate(cursor.getUTCDate() + 1);
+	}
+	return count;
+}
+
+const { db } = setupDb();
+
+const nowIso = new Date().toISOString().slice(0, 10);
+
+// Same plausibility guard as ingest — belt and suspenders against any
+// corrupt rows already in the DB (see list-corrupt-reform-dates.ts) that
+// haven't been cleaned up yet.
+const row = db
+	.query<{ date: string }, [string, string]>(
+		"SELECT date FROM reforms WHERE date >= ? AND date <= ? ORDER BY date DESC LIMIT 1",
+	)
+	.get(MIN_PLAUSIBLE_REFORM_DATE, nowIso);
+
+if (!row || !isPlausibleReformDate(row.date)) {
+	console.error(
+		"[freshness] No reforms with a plausible date found in the database at all. " +
+			"This is a different (worse) problem than staleness — investigate the DB directly.",
+	);
+	process.exit(2);
+}
+
+const lastReformDate = new Date(`${row.date}T00:00:00Z`);
+const now = new Date();
+const businessDaysSince = countBusinessDaysBetween(lastReformDate, now);
+
+console.log(
+	`[freshness] Last reform ingested: ${row.date} (${businessDaysSince} business day(s) ago)`,
+);
+console.log(`[freshness] Threshold: ${maxBusinessDays} business day(s)`);
+
+if (businessDaysSince > maxBusinessDays) {
+	console.error(
+		`[freshness] ALERT: ${businessDaysSince} business days since the last reform ` +
+			`(threshold ${maxBusinessDays}). Either the BOE has genuinely gone quiet for an ` +
+			`unusually long stretch, or the pipeline fetch is broken. Check the daily cron ` +
+			`logs for "0 have changes" vs actual fetch errors.`,
+	);
+	process.exit(1);
+}
+
+console.log("[freshness] OK — within threshold.");
+process.exit(0);

--- a/packages/api/src/scripts/list-corrupt-reform-dates.ts
+++ b/packages/api/src/scripts/list-corrupt-reform-dates.ts
@@ -1,0 +1,88 @@
+/**
+ * List reforms with implausible dates already sitting in the `reforms`
+ * table (production incident behind issue #129: a row with date
+ * `2929-11-19` sourced verbatim from the BOE feed). Ingest now rejects
+ * these going forward (see packages/pipeline/src/db/ingest.ts), but this
+ * script finds — and optionally cleans up — rows that got in before that
+ * fix landed.
+ *
+ * By default this ONLY LISTS the corrupt rows. It never deletes data
+ * unless you pass --fix explicitly.
+ *
+ * Usage:
+ *   bun run packages/api/src/scripts/list-corrupt-reform-dates.ts
+ *   bun run packages/api/src/scripts/list-corrupt-reform-dates.ts --fix
+ */
+
+import { isPlausibleReformDate } from "@leyabierta/pipeline";
+import { hasFlag, setupDb } from "./shared.ts";
+
+const { db } = setupDb();
+const fix = hasFlag("fix");
+
+interface ReformDateRow {
+	norm_id: string;
+	date: string;
+	source_id: string;
+}
+
+const rows = db
+	.query<ReformDateRow, []>(
+		"SELECT norm_id, date, source_id FROM reforms ORDER BY date DESC",
+	)
+	.all();
+
+const corrupt = rows.filter((r) => !isPlausibleReformDate(r.date));
+
+console.log(`Scanned ${rows.length} reforms.`);
+
+if (corrupt.length === 0) {
+	console.log("No corrupt reform dates found.");
+	process.exit(0);
+}
+
+console.log(`Found ${corrupt.length} reform(s) with an implausible date:\n`);
+for (const r of corrupt) {
+	console.log(`  norm_id=${r.norm_id} date=${r.date} source_id=${r.source_id}`);
+}
+
+if (!fix) {
+	console.log(
+		"\nDry run (default): no rows deleted. Re-run with --fix to delete these rows.",
+	);
+	process.exit(0);
+}
+
+console.log("\n--fix passed — deleting the rows above...");
+const deleteReform = db.prepare(
+	"DELETE FROM reforms WHERE norm_id = $normId AND date = $date AND source_id = $sourceId",
+);
+const deleteReformBlocks = db.prepare(
+	"DELETE FROM reform_blocks WHERE norm_id = $normId AND reform_date = $date AND reform_source_id = $sourceId",
+);
+const deleteReformSummary = db.prepare(
+	"DELETE FROM reform_summaries WHERE norm_id = $normId AND reform_date = $date AND source_id = $sourceId",
+);
+
+const deleteAll = db.transaction(() => {
+	for (const r of corrupt) {
+		deleteReformBlocks.run({
+			$normId: r.norm_id,
+			$date: r.date,
+			$sourceId: r.source_id,
+		});
+		deleteReformSummary.run({
+			$normId: r.norm_id,
+			$date: r.date,
+			$sourceId: r.source_id,
+		});
+		deleteReform.run({
+			$normId: r.norm_id,
+			$date: r.date,
+			$sourceId: r.source_id,
+		});
+	}
+});
+deleteAll();
+
+console.log(`Deleted ${corrupt.length} corrupt reform row(s).`);

--- a/packages/api/src/services/db.ts
+++ b/packages/api/src/services/db.ts
@@ -5,6 +5,7 @@
 import type { Database, SQLQueryBindings } from "bun:sqlite";
 import { BASE_MATERIAS } from "../data/materia-mappings.ts";
 import type { HybridSearcher } from "./hybrid-search.ts";
+import { parseNormReference } from "./norm-reference.ts";
 import {
 	adaptiveSearch,
 	ensureNormsFtsVocab,
@@ -72,6 +73,139 @@ export interface VersionRow {
 export class DbService {
 	constructor(private db: Database) {
 		ensureNormsFtsVocab(db);
+		// Issue #128: exact-reference fast path (short_title / source_url
+		// lookups) needs these indexed, not sequentially scanned.
+		//
+		// Wrapped like ensureNormsFtsVocab: several callers open the database
+		// read-only (vector workers, eval scripts, OG-image generation), and a
+		// bare CREATE INDEX would throw SQLITE_READONLY at construction time —
+		// or SQLITE_BUSY when another process holds the write lock. Missing
+		// indexes only cost a sequential scan; a throwing constructor costs the
+		// whole process.
+		try {
+			db.exec(
+				"CREATE INDEX IF NOT EXISTS idx_norms_short_title ON norms(short_title)",
+			);
+			db.exec(
+				"CREATE INDEX IF NOT EXISTS idx_norms_source_url ON norms(source_url)",
+			);
+		} catch {
+			// Read-only connection or concurrent writer — fall back to scans.
+		}
+	}
+
+	/**
+	 * Issue #128 fast path: resolve a query that looks like a citation of a
+	 * specific norm ("Real Decreto 1312/2024", "BOE-A-2024-26931", an ELI
+	 * URL, "LAU", a bare "1312/2024") into an ordered list of norm ids via
+	 * exact, indexed lookup — no BM25/FTS involved.
+	 *
+	 * Order: state-level (jurisdiction='es') norms first, since multiple
+	 * jurisdictions can share the same short_title (e.g. "Ley 12/2016"
+	 * exists both nationally and regionally). Filters are applied so the
+	 * fast path never surfaces a result the caller explicitly excluded.
+	 *
+	 * Returns `[]` when the query isn't reference-shaped, or is but matches
+	 * nothing.
+	 */
+	private resolveNormReference(
+		query: string,
+		filters: SearchFilters,
+	): string[] {
+		const parsed = parseNormReference(query);
+		if (!parsed) return [];
+
+		let ids: string[] = [];
+		switch (parsed.kind) {
+			case "id": {
+				const row = this.db
+					.query<{ id: string }, [string]>("SELECT id FROM norms WHERE id = ?")
+					.get(parsed.id);
+				if (row) ids = [row.id];
+				break;
+			}
+			case "alias": {
+				const row = this.db
+					.query<{ id: string }, [string]>("SELECT id FROM norms WHERE id = ?")
+					.get(parsed.id);
+				if (row) ids = [row.id];
+				break;
+			}
+			case "eli": {
+				const placeholders = parsed.urls.map(() => "?").join(",");
+				ids = this.db
+					.query<{ id: string }, SqlParams>(
+						`SELECT id FROM norms WHERE source_url IN (${placeholders})
+						 ORDER BY (jurisdiction = 'es') DESC, id`,
+					)
+					.all(...parsed.urls)
+					.map((r) => r.id);
+				break;
+			}
+			case "ranked": {
+				// COLLATE NOCASE: short_title casing is not normalized at ingest
+				// — the corpus holds both "Decreto-ley 2/2009" (293 norms) and
+				// "Decreto-Ley 1/2016" (6). An exact match would silently miss
+				// the minority spelling.
+				ids = this.db
+					.query<{ id: string }, [string, string]>(
+						`SELECT id FROM norms
+						 WHERE short_title = ? COLLATE NOCASE AND rank = ?
+						 ORDER BY (jurisdiction = 'es') DESC, id`,
+					)
+					.all(parsed.shortTitle, parsed.rank)
+					.map((r) => r.id);
+				break;
+			}
+			case "number_year": {
+				// short_title always ends "<Tipo> <num>/<año>" with no trailing
+				// text (see extractShortTitle), so a suffix match is exact.
+				//
+				// Two separators matter: most ranks put a space before the
+				// number ("Ley 12/2016"), but ministerial orders put a slash
+				// ("Orden HAP/1370/2014"), so a space-only pattern silently
+				// missed every order searched by its bare number.
+				const spaced = `% ${parsed.number}/${parsed.year}`;
+				const slashed = `%/${parsed.number}/${parsed.year}`;
+				ids = this.db
+					.query<{ id: string }, [string, string]>(
+						`SELECT id FROM norms
+						 WHERE short_title LIKE ? ESCAPE '\\'
+						    OR short_title LIKE ? ESCAPE '\\'
+						 ORDER BY (jurisdiction = 'es') DESC, id`,
+					)
+					.all(spaced, slashed)
+					.map((r) => r.id);
+				break;
+			}
+			case "id_suffix": {
+				// "26931" → BOE-A-2024-26931. Newest first: when the same
+				// sequence was reused across years, the recent norm is far more
+				// likely to be the one being cited.
+				ids = this.db
+					.query<{ id: string }, [string]>(
+						`SELECT id FROM norms WHERE id LIKE ? ESCAPE '\\'
+						 ORDER BY published_at DESC, id`,
+					)
+					.all(`%-${parsed.sequence}`)
+					.map((r) => r.id);
+				break;
+			}
+		}
+
+		if (ids.length === 0) return ids;
+
+		const hasFilters =
+			!!filters.country ||
+			!!filters.jurisdiction ||
+			!!filters.rank ||
+			!!filters.status ||
+			!!filters.materia ||
+			!!filters.citizen_tag;
+		if (!hasFilters) return ids;
+
+		const allowed = new Set(this.filterIdsByChunks(ids, filters));
+		return ids.filter((id) => allowed.has(id));
 	}
 
 	searchLaws(
@@ -209,6 +343,14 @@ export class DbService {
 			// full intersection.
 			const FTS_CAP = 500;
 			try {
+				// Issue #128: if the query cites a specific norm ("Real Decreto
+				// 1312/2024", "LAU", an ELI URL, a bare "1312/2024", …), resolve
+				// it via exact indexed lookup first. These ids are prepended to
+				// the BM25-ranked results below (deduped), not returned alone —
+				// e.g. "Ley 12/2016" should still surface every jurisdiction
+				// that has a law by that reference, not just one.
+				const refIds = this.resolveNormReference(query, filters);
+
 				// Pass 0: exact/prefix title matches (highest relevance)
 				// These go first regardless of BM25 score
 				const escaped = escapeLike(query);
@@ -285,7 +427,13 @@ export class DbService {
 					filteredIds = allIds.filter((id) => filteredSet.has(id));
 				}
 
-				const matchIds = filteredIds.map((id) => ({ norm_id: id }));
+				// Exact reference matches go first, then BM25 results with any
+				// duplicate of a reference match removed.
+				const refSet = new Set(refIds);
+				const matchIds = [
+					...refIds,
+					...filteredIds.filter((id) => !refSet.has(id)),
+				].map((id) => ({ norm_id: id }));
 
 				const ids = matchIds.map((r) => r.norm_id);
 				const total = ids.length;
@@ -412,6 +560,12 @@ export class DbService {
 			return law ? { laws: [law], total: 1 } : { laws: [], total: 0 };
 		}
 
+		// Issue #128: exact-reference fast path (see searchLaws for the
+		// rationale). Resolved ids are prepended to the fused BM25+vector
+		// list below, not returned alone — other jurisdictions sharing the
+		// same reference, or additional relevant hits, are still surfaced.
+		const refIds = this.resolveNormReference(trimmed, filters);
+
 		// 1. BM25 ranked norm IDs (unfiltered, larger cap so the fusion has
 		//    enough candidates to pick from).
 		const bm25Ids = this.bm25RankedNormIds(trimmed, 500);
@@ -425,10 +579,13 @@ export class DbService {
 			normTopK: NORM_TOP_K,
 		});
 
-		if (fused.length === 0) return { laws: [], total: 0 };
+		if (fused.length === 0 && refIds.length === 0) {
+			return { laws: [], total: 0 };
+		}
 		const capped = fused.length >= NORM_TOP_K;
 
-		// 3. Apply filters across the fused IDs.
+		// 3. Apply filters across the fused IDs (refIds are already filtered
+		//    by resolveNormReference).
 		const hasFilters =
 			!!filters.country ||
 			!!filters.jurisdiction ||
@@ -442,8 +599,14 @@ export class DbService {
 			filteredIds = fused.filter((id) => filteredSet.has(id));
 		}
 
-		const total = filteredIds.length;
-		const pageIds = filteredIds.slice(offset, offset + limit);
+		const refSet = new Set(refIds);
+		const mergedIds = [
+			...refIds,
+			...filteredIds.filter((id) => !refSet.has(id)),
+		];
+
+		const total = mergedIds.length;
+		const pageIds = mergedIds.slice(offset, offset + limit);
 		if (pageIds.length === 0) {
 			return capped ? { laws: [], total, capped: true } : { laws: [], total };
 		}
@@ -1197,6 +1360,13 @@ export class DbService {
 			}
 		}
 
+		// Upper-bounded like getRecentReforms/getRecentlyUpdated. Without this,
+		// a single corrupt source date (there is one real row dated 2929-11-19,
+		// straight from the BOE) sorts to the top of DESC and becomes the first
+		// entry citizens see under "Cambios recientes". Ingest now rejects such
+		// dates, but the query must not depend on the data being clean.
+		const today = new Date().toISOString().slice(0, 10);
+
 		const sql = `
 			SELECT DISTINCT n.id, n.title, n.rank, n.status, r.date, r.source_id,
 				rs.headline, rs.summary, rs.reform_type, rs.importance,
@@ -1207,6 +1377,7 @@ export class DbService {
 			LEFT JOIN reform_summaries rs
 				ON rs.norm_id = r.norm_id AND rs.source_id = r.source_id AND rs.reform_date = r.date
 			WHERE r.date >= ?
+			  AND r.date <= ?
 			  AND (rs.importance IS NULL OR rs.importance NOT IN ('skip'))
 			  ${jurisdictionClause}
 			ORDER BY r.date DESC
@@ -1231,7 +1402,7 @@ export class DbService {
 				},
 				SqlParams
 			>(sql)
-			.all(since, ...jurisdictionParams, limit);
+			.all(since, today, ...jurisdictionParams, limit);
 	}
 
 	upsertReformSummary(

--- a/packages/api/src/services/norm-reference.ts
+++ b/packages/api/src/services/norm-reference.ts
@@ -1,0 +1,233 @@
+/**
+ * Norm reference parsing — issue #128.
+ *
+ * BM25 falls apart on the way people actually cite a law: "Real Decreto
+ * 1312/2024" dilutes the discriminating token (the number) between two
+ * hyper-frequent words ("real", "decreto"), so it loses to unrelated norms
+ * whose title happens to contain "real decreto" plus some other number.
+ *
+ * This module is a pure parser: given a raw search query, detect whether it
+ * looks like a citation of a specific norm (BOE/regional bulletin ID, ELI
+ * URL, "<rango> <num>/<año>", "Orden <SIGLA>/<num>/<año>", a bare "<num>/<año>",
+ * or a well-known acronym) and return a typed, normalized description of it.
+ *
+ * It does NOT touch the database — `db.ts` uses the result to do an exact,
+ * indexed lookup (mainly against `norms.short_title`, which already stores
+ * the canonical reference for ~85% of norms) before falling back to BM25/
+ * hybrid ranking.
+ */
+
+import type { Rank } from "@leyabierta/pipeline";
+
+/** The four things a query can resolve to. */
+export type NormReferenceMatch =
+	| { kind: "id"; id: string }
+	| { kind: "eli"; urls: string[] }
+	| { kind: "alias"; id: string }
+	| { kind: "ranked"; rank: Rank; shortTitle: string }
+	| { kind: "number_year"; number: string; year: string }
+	| { kind: "id_suffix"; sequence: string };
+
+/** Existing norm-ID fast path pattern (BOE-A-2024-26931, BORM-s-2026-90179, …). */
+const NORM_ID_RE = /^[A-Z]+-[A-Z]+-\d{4}-\d+$/i;
+
+/** ELI URL, e.g. https://www.boe.es/eli/es/rd/2024/12/23/1312 */
+const ELI_RE =
+	/\/eli\/[a-z0-9-]+\/[a-z0-9-]+\/\d{4}\/\d{2}\/\d{2}\/[a-z0-9-]+/i;
+
+/** Bare "<num>/<año>" — the whole (trimmed) query, nothing else. */
+const NUMBER_YEAR_RE = /^(\d{1,5})\s*\/\s*(\d{4})$/;
+
+/**
+ * Bare BOE sequence number — 3 to 6 digits, the whole query. Shorter runs
+ * (1-2 digits) are far too ambiguous to be worth a fast path.
+ */
+const BARE_SEQUENCE_RE = /^(\d{3,6})$/;
+
+/**
+ * Ministerial order: "Orden HAP/1370/2014", "Orden ETU/615/2017",
+ * optionally "Orden Ministerial …". Ministry sigla is 2-6 letters.
+ */
+const ORDEN_PREFIX_RE =
+	/^orden(?:\s+ministerial)?\s+([a-z]{2,6})\s*\/\s*(\d{1,6})\s*\/\s*(\d{4})\b/;
+
+/**
+ * Well-known law acronyms → norm id. Each entry was verified against the
+ * production database (exact id + short_title/title match) before being
+ * hardcoded — see PR description for the queries used. An alias pointing at
+ * the wrong norm is worse than no alias, so keep this list conservative.
+ */
+export const NORM_ALIASES: Record<string, string> = {
+	LAU: "BOE-A-1994-26003", // Ley 29/1994, de Arrendamientos Urbanos
+	LEC: "BOE-A-2000-323", // Ley 1/2000, de Enjuiciamiento Civil
+	LECRIM: "BOE-A-1882-6036", // RD de 14 sept 1882, aprueba la Ley de Enjuiciamiento Criminal
+	ET: "BOE-A-2015-11430", // RD Legislativo 2/2015, texto refundido Estatuto de los Trabajadores
+	LGSS: "BOE-A-2015-11724", // RD Legislativo 8/2015, texto refundido Ley General de la Seguridad Social
+	LOPDGDD: "BOE-A-2018-16673", // LO 3/2018, Protección de Datos Personales y garantía de derechos digitales
+	LPACAP: "BOE-A-2015-10565", // Ley 39/2015, Procedimiento Administrativo Común
+	LRJSP: "BOE-A-2015-10566", // Ley 40/2015, Régimen Jurídico del Sector Público
+	CE: "BOE-A-1978-31229", // Constitución Española
+	CC: "BOE-A-1889-4763", // Código Civil
+	CP: "BOE-A-1995-25444", // LO 10/1995, Código Penal
+};
+
+/**
+ * Ordered (longest/most-specific first) list of rango aliases. Matched
+ * against a normalized query (lowercase, accents stripped, hyphens folded
+ * to spaces, periods removed, whitespace collapsed) so "R.D.", "Real
+ * Decreto-ley" and "real decreto ley" all converge to the same lookup.
+ *
+ * `prefix` is the exact string norms.short_title uses for this rango — see
+ * extractShortTitle() in packages/pipeline/src/spain/boe-metadata.ts, the
+ * source of truth for how short_title is built at ingest.
+ */
+const RANGO_ALIASES: Array<{ token: string; rank: Rank; prefix: string }> = [
+	{
+		token: "real decreto legislativo",
+		rank: "real_decreto_legislativo",
+		prefix: "Real Decreto Legislativo",
+	},
+	{
+		token: "rdleg",
+		rank: "real_decreto_legislativo",
+		prefix: "Real Decreto Legislativo",
+	},
+	{
+		token: "real decreto ley",
+		rank: "real_decreto_ley",
+		prefix: "Real Decreto-ley",
+	},
+	{ token: "rdl", rank: "real_decreto_ley", prefix: "Real Decreto-ley" },
+	{ token: "rd ley", rank: "real_decreto_ley", prefix: "Real Decreto-ley" },
+	{ token: "real decreto", rank: "real_decreto", prefix: "Real Decreto" },
+	{ token: "rd", rank: "real_decreto", prefix: "Real Decreto" },
+	{
+		token: "decreto legislativo",
+		rank: "decreto",
+		prefix: "Decreto Legislativo",
+	},
+	{ token: "decreto ley", rank: "real_decreto_ley", prefix: "Decreto-ley" },
+	{ token: "decreto", rank: "decreto", prefix: "Decreto" },
+	{ token: "ley organica", rank: "ley_organica", prefix: "Ley Orgánica" },
+	{ token: "lo", rank: "ley_organica", prefix: "Ley Orgánica" },
+	{ token: "ley foral", rank: "ley", prefix: "Ley Foral" },
+	{ token: "ley", rank: "ley", prefix: "Ley" },
+	{ token: "circular", rank: "circular", prefix: "Circular" },
+	{ token: "instruccion", rank: "instruccion", prefix: "Instrucción" },
+	{
+		token: "acuerdo internacional",
+		rank: "acuerdo_internacional",
+		prefix: "Acuerdo Internacional",
+	},
+	{ token: "acuerdo", rank: "acuerdo", prefix: "Acuerdo" },
+].sort((a, b) => b.token.length - a.token.length);
+
+/**
+ * Strip accents, lowercase, drop periods (so "R.D." → "rd"), fold hyphens to
+ * spaces (so "Decreto-ley" and "Decreto ley" converge), collapse whitespace.
+ */
+function normalize(s: string): string {
+	return s
+		.normalize("NFD")
+		.replace(/[̀-ͯ]/g, "")
+		.toLowerCase()
+		.replace(/\./g, "")
+		.replace(/[-–]/g, " ")
+		.replace(/\s+/g, " ")
+		.trim();
+}
+
+/**
+ * Parse a raw search query into a norm reference match, or `null` if it
+ * doesn't look like one (plain natural-language queries, bare years,
+ * single common words like "vivienda" or "real decreto" with no number).
+ */
+export function parseNormReference(query: string): NormReferenceMatch | null {
+	const trimmed = query.trim();
+	if (!trimmed) return null;
+
+	// 1. Norm ID (BOE-A-2024-26931, BORM-s-2026-90179, …)
+	if (NORM_ID_RE.test(trimmed)) {
+		return { kind: "id", id: trimmed.toUpperCase() };
+	}
+
+	// 2. ELI URL — accept with/without scheme, http/https, trailing slash.
+	const eliMatch = trimmed.match(ELI_RE);
+	if (eliMatch) {
+		const path = eliMatch[0].replace(/\/$/, "");
+		return {
+			kind: "eli",
+			urls: [`https://www.boe.es${path}`, `http://www.boe.es${path}`, path],
+		};
+	}
+
+	// 3. Bare number/year — the ENTIRE query, nothing else attached.
+	const numberYear = trimmed.match(NUMBER_YEAR_RE);
+	if (numberYear) {
+		return {
+			kind: "number_year",
+			number: numberYear[1]!,
+			year: numberYear[2]!,
+		};
+	}
+
+	// 4. Well-known acronym — exact match on the whole (trimmed, uppercased)
+	//    query. No partial/substring matching: "LAU" must be the entire
+	//    query, not a substring of something else.
+	const upper = trimmed.toUpperCase();
+	if (Object.hasOwn(NORM_ALIASES, upper)) {
+		return { kind: "alias", id: NORM_ALIASES[upper]! };
+	}
+
+	const normalized = normalize(trimmed);
+
+	// 5. Ministerial order: "Orden HAP/1370/2014".
+	const ordenMatch = normalized.match(ORDEN_PREFIX_RE);
+	if (ordenMatch) {
+		const ministry = ordenMatch[1]!.toUpperCase();
+		const num = ordenMatch[2]!;
+		const year = ordenMatch[3]!;
+		return {
+			kind: "ranked",
+			rank: "orden" as Rank,
+			shortTitle: `Orden ${ministry}/${num}/${year}`,
+		};
+	}
+
+	// 6. "<rango> <num>/<año>", tolerating trailing text ("Real Decreto
+	//    1312/2024, de 23 de diciembre" — pasting the whole official title).
+	for (const { token, rank, prefix } of RANGO_ALIASES) {
+		if (normalized === token) continue; // rango alone isn't a reference
+		if (!normalized.startsWith(`${token} `)) continue;
+		const rest = normalized.slice(token.length).trim();
+		const numMatch = rest.match(/^(\d{1,5})\s*\/\s*(\d{4})\b/);
+		if (!numMatch) continue;
+		return {
+			kind: "ranked",
+			rank,
+			shortTitle: `${prefix} ${numMatch[1]}/${numMatch[2]}`,
+		};
+	}
+
+	// 7. Bare BOE sequence number ("26931" — the trailing segment of
+	//    BOE-A-2024-26931). People paste it after copying half an id, and FTS
+	//    can't help: norm_id is UNINDEXED in norms_fts and the digits appear
+	//    nowhere in the title, so the query returned ZERO results before this.
+	//    Resolved by id suffix; ties (the same sequence reused in different
+	//    years, common for regional bulletins) are returned newest-first
+	//    rather than dropped.
+	const bareSequence = trimmed.match(BARE_SEQUENCE_RE);
+	if (bareSequence) {
+		const digits = bareSequence[1]!;
+		// A 4-digit number in the plausible-year range is a year, not a
+		// sequence — "2024" must stay a normal text search.
+		const asNumber = Number(digits);
+		const looksLikeYear =
+			digits.length === 4 && asNumber >= 1800 && asNumber <= 2100;
+		if (!looksLikeYear) {
+			return { kind: "id_suffix", sequence: digits };
+		}
+	}
+
+	return null;
+}

--- a/packages/api/src/services/norm-reference.ts
+++ b/packages/api/src/services/norm-reference.ts
@@ -127,14 +127,21 @@ const RANGO_ALIASES: Array<{ token: string; rank: Rank; prefix: string }> = [
  * spaces (so "Decreto-ley" and "Decreto ley" converge), collapse whitespace.
  */
 function normalize(s: string): string {
-	return s
-		.normalize("NFD")
-		.replace(/[̀-ͯ]/g, "")
-		.toLowerCase()
-		.replace(/\./g, "")
-		.replace(/[-–]/g, " ")
-		.replace(/\s+/g, " ")
-		.trim();
+	return (
+		s
+			.normalize("NFD")
+			// Combining diacritical marks — written as escapes on purpose: the
+			// literal characters are invisible in an editor, so nobody can review
+			// or safely edit the range by eye.
+			.replace(/[\u0300-\u036f]/g, "")
+			.toLowerCase()
+			.replace(/\./g, "")
+			// Hyphen and en dash both fold to a space ("Real Decreto-ley" and
+			// "Real Decreto\u2013ley" must reach the same lookup).
+			.replace(/[-\u2013]/g, " ")
+			.replace(/\s+/g, " ")
+			.trim()
+	);
 }
 
 /**

--- a/packages/api/src/services/status.ts
+++ b/packages/api/src/services/status.ts
@@ -1,0 +1,138 @@
+/**
+ * Corpus freshness status (issue #129).
+ *
+ * Ley Abierta only ingests CONSOLIDATED legislation from the BOE, which
+ * lags the daily official bulletin by 1-2 weeks. That's expected and not
+ * a bug — but a citizen seeing "Cambios recientes -> 18 de julio" on the
+ * 23rd reasonably assumes the site is broken. This service backs the
+ * public `GET /v1/status` endpoint that lets the frontend communicate
+ * that lag honestly instead of looking abandoned.
+ */
+
+import type { Database } from "bun:sqlite";
+import { existsSync, readFileSync, statSync } from "node:fs";
+import {
+	isPlausibleReformDate,
+	MIN_PLAUSIBLE_REFORM_DATE,
+} from "@leyabierta/pipeline";
+
+export type LastSyncSource =
+	| "state_watermark"
+	| "state_file_mtime"
+	| "unavailable";
+
+export interface StatusData {
+	norms_count: number;
+	reforms_count: number;
+	/** MAX(norms.published_at) across the whole corpus. */
+	corpus_max_published_at: string | null;
+	/**
+	 * MAX(reforms.date), excluding implausible dates (see
+	 * isPlausibleReformDate) so a corrupt row like the known `2929-11-19`
+	 * incident can never contaminate this even before the DB is cleaned up.
+	 */
+	last_reform_date: string | null;
+	days_since_last_reform: number | null;
+	/**
+	 * Best-effort "when did the ingest pipeline last run" signal. See
+	 * `last_sync_source` for how reliable it is — today there is NO fully
+	 * reliable signal for this (see the class doc + open_issues in the PR
+	 * that introduced this field).
+	 */
+	last_sync: string | null;
+	last_sync_source: LastSyncSource;
+}
+
+export class StatusService {
+	constructor(
+		private db: Database,
+		private dataDir: string = process.env.RAG_DATA_DIR ?? "./data",
+	) {}
+
+	getStatus(now: Date = new Date()): StatusData {
+		const norms_count = this.db
+			.query<{ c: number }, []>("SELECT count(*) as c FROM norms")
+			.get()!.c;
+		const reforms_count = this.db
+			.query<{ c: number }, []>("SELECT count(*) as c FROM reforms")
+			.get()!.c;
+		const corpus_max_published_at =
+			this.db
+				.query<{ d: string | null }, []>(
+					"SELECT max(published_at) as d FROM norms",
+				)
+				.get()?.d ?? null;
+
+		const nowIso = now.toISOString().slice(0, 10);
+		const maxRow = this.db
+			.query<{ date: string }, [string, string]>(
+				"SELECT date FROM reforms WHERE date >= ? AND date <= ? ORDER BY date DESC LIMIT 1",
+			)
+			.get(MIN_PLAUSIBLE_REFORM_DATE, nowIso);
+		// Belt and suspenders: the range query above already excludes dates
+		// outside [1800-01-01, today], but re-check plausibility in case of
+		// any other kind of garbage that slipped past the SQL bounds.
+		const last_reform_date =
+			maxRow && isPlausibleReformDate(maxRow.date, now) ? maxRow.date : null;
+
+		let days_since_last_reform: number | null = null;
+		if (last_reform_date) {
+			const ms =
+				now.getTime() - new Date(`${last_reform_date}T00:00:00Z`).getTime();
+			days_since_last_reform = Math.floor(ms / 86_400_000);
+		}
+
+		const { last_sync, last_sync_source } = this.readLastSync();
+
+		return {
+			norms_count,
+			reforms_count,
+			corpus_max_published_at,
+			last_reform_date,
+			days_since_last_reform,
+			last_sync,
+			last_sync_source,
+		};
+	}
+
+	/**
+	 * Read the best available "last sync" signal from data/state.json.
+	 *
+	 * KNOWN GAP (see open_issues): `state.save()` in the pipeline CLI is
+	 * only called when there is something new to persist — a genuine
+	 * "0 changed" run returns early and never touches state.json. That
+	 * means neither `lastBoeUpdate` nor the file's mtime is a reliable
+	 * "the cron ran and is healthy" heartbeat; both can go stale on quiet
+	 * nights exactly like the freshness signal they're meant to
+	 * corroborate. Reported honestly via `last_sync_source` rather than
+	 * silently treating a stale watermark as if it were fresh.
+	 */
+	private readLastSync(): {
+		last_sync: string | null;
+		last_sync_source: LastSyncSource;
+	} {
+		const path = `${this.dataDir}/state.json`;
+		if (!existsSync(path)) {
+			return { last_sync: null, last_sync_source: "unavailable" };
+		}
+		try {
+			const raw = JSON.parse(readFileSync(path, "utf-8")) as {
+				lastBoeUpdate?: unknown;
+			};
+			if (typeof raw.lastBoeUpdate === "string" && raw.lastBoeUpdate) {
+				return {
+					last_sync: raw.lastBoeUpdate,
+					last_sync_source: "state_watermark",
+				};
+			}
+		} catch {
+			// Fall through to mtime below
+		}
+		try {
+			const mtime = statSync(path).mtime.toISOString();
+			return { last_sync: mtime, last_sync_source: "state_file_mtime" };
+		} catch {
+			return { last_sync: null, last_sync_source: "unavailable" };
+		}
+	}
+}

--- a/packages/pipeline/src/cli.ts
+++ b/packages/pipeline/src/cli.ts
@@ -317,6 +317,11 @@ async function ingest() {
 	console.log(`Blocks:   ${result.blocksInserted}`);
 	console.log(`Versions: ${result.versionsInserted}`);
 	console.log(`Reforms:  ${result.reformsInserted}`);
+	if (result.reformsRejected > 0) {
+		console.warn(
+			`Reforms rejected (implausible date): ${result.reformsRejected}`,
+		);
+	}
 
 	if (result.errors.length > 0) {
 		console.error(`Errors: ${result.errors.length}`);

--- a/packages/pipeline/src/db/ingest.ts
+++ b/packages/pipeline/src/db/ingest.ts
@@ -7,6 +7,7 @@
 
 import type { Database } from "bun:sqlite";
 import { Glob } from "bun";
+import { isPlausibleReformDate } from "../utils/date.ts";
 
 const DEFAULT_BATCH_SIZE = 100;
 
@@ -80,6 +81,8 @@ export interface IngestResult {
 	blocksInserted: number;
 	versionsInserted: number;
 	reformsInserted: number;
+	/** Reforms rejected for having an implausible date (outside [1800-01-01, today+5y]). */
+	reformsRejected: number;
 	errors: string[];
 	duration: number;
 }
@@ -169,6 +172,7 @@ export async function ingestJsonDir(
 		blocksInserted: 0,
 		versionsInserted: 0,
 		reformsInserted: 0,
+		reformsRejected: 0,
 		errors: [],
 		duration: 0,
 	};
@@ -375,6 +379,24 @@ export async function ingestJsonDir(
 					}
 
 					for (const reform of reforms) {
+						// Reject (not silently drop) reforms with implausible dates —
+						// the BOE feed has produced garbage like `2929-11-19` in
+						// production, which contaminates MAX(reforms.date) and any
+						// "last reform" freshness signal downstream. Loud warning so
+						// operators see it in the ingest logs, not a quiet skip.
+						if (!isPlausibleReformDate(reform.date)) {
+							result.reformsRejected++;
+							// Counted separately, NOT pushed to result.errors: bad
+							// source data is not an ingest failure, and folding it
+							// into the error count makes a healthy run report
+							// "Errors: 1" forever. The CLI prints reformsRejected
+							// on its own line.
+							console.warn(
+								`  [WARN] Rejected implausible reform date "${reform.date}" for norm ${metadata.id} (source ${reform.sourceId}) — outside plausible range`,
+							);
+							continue;
+						}
+
 						insertReform.run({
 							$normId: metadata.id,
 							$date: reform.date,

--- a/packages/pipeline/src/db/schema.ts
+++ b/packages/pipeline/src/db/schema.ts
@@ -70,6 +70,13 @@ const SCHEMA_SQL = /* sql */ `
   CREATE INDEX IF NOT EXISTS idx_norms_country ON norms(country);
   CREATE INDEX IF NOT EXISTS idx_norms_rank ON norms(rank);
   CREATE INDEX IF NOT EXISTS idx_norms_status ON norms(status);
+  -- Issue #128: exact-reference fast path in the search API resolves queries
+  -- like "Real Decreto 1312/2024" and ELI URLs through these two columns.
+  -- DbService also creates them lazily so existing databases get them without
+  -- a migration, but the schema is the source of truth: scripts that build a
+  -- database without going through DbService need them too.
+  CREATE INDEX IF NOT EXISTS idx_norms_short_title ON norms(short_title);
+  CREATE INDEX IF NOT EXISTS idx_norms_source_url ON norms(source_url);
   CREATE INDEX IF NOT EXISTS idx_blocks_norm ON blocks(norm_id);
   CREATE INDEX IF NOT EXISTS idx_versions_norm_block ON versions(norm_id, block_id);
   CREATE INDEX IF NOT EXISTS idx_reforms_norm ON reforms(norm_id);

--- a/packages/pipeline/src/db/schema.ts
+++ b/packages/pipeline/src/db/schema.ts
@@ -70,8 +70,8 @@ const SCHEMA_SQL = /* sql */ `
   CREATE INDEX IF NOT EXISTS idx_norms_country ON norms(country);
   CREATE INDEX IF NOT EXISTS idx_norms_rank ON norms(rank);
   CREATE INDEX IF NOT EXISTS idx_norms_status ON norms(status);
-  -- Issue #128: exact-reference fast path in the search API resolves queries
-  -- like "Real Decreto 1312/2024" and ELI URLs through these two columns.
+  -- The search API's exact-reference fast path resolves citations like
+  -- "Real Decreto 1312/2024" and ELI URLs through these two columns.
   -- DbService also creates them lazily so existing databases get them without
   -- a migration, but the schema is the source of truth: scripts that build a
   -- database without going through DbService need them too.

--- a/packages/pipeline/src/utils/date.ts
+++ b/packages/pipeline/src/utils/date.ts
@@ -30,3 +30,44 @@ export function parseBoeDate(raw: string | undefined): string | undefined {
 	}
 	return undefined;
 }
+
+/** Earliest plausible date for a reform (nothing in force before this). */
+export const MIN_PLAUSIBLE_REFORM_DATE = "1800-01-01";
+
+/**
+ * Latest plausible date for a reform: today + 5 years. Computed relative to
+ * `now` (default: current time) so tests can pin it.
+ */
+export function maxPlausibleReformDate(now: Date = new Date()): string {
+	const d = new Date(now.getTime());
+	d.setUTCFullYear(d.getUTCFullYear() + 5);
+	return d.toISOString().slice(0, 10);
+}
+
+/**
+ * Validate that a reform date is both a real calendar date (rejects things
+ * like Feb 30 via the ISO round-trip check) AND falls within a plausible
+ * range: [1800-01-01, today + 5 years].
+ *
+ * Exists because the BOE feed has been observed to emit corrupt dates (a
+ * production reform row was seen with `2929-11-19`) that pass basic ISO
+ * format checks but are obvious nonsense. Rejecting them here — at ingest —
+ * keeps `MAX(reforms.date)` and similar aggregates from being contaminated
+ * at the source, instead of relying on every downstream query to filter
+ * them out individually.
+ */
+export function isPlausibleReformDate(
+	dateStr: string,
+	now: Date = new Date(),
+): boolean {
+	if (!/^\d{4}-\d{2}-\d{2}$/.test(dateStr)) return false;
+	const d = new Date(`${dateStr}T00:00:00Z`);
+	if (Number.isNaN(d.getTime())) return false;
+	// Round-trip through ISO to reject calendar rollovers (e.g. 2024-02-30 ->
+	// 2024-03-01 would not match the original string).
+	if (d.toISOString().slice(0, 10) !== dateStr) return false;
+	return (
+		dateStr >= MIN_PLAUSIBLE_REFORM_DATE &&
+		dateStr <= maxPlausibleReformDate(now)
+	);
+}

--- a/packages/pipeline/tests/date-validation.test.ts
+++ b/packages/pipeline/tests/date-validation.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Unit tests for isPlausibleReformDate / maxPlausibleReformDate.
+ *
+ * Motivated by a real production incident: the `reforms` table contains a
+ * row with date `2929-11-19` sourced verbatim from the BOE feed. It passes
+ * basic ISO format checks but is obvious garbage and contaminates
+ * MAX(reforms.date) (see issue #129).
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+	isPlausibleReformDate,
+	MIN_PLAUSIBLE_REFORM_DATE,
+	maxPlausibleReformDate,
+} from "../src/utils/date.ts";
+
+const FIXED_NOW = new Date("2026-07-23T12:00:00Z");
+
+describe("isPlausibleReformDate", () => {
+	// ── Valid dates ──────────────────────────────────────────────────────
+
+	test("accepts a normal recent reform date", () => {
+		expect(isPlausibleReformDate("2026-07-18", FIXED_NOW)).toBe(true);
+	});
+
+	test("accepts the earliest allowed date", () => {
+		expect(isPlausibleReformDate(MIN_PLAUSIBLE_REFORM_DATE, FIXED_NOW)).toBe(
+			true,
+		);
+	});
+
+	test("accepts a historical date (1978 Constitution)", () => {
+		expect(isPlausibleReformDate("1978-12-29", FIXED_NOW)).toBe(true);
+	});
+
+	test("accepts a date up to 5 years in the future", () => {
+		expect(isPlausibleReformDate("2031-07-23", FIXED_NOW)).toBe(true);
+	});
+
+	// ── The real corrupt-data incident ──────────────────────────────────
+
+	test("rejects the known corrupt production date 2929-11-19", () => {
+		expect(isPlausibleReformDate("2929-11-19", FIXED_NOW)).toBe(false);
+	});
+
+	// ── Out of range ─────────────────────────────────────────────────────
+
+	test("rejects a date before 1800", () => {
+		expect(isPlausibleReformDate("1799-12-31", FIXED_NOW)).toBe(false);
+	});
+
+	test("rejects a date more than 5 years in the future", () => {
+		expect(isPlausibleReformDate("2032-01-01", FIXED_NOW)).toBe(false);
+	});
+
+	// ── Malformed / invalid calendar dates ───────────────────────────────
+
+	test("rejects Feb 30", () => {
+		expect(isPlausibleReformDate("2024-02-30", FIXED_NOW)).toBe(false);
+	});
+
+	test("rejects Feb 29 in a non-leap year", () => {
+		expect(isPlausibleReformDate("2023-02-29", FIXED_NOW)).toBe(false);
+	});
+
+	test("rejects malformed string", () => {
+		expect(isPlausibleReformDate("20260718", FIXED_NOW)).toBe(false);
+	});
+
+	test("rejects empty string", () => {
+		expect(isPlausibleReformDate("", FIXED_NOW)).toBe(false);
+	});
+
+	test("rejects random text", () => {
+		expect(isPlausibleReformDate("not-a-date", FIXED_NOW)).toBe(false);
+	});
+});
+
+describe("maxPlausibleReformDate", () => {
+	test("is exactly 5 years after `now`", () => {
+		expect(maxPlausibleReformDate(FIXED_NOW)).toBe("2031-07-23");
+	});
+});

--- a/packages/pipeline/tests/ingest.test.ts
+++ b/packages/pipeline/tests/ingest.test.ts
@@ -189,6 +189,70 @@ describe("ingestJsonDir", () => {
 		expect(reformBlocks).toHaveLength(3);
 	});
 
+	test("rejects reform with implausible date (2929-11-19) but keeps valid reforms", async () => {
+		// Regression test for the real production incident behind issue #129:
+		// the BOE feed produced a reform dated 2929-11-19 for a norm, which
+		// contaminated MAX(reforms.date) downstream. Ingest must reject it
+		// loudly (logged + counted) rather than insert it silently.
+		const norm = makeNormJson({
+			reforms: [
+				{
+					date: "2024-06-01",
+					sourceId: "BOE-A-2024-5678",
+					affectedBlocks: ["art-1"],
+				},
+				{
+					date: "2929-11-19",
+					sourceId: "BOE-A-2929-99999",
+					affectedBlocks: ["art-1"],
+				},
+			],
+		});
+		await writeFile(
+			join(tempDir, "BOE-A-2024-1234.json"),
+			JSON.stringify(norm),
+		);
+
+		const result = await ingestJsonDir(db, tempDir);
+
+		expect(result.reformsInserted).toBe(1);
+		expect(result.reformsRejected).toBe(1);
+		// Bad source data is NOT an ingest error: it gets its own counter and a
+		// loud warning, but must not inflate result.errors — otherwise a
+		// perfectly healthy run reports "Errors: 1" every single night.
+		expect(result.errors.some((e) => e.includes("2929-11-19"))).toBe(false);
+
+		const reforms = db
+			.query("SELECT * FROM reforms WHERE norm_id = 'BOE-A-2024-1234'")
+			.all() as Array<Record<string, unknown>>;
+		expect(reforms).toHaveLength(1);
+		expect(reforms[0]?.date).toBe("2024-06-01");
+	});
+
+	test("rejects reform with date before 1800", async () => {
+		const norm = makeNormJson({
+			reforms: [
+				{
+					date: "1799-01-01",
+					sourceId: "BOE-A-1799-1",
+					affectedBlocks: ["art-1"],
+				},
+			],
+		});
+		await writeFile(
+			join(tempDir, "BOE-A-2024-1234.json"),
+			JSON.stringify(norm),
+		);
+
+		const result = await ingestJsonDir(db, tempDir);
+
+		expect(result.reformsInserted).toBe(0);
+		expect(result.reformsRejected).toBe(1);
+
+		const reforms = db.query("SELECT * FROM reforms").all();
+		expect(reforms).toHaveLength(0);
+	});
+
 	test("populates FTS5 index and search by title works", async () => {
 		const norm = makeNormJson();
 		await writeFile(

--- a/packages/web/src/layouts/Base.astro
+++ b/packages/web/src/layouts/Base.astro
@@ -218,12 +218,12 @@ const resolvedOgUrl = resolvedCanonicalUrl ?? `${SITE_URL}${Astro.url.pathname}`
 			min-height: 100vh;
 		}
 
-		main { flex: 1; }
+		main { flex: 1; min-width: 0; }
 
 		a { color: var(--accent-light); text-decoration: none; }
 		a:hover { text-decoration: underline; }
 
-		.container { max-width: var(--max-w); margin: 0 auto; padding: 0 1.25rem; }
+		.container { max-width: var(--max-w); width: 100%; min-width: 0; margin: 0 auto; padding: 0 1.25rem; }
 
 		/* ── Footer ── */
 		footer {
@@ -295,6 +295,8 @@ const resolvedOgUrl = resolvedCanonicalUrl ?? `${SITE_URL}${Astro.url.pathname}`
 			border: 1.5px solid var(--border);
 			background: var(--surface);
 			color: var(--text-secondary);
+			font-family: var(--font-sans);
+			min-height: 44px;
 			cursor: pointer;
 			transition: border-color 0.2s var(--ease-out-quart), color 0.2s var(--ease-out-quart), background 0.2s var(--ease-out-quart), opacity 0.15s var(--ease-out-quart);
 		}
@@ -312,9 +314,11 @@ const resolvedOgUrl = resolvedCanonicalUrl ?? `${SITE_URL}${Astro.url.pathname}`
 		.pagination {
 			margin-top: 1.5rem;
 			display: flex;
+			flex-wrap: wrap;
 			justify-content: center;
 			align-items: center;
 			gap: 0.25rem;
+			row-gap: 0.5rem;
 			font-size: 0.8125rem;
 		}
 		.page-num {
@@ -418,6 +422,8 @@ const resolvedOgUrl = resolvedCanonicalUrl ?? `${SITE_URL}${Astro.url.pathname}`
 		.prose td { color: var(--text-secondary); }
 		.prose tr:nth-child(even) td { background: var(--bg); }
 		.prose > :first-child { margin-top: 0; }
+		.prose .table-scroll { overflow-x: auto; -webkit-overflow-scrolling: touch; margin: 1.5em 0; }
+		.prose .table-scroll table { margin: 0; min-width: 480px; }
 
 		/* ── Screen reader only (a11y) ── */
 		.sr-only {

--- a/packages/web/src/pages/aviso-legal.astro
+++ b/packages/web/src/pages/aviso-legal.astro
@@ -14,8 +14,7 @@ import Legal from "../layouts/Legal.astro";
 		<p>
 			Ley Abierta es un proyecto personal de <strong>Alejandro Martínez</strong>,
 			de código abierto y sin ánimo de lucro. No constituye una entidad jurídica
-			ni una empresa. Puedes conocer más sobre el proyecto en la página
-			<a href="/sobre/">Sobre Ley Abierta</a>.
+			ni una empresa. Puedes conocer más sobre el proyecto en la página <a href="/sobre/">Sobre Ley Abierta</a>.
 		</p>
 		<ul>
 			<li><strong>Responsable:</strong> Alejandro Martínez</li>
@@ -36,8 +35,7 @@ import Legal from "../layouts/Legal.astro";
 		<p>
 			Los textos legislativos reproducidos en este sitio son de <strong>dominio público</strong>,
 			conforme al artículo 13 del Real Decreto Legislativo 1/1996 (Ley de Propiedad Intelectual).
-			La fuente oficial y de referencia es siempre el
-			<a href="https://www.boe.es" target="_blank" rel="noopener">Boletín Oficial del Estado</a>.
+			La fuente oficial y de referencia es siempre el <a href="https://www.boe.es" target="_blank" rel="noopener">Boletín Oficial del Estado</a>.
 		</p>
 		<p>
 			Ley Abierta no sustituye al BOE ni tiene carácter oficial. En caso de discrepancia,
@@ -46,8 +44,7 @@ import Legal from "../layouts/Legal.astro";
 
 		<h2>Propiedad intelectual</h2>
 		<p>
-			El código fuente de Ley Abierta se distribuye bajo la
-			<a href="https://www.gnu.org/licenses/agpl-3.0.html" target="_blank" rel="noopener">licencia AGPL-3.0</a>.
+			El código fuente de Ley Abierta se distribuye bajo la <a href="https://www.gnu.org/licenses/agpl-3.0.html" target="_blank" rel="noopener">licencia AGPL-3.0</a>.
 			El contenido legislativo es de dominio público. Los elementos de diseño y marca (logo,
 			nombre "Ley Abierta") son propiedad de sus autores.
 		</p>

--- a/packages/web/src/pages/cambios/para-mi/index.astro
+++ b/packages/web/src/pages/cambios/para-mi/index.astro
@@ -591,7 +591,7 @@ import Base from "../../../layouts/Base.astro";
 							if (!loadMoreBtn) {
 								loadMoreBtn = document.createElement("button");
 								loadMoreBtn.type = "button";
-								loadMoreBtn.className = "btn btn-back";
+								loadMoreBtn.className = "btn";
 								loadMoreBtn.textContent = "Ver más";
 								loadMoreBtn.style.display = "block";
 								loadMoreBtn.style.margin = "1.5rem auto 0";

--- a/packages/web/src/pages/cambios/recientes.astro
+++ b/packages/web/src/pages/cambios/recientes.astro
@@ -46,6 +46,7 @@ import Base from "../../layouts/Base.astro";
 			color: var(--text);
 			font-size: 0.875rem;
 			font-family: var(--font-sans);
+			min-height: 44px;
 		}
 		.cambios-info {
 			font-size: 0.8125rem;
@@ -148,11 +149,13 @@ import Base from "../../layouts/Base.astro";
 			font-size: 0.75rem;
 			color: var(--text-muted);
 			font-family: var(--font-mono);
+			white-space: nowrap;
 		}
 		.reform-type-badge {
 			font-size: 0.6875rem;
 			font-weight: 500;
 			color: var(--text-muted);
+			white-space: nowrap;
 		}
 		.reform-importance-badge {
 			font-size: 0.6875rem;
@@ -197,6 +200,8 @@ import Base from "../../layouts/Base.astro";
 			font-size: 0.8125rem;
 			color: var(--accent-light);
 			font-weight: 500;
+			display: inline-block;
+			padding: 0.5rem 0;
 		}
 		.reform-link:hover {
 			text-decoration: underline;
@@ -321,6 +326,21 @@ import Base from "../../layouts/Base.astro";
 
 			function esc(s) { return String(s).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;"); }
 
+			var MONTHS = ["ene", "feb", "mar", "abr", "may", "jun", "jul", "ago", "sep", "oct", "nov", "dic"];
+
+			function formatDateRange(range) {
+				if (!range) return "";
+				var parts = range.split(" to ");
+				if (parts.length !== 2) return range;
+				var d1 = new Date(parts[0] + "T00:00:00");
+				var d2 = new Date(parts[1] + "T00:00:00");
+				if (isNaN(d1.getTime()) || isNaN(d2.getTime())) return range;
+				var y1 = d1.getFullYear(), y2 = d2.getFullYear();
+				var s1 = d1.getDate() + " " + MONTHS[d1.getMonth()] + (y1 !== y2 ? " " + y1 : "");
+				var s2 = d2.getDate() + " " + MONTHS[d2.getMonth()] + " " + y2;
+				return s1 + " – " + s2;
+			}
+
 			var API = document.documentElement.dataset.api;
 			var contentDiv = document.getElementById("cambios-content");
 			var infoDiv = document.getElementById("cambios-info");
@@ -340,7 +360,7 @@ import Base from "../../layouts/Base.astro";
 					.then(function (data) {
 						if (!data.reforms || data.reforms.length === 0) {
 							contentDiv.innerHTML = '<div class="empty-state"><h2>No hay cambios recientes</h2><p>No se han encontrado modificaciones legislativas en este período.</p></div>';
-							infoDiv.textContent = data.date_range || "";
+							infoDiv.textContent = formatDateRange(data.date_range);
 							return;
 						}
 
@@ -357,7 +377,7 @@ import Base from "../../layouts/Base.astro";
 							return;
 						}
 
-						infoDiv.textContent = validReforms.length + " cambios · " + (data.date_range || "");
+						infoDiv.textContent = validReforms.length + " cambios · " + formatDateRange(data.date_range);
 
 						var html = '<div class="reform-timeline">';
 						for (var i = 0; i < validReforms.length; i++) {

--- a/packages/web/src/pages/cambios/reforma/index.astro
+++ b/packages/web/src/pages/cambios/reforma/index.astro
@@ -92,10 +92,12 @@ import Base from "../../../layouts/Base.astro";
 			display: grid; grid-template-columns: 1fr 1fr; gap: 0.625rem;
 			margin-bottom: 0.75rem;
 		}
+		.diff-mod-pair > * { min-width: 0; }
 		.diff-para {
 			font-size: 0.8125rem; line-height: 1.65; color: var(--text-secondary);
 			padding: 0.625rem 0.75rem; border-radius: 6px;
 			font-family: var(--font-serif);
+			overflow-wrap: break-word; word-break: break-word;
 		}
 		.diff-para-removed { background: #fbeaea; }
 		.diff-para-added { background: #e8f5ec; }

--- a/packages/web/src/pages/cookies.astro
+++ b/packages/web/src/pages/cookies.astro
@@ -24,6 +24,7 @@ import Legal from "../layouts/Legal.astro";
 			cookies de seguimiento ni publicitarias.</strong>
 		</p>
 
+		<div class="table-scroll">
 		<table class="legal-table">
 			<thead>
 				<tr>
@@ -42,6 +43,7 @@ import Legal from "../layouts/Legal.astro";
 				</tr>
 			</tbody>
 		</table>
+		</div>
 
 		<p>
 			Nota: la preferencia de tema se almacena en <code>localStorage</code>, una tecnología
@@ -52,8 +54,7 @@ import Legal from "../layouts/Legal.astro";
 		<h2>Cookies de terceros</h2>
 		<p>
 			<strong>Cloudflare Web Analytics</strong> — Utilizamos este servicio para obtener
-			estadísticas anónimas de uso del sitio. Cloudflare Web Analytics
-			<strong>no utiliza cookies</strong> ni recoge datos personales.
+			estadísticas anónimas de uso del sitio. Cloudflare Web Analytics <strong>no utiliza cookies</strong> ni recoge datos personales.
 		</p>
 		<p>
 			<strong>Cloudflare</strong> — Como servicio de alojamiento y CDN, Cloudflare puede
@@ -77,11 +78,9 @@ import Legal from "../layouts/Legal.astro";
 
 		<h2>Más información</h2>
 		<p>
-			Si tienes dudas sobre nuestra política de cookies, puedes contactarnos en
-			<strong>contacto@leyabierta.es</strong>.
+			Si tienes dudas sobre nuestra política de cookies, puedes contactarnos en <strong>contacto@leyabierta.es</strong>.
 		</p>
 		<p>
-			Para más información sobre tus derechos, consulta nuestra
-			<a href="/privacidad/">política de privacidad</a>.
+			Para más información sobre tus derechos, consulta nuestra <a href="/privacidad/">política de privacidad</a>.
 		</p>
 </Legal>

--- a/packages/web/src/pages/index.astro
+++ b/packages/web/src/pages/index.astro
@@ -71,7 +71,7 @@ const TOPICS = [
 <Base
 	fullWidth
 	title="Las leyes de España, accesibles para todos"
-	description={`Más de ${totalNorms.toLocaleString("es")} leyes españolas. Consulta cualquier ley, entiende qué cambió y cuándo.`}
+	description={`Más de ${totalNorms.toLocaleString("es", { useGrouping: "always" })} leyes españolas. Consulta cualquier ley, entiende qué cambió y cuándo.`}
 	ogTitle="Ley Abierta — Las leyes de España, accesibles para todos"
 	canonicalUrl="/"
 >
@@ -117,8 +117,10 @@ const TOPICS = [
 			padding: 0.375rem 0.375rem 0.375rem 1.125rem;
 		}
 		.search-box svg { width: 18px; height: 18px; color: var(--text-muted); flex: 0 0 auto; }
+		.search-field { display: flex; align-items: center; gap: 0.625rem; flex: 1; min-width: 0; }
 		.search-box input {
 			flex: 1;
+			min-width: 0;
 			border: none;
 			background: transparent;
 			padding: 0.875rem 0.25rem;
@@ -189,6 +191,11 @@ const TOPICS = [
 		.stat-label { font-size: 0.8125rem; color: var(--text-muted); margin-top: 0.125rem; }
 		.stat-divider { width: 1px; background: var(--border-light); }
 
+		/* Compact hero while search results are shown — keeps results right under the search box */
+		.hero.search-active .hero-lede,
+		.hero.search-active .stats-rail { display: none; }
+		.hero.search-active { padding-bottom: 2rem; }
+
 		/* ── Sections ── */
 		.la-section { max-width: 77.5rem; margin: 0 auto; padding: 5rem 3rem 0; }
 		.section-header {
@@ -209,6 +216,10 @@ const TOPICS = [
 		}
 		.section-header .see-all { font-size: 0.8125rem; color: var(--accent); font-weight: 500; }
 		.section-header .see-all:hover { text-decoration: underline; }
+
+		/* Freshness note — under "Cambios recientes", tells citizens when the data was last synced with the BOE */
+		.freshness-note { font-size: 0.8125rem; color: var(--text-muted); line-height: 1.5; margin: -1rem 0 1.25rem; }
+		.freshness-note strong { color: var(--text-secondary); font-weight: 600; }
 
 		/* ── Regions ── */
 		.region-layout { display: grid; grid-template-columns: 1.15fr 1fr; gap: 2.5rem; align-items: start; }
@@ -469,6 +480,7 @@ const TOPICS = [
 		.cta-box svg { width: 20px; height: 20px; color: var(--text-secondary); flex: 0 0 auto; }
 		.cta-box input {
 			flex: 1;
+			min-width: 0;
 			border: none;
 			background: transparent;
 			padding: 0.875rem 0.25rem;
@@ -531,8 +543,8 @@ const TOPICS = [
 			.hero h1 { font-size: 1.75rem; }
 			.search-box { flex-direction: column; padding: 0.75rem; }
 			.search-box .search-btn { width: 100%; justify-content: center; }
-			.stats-rail { flex-direction: column; gap: 0.75rem; padding: 1rem 0; }
-			.stat { flex: 1; }
+			.cta-box { flex-direction: column; align-items: stretch; padding: 0.75rem; }
+			.cta-box button { width: 100%; justify-content: center; }
 			.region-list li { grid-template-columns: 1fr 2.5rem; }
 			.region-list .bar-wrap { display: none; }
 		}
@@ -620,14 +632,16 @@ const TOPICS = [
 			<div class="hero-eyebrow">Legislación española · Acceso libre</div>
 			<h1>Las leyes de España,<br><em>accesibles para todos.</em></h1>
 			<p class="hero-lede">
-				Más de {totalNorms.toLocaleString("es")} leyes desde {earliestYear}, actualizadas cada día. Busca cualquier ley,
+				Más de {totalNorms.toLocaleString("es", { useGrouping: "always" })} leyes desde {earliestYear}, actualizadas cada día. Busca cualquier ley,
 				consulta su texto completo y mira cómo ha cambiado con el tiempo.
 			</p>
 
 			<div class="search-wrap">
 				<div class="search-box">
-					<svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8"><circle cx="9" cy="9" r="6"/><path d="m14 14 4 4" stroke-linecap="round"/></svg>
-					<input type="search" id="search-input" placeholder="Busca una ley, un artículo o una materia…" aria-label="Buscar leyes" />
+					<div class="search-field">
+						<svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8"><circle cx="9" cy="9" r="6"/><path d="m14 14 4 4" stroke-linecap="round"/></svg>
+						<input type="search" id="search-input" placeholder="Busca una ley, un artículo o una materia…" aria-label="Buscar leyes" />
+					</div>
 					<button type="button" class="search-btn" id="search-btn">
 						Buscar
 						<svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M4 10h12m-4-4 4 4-4 4" stroke-linecap="round" stroke-linejoin="round"/></svg>
@@ -644,7 +658,7 @@ const TOPICS = [
 
 			<div class="stats-rail">
 				<div class="stat">
-					<div class="stat-num">{totalNorms.toLocaleString("es")}</div>
+					<div class="stat-num">{totalNorms.toLocaleString("es", { useGrouping: "always" })}</div>
 					<div class="stat-label">leyes consolidadas</div>
 				</div>
 				<div class="stat-divider"></div>
@@ -654,7 +668,7 @@ const TOPICS = [
 				</div>
 				<div class="stat-divider"></div>
 				<div class="stat">
-					<div class="stat-num">{vigentes.toLocaleString("es")}</div>
+					<div class="stat-num">{vigentes.toLocaleString("es", { useGrouping: "always" })}</div>
 					<div class="stat-label">vigentes</div>
 				</div>
 				<div class="stat-divider"></div>
@@ -733,7 +747,7 @@ const TOPICS = [
 								<li data-jurisdiction={j.jurisdiction}>
 									<span class="name">{JURISDICTION_LABELS[j.jurisdiction] ?? j.jurisdiction}</span>
 									<div class="bar-wrap"><div class="bar" style={`width:${pct}%`}></div></div>
-									<span class="count">{j.count.toLocaleString("es")}</span>
+									<span class="count">{j.count.toLocaleString("es", { useGrouping: "always" })}</span>
 								</li>
 							);
 						})}
@@ -804,6 +818,7 @@ const TOPICS = [
 						<h2>Cambios recientes</h2>
 						<a href="/cambios/" class="see-all">Historial completo &rarr;</a>
 					</div>
+					<p class="freshness-note" id="freshness-note" style="display:none"></p>
 					<div id="recent-reforms">
 						<div style="text-align:center;padding:2rem;color:var(--text-muted);font-size:0.875rem">
 							<span class="loading-spinner"></span> Cargando...
@@ -874,8 +889,10 @@ const TOPICS = [
 					situación y te decimos qué ley se aplica.
 				</p>
 				<div class="cta-box">
-					<svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8"><circle cx="9" cy="9" r="6"/><path d="m14 14 4 4" stroke-linecap="round"/></svg>
-					<input type="search" id="cta-search-input" placeholder="Busca una ley…" aria-label="Buscar leyes" />
+					<div class="search-field">
+						<svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8"><circle cx="9" cy="9" r="6"/><path d="m14 14 4 4" stroke-linecap="round"/></svg>
+						<input type="search" id="cta-search-input" placeholder="Busca una ley…" aria-label="Buscar leyes" />
+					</div>
 					<button type="button" id="cta-search-btn">Buscar</button>
 				</div>
 				<div class="cta-links">
@@ -903,6 +920,11 @@ const TOPICS = [
 		var currentPage = 1;
 		var currentCountry = "";
 		var currentSort = "";
+
+		// Shorter placeholder on narrow screens so it doesn't get cut mid-word.
+		if (searchInput && window.innerWidth <= 480) {
+			searchInput.placeholder = "Busca una ley…";
+		}
 		var LIMIT = 20;
 
 		// Topic chips
@@ -1039,9 +1061,12 @@ const TOPICS = [
 				resultsSection.style.display = "none";
 				landingDiv.style.display = "block";
 				if (searchHints) searchHints.style.display = "";
+				if (heroSection) heroSection.classList.remove("search-active");
 				history.replaceState(null, "", "/");
 				return;
 			}
+
+			if (heroSection) heroSection.classList.add("search-active");
 
 			if (searchHints) searchHints.style.display = "none";
 
@@ -1104,7 +1129,7 @@ const TOPICS = [
 
 					var hasQuery = searchInput.value.trim();
 					html += '<div class="results-header">';
-					var totalLabel = result.capped ? 'más de ' + result.total.toLocaleString("es") : result.total.toLocaleString("es");
+					var totalLabel = result.capped ? 'más de ' + result.total.toLocaleString("es", { useGrouping: "always" }) : result.total.toLocaleString("es", { useGrouping: "always" });
 					html += '<span class="results-info">Mostrando ' + (offset + 1) + '–' + Math.min(offset + LIMIT, result.total) + ' de ' + totalLabel + '</span>';
 					html += '<select class="sort-select" id="sort-select">';
 					html += '<option value=""' + (currentSort === "" ? ' selected' : '') + '>' + (hasQuery ? 'Más relevantes' : 'Más recientes') + '</option>';
@@ -1256,6 +1281,28 @@ const TOPICS = [
 			document.getElementById("recent-reforms").innerHTML = html;
 		}).catch(function () {
 			document.getElementById("recent-reforms").parentElement.style.display = "none";
+		});
+
+		// Freshness note: when did we last sync with the BOE? Degrades silently if /v1/status
+		// doesn't exist yet or fails — the note simply stays hidden, no gaps or console errors.
+		fetch(API + "/v1/status").then(function (r) {
+			if (!r.ok) throw new Error("status endpoint unavailable");
+			return r.json();
+		}).then(function (data) {
+			var isoDate = data && (data.last_reform_date || data.corpus_max_published_at);
+			if (!isoDate) return;
+			var d = new Date(isoDate + "T00:00:00");
+			if (isNaN(d.getTime())) return;
+			var months = ["enero", "febrero", "marzo", "abril", "mayo", "junio", "julio", "agosto", "septiembre", "octubre", "noviembre", "diciembre"];
+			var formatted = d.getDate() + " de " + months[d.getMonth()] + " de " + d.getFullYear();
+			var note = document.getElementById("freshness-note");
+			if (!note) return;
+			note.innerHTML = "Actualizado con el BOE el <strong>" + formatted + "</strong>. " +
+				"El Boletín Oficial del Estado tarda unos días en publicar el texto ya actualizado de cada ley, " +
+				"así que es normal que la fecha más reciente no sea la de hoy.";
+			note.style.display = "block";
+		}).catch(function () {
+			// No endpoint yet, or it failed: leave the note hidden, home looks exactly as before.
 		});
 
 		}); // end requestIdleCallback

--- a/packages/web/src/pages/leyes/[id].astro
+++ b/packages/web/src/pages/leyes/[id].astro
@@ -605,7 +605,7 @@ const seoDescription = [
 			font-size: 0.8125rem;
 			font-weight: 500;
 			color: var(--accent);
-			padding: 0.15rem 0;
+			padding: 0.875rem 0;
 			user-select: none;
 		}
 		:global(.law-content .article-summary-toggle::-webkit-details-marker) {
@@ -671,7 +671,7 @@ const seoDescription = [
 		.timeline-item:first-child .timeline-dot { border-color: var(--accent); background: var(--accent); }
 		.timeline-date { font-weight: 600; font-size: 0.8125rem; }
 		.timeline-detail { font-size: 0.75rem; color: var(--text-muted); margin-top: 0.125rem; }
-		.timeline-link { font-size: 0.75rem; margin-top: 0.25rem; display: inline-block; }
+		.timeline-link { font-size: 0.75rem; margin-top: 0.25rem; display: inline-block; padding: 0.8rem 0; margin-bottom: -0.8rem; }
 
 		/* ── Follow card ── */
 		.follow-card {

--- a/packages/web/src/pages/mi-situacion.astro
+++ b/packages/web/src/pages/mi-situacion.astro
@@ -117,6 +117,12 @@ const JURISDICTION_OPTIONS = [
 			line-height: 1.2;
 			margin-bottom: 0.375rem;
 		}
+		/* This heading only receives programmatic focus (tabindex="-1") as an
+		   anchor for screen readers moving between steps — it isn't
+		   interactive for sighted users, so the default focus ring is noise. */
+		.step-heading:focus {
+			outline: none;
+		}
 		.step-subtitle {
 			color: var(--text-secondary);
 			font-size: 0.9rem;
@@ -396,6 +402,7 @@ const JURISDICTION_OPTIONS = [
 			cursor: pointer;
 			padding: 0.5rem 0.75rem;
 			min-height: 48px;
+			white-space: nowrap;
 			transition: color 0.15s;
 		}
 		.btn-skip:hover {
@@ -427,12 +434,17 @@ const JURISDICTION_OPTIONS = [
 			.btn-next {
 				max-width: none;
 				flex: 1;
+				min-width: 0;
 			}
 			.btn-back {
 				flex-shrink: 0;
+				min-width: 0;
+			}
+			.btn-skip {
+				min-width: 0;
 			}
 			.wizard-nav {
-				flex-wrap: nowrap;
+				flex-wrap: wrap;
 			}
 		}
 	</style>

--- a/packages/web/src/pages/pregunta.astro
+++ b/packages/web/src/pages/pregunta.astro
@@ -121,6 +121,16 @@ import AskChat from "../components/AskChat.tsx";
 		border-top: 2px solid var(--border);
 	}
 
+	/* On mobile, a sticky composer covers the tail end of the answer while
+	   the user scrolls to read it. Let it flow in the document instead. */
+	@media (max-width: 640px) {
+		:global(.ask-input-sticky) {
+			position: static;
+			bottom: auto;
+			box-shadow: none;
+		}
+	}
+
 	:global(.ask-textarea) {
 		width: 100%;
 		border: none;
@@ -160,6 +170,7 @@ import AskChat from "../components/AskChat.tsx";
 		gap: 0.4rem;
 		font-size: 0.8125rem;
 		padding: 0.4rem 0.875rem;
+		min-height: 44px;
 	}
 
 	:global(.ask-submit:disabled) {
@@ -836,6 +847,8 @@ import AskChat from "../components/AskChat.tsx";
 		align-items: center;
 		gap: 0.625rem;
 		padding: 0.5rem 0.75rem;
+		min-height: 44px;
+		box-sizing: border-box;
 		color: inherit;
 		text-decoration: none;
 	}

--- a/packages/web/src/pages/privacidad.astro
+++ b/packages/web/src/pages/privacidad.astro
@@ -27,6 +27,7 @@ import Legal from "../layouts/Legal.astro";
 			salvo lo indicado en esta política.
 		</p>
 
+		<div class="table-scroll">
 		<table >
 			<thead>
 				<tr>
@@ -69,6 +70,7 @@ import Legal from "../layouts/Legal.astro";
 				</tr>
 			</tbody>
 		</table>
+		</div>
 
 		<h2>Alertas legislativas</h2>
 		<p>
@@ -95,8 +97,7 @@ import Legal from "../layouts/Legal.astro";
 
 		<h3>Encargado de tratamiento: Resend</h3>
 		<p>
-			Para el envío de emails utilizamos <strong><a href="https://resend.com" target="_blank" rel="noopener">Resend</a></strong>
-			como encargado de tratamiento. Resend, Inc. es una empresa con sede en Estados Unidos
+			Para el envío de emails utilizamos <strong><a href="https://resend.com" target="_blank" rel="noopener">Resend</a></strong> como encargado de tratamiento. Resend, Inc. es una empresa con sede en Estados Unidos
 			que procesa los emails en nuestro nombre. La transferencia de datos se realiza bajo
 			cláusulas contractuales tipo aprobadas por la Comisión Europea. No compartimos tus
 			datos con ningún otro tercero.
@@ -104,8 +105,7 @@ import Legal from "../layouts/Legal.astro";
 
 		<h2>Analítica</h2>
 		<p>
-			Utilizamos <strong>Umami</strong>, un servicio de analítica web open source
-			<strong>auto-alojado en nuestros servidores en Alemania</strong> (Hetzner, Frankfurt).
+			Utilizamos <strong>Umami</strong>, un servicio de analítica web open source <strong>auto-alojado en nuestros servidores en Alemania</strong> (Hetzner, Frankfurt).
 			Umami se ha diseñado específicamente para respetar la privacidad:
 		</p>
 		<ul>
@@ -123,8 +123,7 @@ import Legal from "../layouts/Legal.astro";
 		<p>
 			Esta medición está <strong>exenta de consentimiento</strong> conforme a los criterios
 			de la AEPD para herramientas de medición de audiencia
-			(<a href="https://www.aepd.es/guias/guia-cookies.pdf" target="_blank" rel="noopener">Guía de cookies AEPD</a>;
-			<a href="https://www.aepd.es/guias/orientaciones-analitica-web-aapp.pdf" target="_blank" rel="noopener">Orientaciones para AAPP, febrero 2023</a>),
+			(<a href="https://www.aepd.es/guias/guia-cookies.pdf" target="_blank" rel="noopener">Guía de cookies AEPD</a>; <a href="https://www.aepd.es/guias/orientaciones-analitica-web-aapp.pdf" target="_blank" rel="noopener">Orientaciones para AAPP, febrero 2023</a>),
 			por lo que no mostramos banner de cookies.
 		</p>
 		<p>
@@ -145,8 +144,7 @@ import Legal from "../layouts/Legal.astro";
 			<li><strong>Limitación:</strong> solicitar la limitación del tratamiento.</li>
 		</ul>
 		<p>
-			Para ejercer cualquiera de estos derechos, escríbenos a
-			<strong>contacto@leyabierta.es</strong>. Responderemos en un plazo máximo de 30 días.
+			Para ejercer cualquiera de estos derechos, escríbenos a <strong>contacto@leyabierta.es</strong>. Responderemos en un plazo máximo de 30 días.
 		</p>
 		<p>
 			Si consideras que tus derechos no han sido atendidos, puedes presentar una reclamación
@@ -161,8 +159,7 @@ import Legal from "../layouts/Legal.astro";
 			Europea para transferencias internacionales de datos.
 		</p>
 		<p>
-			Los datos analíticos (Umami) se procesan íntegramente en nuestros servidores en
-			<strong>Hetzner Online GmbH</strong> (Frankfurt, Alemania), dentro del Espacio
+			Los datos analíticos (Umami) se procesan íntegramente en nuestros servidores en <strong>Hetzner Online GmbH</strong> (Frankfurt, Alemania), dentro del Espacio
 			Económico Europeo. <strong>No hay transferencia internacional de datos analíticos.</strong>
 		</p>
 		<p>

--- a/packages/web/wrangler.jsonc
+++ b/packages/web/wrangler.jsonc
@@ -26,6 +26,11 @@
 		//    HTML requests these paths just fall straight through to ASSETS, so
 		//    the only added cost is one passthrough Worker invocation on them.
 		// Everything else (assets, other pages) still skips the Worker entirely.
-		"run_worker_first": ["/", "/leyes/*", "/cambios/reforma/*"]
+		"run_worker_first": ["/", "/leyes/*", "/cambios/reforma/*"],
+		// Without this, an unmatched path returns a bare 404 with an EMPTY body
+		// (0 bytes, no content-type) and the browser shows its own native error
+		// screen instead of dist/404.html — losing the site's branding,
+		// navigation and Spanish copy entirely.
+		"not_found_handling": "404-page"
 	}
 }


### PR DESCRIPTION
Cierra #128, #129 y #127.

## Qué se arregla, en una línea cada uno

- **#128** — "Real Decreto 1312/2024" devolvía la norma equivocada; "26931" no devolvía nada.
- **#129** — la web parecía abandonada porque nunca explicamos el retraso del BOE consolidado.
- **#127** — 9 fallos críticos de móvil, tres de ellos con la misma causa raíz.

---

## Buscador: consultas por referencia (#128)

BM25 diluye el token discriminante (el número) entre términos hiperfrecuentes. Resultado: la forma **más natural y más específica** de citar una norma fallaba, mientras que la versión mutilada acertaba.

| Consulta | Antes | Ahora |
|---|---|---|
| `Real Decreto 1312/2024` | ❌ RDL 1/1986 (medidas urgentes) | ✅ BOE-A-2024-26931 |
| `1312/2024` | ✅ | ✅ |
| `BOE-A-2024-26931` | ✅ | ✅ |
| `26931` | ❌ **0 resultados** | ✅ BOE-A-2024-26931 |
| `LAU` | ❌ Ley de 1943 sobre la Universidad | ✅ Ley 29/1994 |
| `1370/2014` (orden ministerial) | ❌ solo por BM25 | ✅ por lookup exacto |

Nuevo `norm-reference.ts`: parser puro, sin acceso a BD. Detecta identificadores de boletín, URLs ELI, `<rango> <num>/<año>` (tolerando `R.D.`, acentos ausentes, y el título oficial pegado entero), órdenes ministeriales, número suelto, secuencia BOE y 11 siglas. `db.ts` resuelve por lookup exacto e indexado **antes** del ranking.

Los aciertos exactos se **anteponen** a los resultados BM25, no los sustituyen: `Ley 12/2016` existe en varias jurisdicciones y hay que devolverlas todas, con la estatal primero.

### Tres cosas que no eran obvias

1. **`26931` era irresoluble por construcción, no mal rankeado.** `norm_id` está declarado `UNINDEXED` en `norms_fts` y los dígitos no aparecen en el título: la búsqueda de texto no podía encontrarlo jamás. Se resuelve por sufijo de id, devolviendo las colisiones más recientes primero en vez de descartarlas.
2. **`short_title` no está normalizado en mayúsculas**: 293 normas usan `Decreto-ley` y 6 usan `Decreto-Ley`. Un match exacto perdía silenciosamente la minoría → `COLLATE NOCASE`.
3. **Las órdenes ministeriales llevan `/` antes del número**, no espacio (`Orden HAP/1370/2014`), así que el patrón de número suelto no encontraba ninguna.

Fuera de alcance: búsqueda semántica (#40) y ranking por autoridad (#131).

---

## Frescura del corpus (#129)

Solo ingerimos legislación **consolidada** del BOE, que va 1-2 semanas por detrás del diario oficial. El pipeline funcionaba perfectamente, pero un usuario que ve "Cambios recientes → 18 de julio" un día 23 concluye, razonablemente, que la web está muerta.

- **`GET /v1/status`** — `last_reform_date`, `corpus_max_published_at`, `days_since_last_reform`, contadores.
- **Nota en la home** explicando el retraso en lenguaje llano, con degradación elegante: si el endpoint falla, la home se ve exactamente como antes.
- **Validación de fechas en la ingesta.** El BOE emitió una reforma fechada en **2929-11-19** y otra el **31 de junio de 2012** (un día que no existe; solo la caza el round-trip de calendario, no un chequeo de rango). Se rechazan con aviso ruidoso y **contador propio, no como errores de ingesta** — si no, un run sano reportaría `Errors: 1` cada noche por basura del origen y nadie volvería a mirar esa cifra.
- **`getChangelog` no tenía tope superior de fecha**, a diferencia de `getRecentReforms` y `getRecentlyUpdated`. Por eso el primer elemento de "Cambios recientes" en producción era una reforma del **año 2929** de una ley derogada. Ahora la consulta no depende de que los datos estén limpios.
- **Script de alerta de frescura.** Hoy "el BOE no consolidó nada" y "nuestro fetch se rompió en silencio" producen exactamente el mismo log (`0 changed`). Este script da la señal independiente que faltaba.

### Ya ejecutado en producción

Las 2 filas corruptas se borraron el 23-07-2026 (`packages/api/src/scripts/ad-hoc/2026-07-23-cleanup-corrupt-reform-dates.js`, con registro de ejecución). Copia de las filas borradas en el servidor: `/opt/leyabierta/backups/corrupt-reforms-backup-20260723.json`.

> ⚠️ **Al hacerlo salió a la luz que `leyabierta.db` no tiene ninguna copia de seguridad automática.** Los backups horarios de `/opt/tecpar-prod/` son de otro proyecto y `/opt/leyabierta/backups/` solo guarda metadatos de Umami. Son 24 GB reconstruibles desde la caché JSON, pero la reconstrucción completa lleva cerca de una hora. Merece issue propio.

---

## Auditoría móvil (#127)

Recorrido con navegador real sobre 15 rutas a 390×844 y 320×568. **25 hallazgos, 9 críticos.**

**Tres críticos compartían una sola causa:** faltaba `min-width: 0` en `.container`. Con `body{display:flex}` y `main{flex:1}`, el `min-width:auto` por defecto impedía que `main` se encogiera, así que tabs con `nowrap`, tablas y bloques de código estiraban el documento entero. `/datos/` se quedaba clavada en 832 px de ancho tanto a 390 como a 320.

El resto: tablas con contenedor de scroll propio, targets táctiles a 44 px, KPIs en dos columnas en vez de un muro de 375 px, diffs de reforma con `overflow-wrap`, y la queja original — **los resultados de búsqueda ya no aparecen enterrados bajo la tira de estadísticas**, que ahora se oculta mientras hay búsqueda activa.

**El 404 tampoco se servía.** `dist/404.html` se generaba correctamente (15 KB) pero Cloudflare devolvía HTTP 404 con **cuerpo vacío**, así que el navegador mostraba su pantalla nativa de error. Faltaba `not_found_handling` en `wrangler.jsonc`.

### Verificación

| Comprobación | Resultado |
|---|---|
| Rutas × viewports sin scroll horizontal | **30/30** |
| Regresión en escritorio (1440×900) | ninguna |
| Tests | **821 pass, 0 fail** |
| Biome | limpio (8 warnings preexistentes en `packages/eval`) |

---

## Nota sobre formato de números

Los KPIs ahora fuerzan `useGrouping: "always"`, de modo que "vigentes" muestra `9.964` en vez de `9964`. Es una decisión **deliberada de legibilidad que se aparta de la norma de la RAE** (los números de cuatro cifras se escriben sin separador). Se aplica solo a cantidades: `1835` en "la más antigua" es un año y conserva el formato correcto sin punto.

## Deuda destapada, no abordada aquí

`bunx tsgo --noEmit` **ya no pasaba limpio antes de esta rama**: 570 errores en `main`. Esta rama añade 7, todos del patrón de tipado de Elysia en tests que ya se tolera en `routes.test.ts` y `reforms-route.test.ts`. No es de esta tanda, pero un type-checker que nadie puede mirar deja de servir para nada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
