### PR TITLE
docs(deploy): documentar el flujo con rama staging

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -16,7 +16,50 @@ Usuario → Cloudflare CDN → HTML estático (web)
 - **Pipeline:** GitHub Actions con cron diario, descarga reformas del BOE
 - **Dominio:** `leyabierta.es` (DonDominio) con DNS delegado a Cloudflare
 
+## Ramas y despliegue
+
+**`main` es la rama de producción. Todo lo que entra en `main` acaba desplegado.**
+
+El trabajo se acumula primero en `staging`, que no despliega nada:
+
+```
+rama de trabajo  →  PR  →  staging     checks completos, cero despliegue
+staging          →  PR  →  main        un solo merge, despliega
+```
+
+Así se puede integrar y verificar un conjunto de cambios entero antes de que llegue a los usuarios, en vez de desplegar pieza a pieza.
+
+Los checks (`pr-checks.yml`, CodeQL, revisión automática) se disparan por `pull_request` sin filtrar por rama destino, así que un PR contra `staging` se verifica exactamente igual que uno contra `main`.
+
+### Qué dispara realmente un despliegue
+
+`deploy.yml` se activa por tres vías, y conviene conocer las tres:
+
+| Disparador | Cuándo ocurre |
+|------------|---------------|
+| `push` a `main` | al mergear cualquier PR a main |
+| `workflow_dispatch` | despliegue manual desde la pestaña Actions |
+| `repository_dispatch: leyes-updated` | **lo lanza el repo `leyes`** cada vez que el pipeline diario publica leyes nuevas |
+
+La tercera es la que sorprende: **una vez que algo está en `main`, se desplegará en el siguiente ciclo diario aunque nadie toque el repo de código.** El flujo con `staging` da control sobre *cuándo entra algo en main*, no sobre si se despliega después — eso es automático.
+
+### Mantener staging sana
+
+`staging` debe reiniciarse desde `main` después de cada promoción, y sincronizarse con `main` si este avanza por otra vía. Cuanto más diverjan, más difícil es verificar el conjunto y más probable el conflicto.
+
+```bash
+git checkout staging
+git merge --ff-only origin/main   # tras promocionar staging → main
+```
+
+Una `staging` que lleva meses sin sincronizarse deja de ser útil: acumula conflictos y su diff frente a main deja de significar nada.
+
 ## CI/CD: GitHub Actions
+
+> **Nota:** las tres secciones siguientes describen workflows que ya no existen
+> con esos nombres. Hoy el despliegue es un único `deploy.yml` (web + API) y el
+> pipeline diario corre en cron en el servidor, no en Actions. Pendiente de
+> reescribir esta parte.
 
 ### deploy-web.yml
 
@@ -84,6 +127,10 @@ No necesitas acceso al servidor de producción para contribuir. El flujo es:
 
 1. Fork o branch del repo
 2. Desarrolla localmente (`bun run api`, `bun run web`)
-3. Push a main → GitHub Actions despliega automáticamente
+3. Abre un PR **contra `staging`**, no contra `main`
+
+Tu PR pasa por los mismos checks que uno contra main, pero no despliega nada.
+La promoción de `staging` a `main` la hacen los mantenedores cuando el conjunto
+de cambios está verificado.
 
 Los secrets de producción están configurados en GitHub y en el servidor. Si necesitas acceso, contacta a los mantenedores.


### PR DESCRIPTION
Documenta en `DEPLOY.md` el flujo que acabamos de adoptar.

## Lo que documenta

```
rama de trabajo  →  PR  →  staging     checks completos, cero despliegue
staging          →  PR  →  main        un solo merge, despliega
```

Y las **tres** vías que disparan `deploy.yml`. La tercera es la que no es obvia:

| Disparador | Cuándo |
|---|---|
| `push` a `main` | al mergear un PR a main |
| `workflow_dispatch` | despliegue manual |
| `repository_dispatch: leyes-updated` | **lo lanza el repo `leyes`** en cada publicación del pipeline diario |

Es decir: una vez que algo está en `main`, se despliega en el siguiente ciclo diario aunque nadie toque el repo de código. El flujo con `staging` da control sobre *cuándo entra algo en main*, no sobre si se despliega después.

También añade la instrucción de mantener `staging` sincronizada. La `staging` anterior llevaba **abandonada desde el 27 de abril**, 135 commits por detrás de main; una rama así deja de significar nada.

## Fuera de lo pedido, pero necesario

Las secciones de CI/CD describen `deploy-web.yml`, `deploy-api.yml` y `daily-pipeline.yml`. **Ninguno de los tres existe ya**: hoy hay un único `deploy.yml` (web + API) y el pipeline diario corre en cron en el servidor, no en Actions.

No he reescrito esas secciones —sería otro cambio y otra revisión— pero sí he añadido un aviso, porque documentar el flujo nuevo justo al lado de nombres de archivo inexistentes habría sido peor que no documentarlo. Queda pendiente actualizarlas.

## Nota sobre la rama staging anterior

Contenía dos datasets (`eval-v2-procedural.json`, `eval-v2-temporal.json`, 545 líneas) que **no están en main en ninguna ruta**. Antes de reiniciar la rama se preservaron en `archive/staging-2026-04`. Alguien debería decidir si se recuperan o se descartan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)