### PR TITLE
Recuperar tsgo como señal útil + corregir NAN_API_KEY en CLAUDE.md

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -16,7 +16,50 @@ Usuario → Cloudflare CDN → HTML estático (web)
 - **Pipeline:** GitHub Actions con cron diario, descarga reformas del BOE
 - **Dominio:** `leyabierta.es` (DonDominio) con DNS delegado a Cloudflare
 
+## Ramas y despliegue
+
+**`main` es la rama de producción. Todo lo que entra en `main` acaba desplegado.**
+
+El trabajo se acumula primero en `staging`, que no despliega nada:
+
+```
+rama de trabajo  →  PR  →  staging     checks completos, cero despliegue
+staging          →  PR  →  main        un solo merge, despliega
+```
+
+Así se puede integrar y verificar un conjunto de cambios entero antes de que llegue a los usuarios, en vez de desplegar pieza a pieza.
+
+Los checks (`pr-checks.yml`, CodeQL, revisión automática) se disparan por `pull_request` sin filtrar por rama destino, así que un PR contra `staging` se verifica exactamente igual que uno contra `main`.
+
+### Qué dispara realmente un despliegue
+
+`deploy.yml` se activa por tres vías, y conviene conocer las tres:
+
+| Disparador | Cuándo ocurre |
+|------------|---------------|
+| `push` a `main` | al mergear cualquier PR a main |
+| `workflow_dispatch` | despliegue manual desde la pestaña Actions |
+| `repository_dispatch: leyes-updated` | **lo lanza el repo `leyes`** cada vez que el pipeline diario publica leyes nuevas |
+
+La tercera es la que sorprende: **una vez que algo está en `main`, se desplegará en el siguiente ciclo diario aunque nadie toque el repo de código.** El flujo con `staging` da control sobre *cuándo entra algo en main*, no sobre si se despliega después — eso es automático.
+
+### Mantener staging sana
+
+`staging` debe reiniciarse desde `main` después de cada promoción, y sincronizarse con `main` si este avanza por otra vía. Cuanto más diverjan, más difícil es verificar el conjunto y más probable el conflicto.
+
+```bash
+git checkout staging
+git merge --ff-only origin/main   # tras promocionar staging → main
+```
+
+Una `staging` que lleva meses sin sincronizarse deja de ser útil: acumula conflictos y su diff frente a main deja de significar nada.
+
 ## CI/CD: GitHub Actions
+
+> **Nota:** las tres secciones siguientes describen workflows que ya no existen
+> con esos nombres. Hoy el despliegue es un único `deploy.yml` (web + API) y el
+> pipeline diario corre en cron en el servidor, no en Actions. Pendiente de
+> reescribir esta parte.
 
 ### deploy-web.yml
 
@@ -84,6 +127,10 @@ No necesitas acceso al servidor de producción para contribuir. El flujo es:
 
 1. Fork o branch del repo
 2. Desarrolla localmente (`bun run api`, `bun run web`)
-3. Push a main → GitHub Actions despliega automáticamente
+3. Abre un PR **contra `staging`**, no contra `main`
+
+Tu PR pasa por los mismos checks que uno contra main, pero no despliega nada.
+La promoción de `staging` a `main` la hacen los mantenedores cuando el conjunto
+de cambios está verificado.
 
 Los secrets de producción están configurados en GitHub y en el servidor. Si necesitas acceso, contacta a los mantenedores.


### PR DESCRIPTION
Deuda destapada durante la sesión de #127/#128/#129, ahora saldada.

## `tsgo` había dejado de servir para nada

`bunx tsgo --noEmit` daba **577 errores**. Un type-checker con 577 errores es un type-checker que nadie ejecuta: cualquier error nuevo se pierde en el ruido. Ahora da **282, y ninguno en el código que corre a diario**.

| | Antes | Ahora |
|---|---:|---:|
| Total | 577 | 282 |
| API + pipeline core | 19 | **0** |
| `packages/web` (falsos) | 98 | excluido |
| `research/archive` (código muerto) | 178 | excluido |

### 1. El tsconfig raíz aplicaba una sola config a todo el monorepo

Sin `include`/`exclude`, cubría código de Bun, de navegador, tests y scripts archivados a la vez. Como el raíz no declara `lib: DOM` ni tiene los tipos que genera `astro sync`, `packages/web` producía ~98 errores del tipo `Cannot find name 'document'` — **falsos**, sobre código que compila y se despliega sin problemas.

`packages/web` tiene su propio `tsconfig.json` y debe comprobarse con `astro check`. `research/archive` es, literalmente, código archivado y no mantenido.

Excluir no es arreglar, y lo digo claramente en un comentario dentro del propio tsconfig. Pero un comando que grita sobre código muerto y falsos positivos no es un comando que nadie vaya a ejecutar.

### 2. Arreglados los 19 errores del pipeline que corre cada noche

- **`cli.ts` (12).** `Record<string, string>` con `noUncheckedIndexedAccess` convierte cada acceso en `string | undefined`. La aserción de tipo mentía sobre diez campos a la vez. Sustituida por interfaces explícitas (`CachedMetadata`, `CachedVersion`, `CachedReference`) que además documentan la forma real del JSON de caché.
- **`AnalisisData` era un duplicado exacto de `NormAnalisis`** salvo por `readonly`, lo que impedía pasar uno donde se esperaba el otro. Ahora es un alias.
- Accesos indexados sin comprobar en `ingest.ts`, `boe-metadata.ts`, `ingest-analisis-cli.ts` y `verify.ts`.

### 3. `bun run typecheck`

No existía un comando obvio. `packages/web` necesita `@astrojs/check` instalado para `astro check`; **no añado la dependencia aquí** — es una decisión que corresponde a quien mantenga el proyecto.

## `CLAUDE.md` documentaba mal la clave del stack RAG

Decía `HERMES_API_KEY`. La variable real —la del `.env` del servidor y la que lee todo el código vivo— es **`NAN_API_KEY`**. Seguir la documentación al pie de la letra da un stack RAG que falla la autenticación en silencio. Corregido, con nota sobre el nombre antiguo porque algunos scripts archivados aún lo leen.

## Lo que queda (no abordado aquí)

282 errores: 167 en tests, 64 en research activo, 42 en scripts operativos (`generate-citizen-tags`, `backfill-citizen-summaries`) y 9 en `search-lab`. Ninguno en la API ni en el pipeline core. Merece un issue propio si se quiere llegar a cero.

**Verificación:** 826 tests pass, 0 fallos. Biome limpio (8 warnings preexistentes en `packages/eval`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)