### PR TITLE
fix(#140): saldar deuda de tipos (tsgo 273→0) y gatear tipos en CI

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -100,6 +100,12 @@ jobs:
           key: astro-data-${{ hashFiles('content/laws/**/*.md') }}
           restore-keys: astro-data-
 
+      - name: Astro check (web types)
+        working-directory: packages/web
+        run: bun run check
+        env:
+          LAWS_PATH: content/laws
+
       - name: Build web
         working-directory: packages/web
         run: bash build-with-progress.sh

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,0 +1,48 @@
+name: Typecheck
+
+# Gates the Bun-side packages (pipeline, api, eval, shared) on `tsgo --noEmit`.
+# Kept as its own lightweight workflow — no leyes checkout, no Astro — so it
+# runs fast on any TypeScript change. packages/web is browser/Astro code and is
+# type-checked separately via `astro check` in pr-checks.yml (build-and-smoke),
+# which already has the leyes content and Node it needs. See #140.
+
+on:
+  pull_request:
+    paths:
+      - "packages/**"
+      - "package.json"
+      - "bun.lock"
+      - "tsconfig.json"
+      - ".github/workflows/typecheck.yml"
+  push:
+    branches:
+      - "seo-loop/**"
+    paths:
+      - "packages/**"
+      - "package.json"
+      - "bun.lock"
+      - "tsconfig.json"
+      - ".github/workflows/typecheck.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: typecheck-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  tsgo:
+    name: tsgo (Bun packages)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: latest
+
+      - run: bun install --frozen-lockfile
+
+      - name: tsgo --noEmit
+        run: bun run typecheck

--- a/bun.lock
+++ b/bun.lock
@@ -66,12 +66,14 @@
         "zod": "^4.4.3",
       },
       "devDependencies": {
+        "@astrojs/check": "^0.9.9",
         "@cloudflare/workers-types": "^5.20260718.1",
         "@types/markdown-it": "^14.1.2",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@types/sanitize-html": "^2.16.1",
         "gray-matter": "^4.0.3",
+        "typescript": "^7.0.2",
       },
     },
   },
@@ -91,6 +93,10 @@
     "@ai-sdk/provider": ["@ai-sdk/provider@3.0.8", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ=="],
 
     "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.23", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg=="],
+
+    "@astrojs/check": ["@astrojs/check@0.9.9", "", { "dependencies": { "@astrojs/language-server": "^2.16.7", "chokidar": "^4.0.3", "kleur": "^4.1.5", "yargs": "^17.7.2" }, "peerDependencies": { "typescript": "^5.0.0 || ^6.0.0" }, "bin": { "astro-check": "bin/astro-check.js" } }, "sha512-A5UW8uIuErLWEoRQvzgXpO1gTjUFtK8r7nU2Z7GewAMxUb7bPvpk11qaKKgxqXlHJWlAvaaxy+Xg28A6bmQ1Tg=="],
+
+    "@astrojs/compiler": ["@astrojs/compiler@2.13.1", "", {}, "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg=="],
 
     "@astrojs/compiler-binding": ["@astrojs/compiler-binding@0.3.1", "", { "optionalDependencies": { "@astrojs/compiler-binding-darwin-arm64": "0.3.1", "@astrojs/compiler-binding-darwin-x64": "0.3.1", "@astrojs/compiler-binding-linux-arm64-gnu": "0.3.1", "@astrojs/compiler-binding-linux-arm64-musl": "0.3.1", "@astrojs/compiler-binding-linux-x64-gnu": "0.3.1", "@astrojs/compiler-binding-linux-x64-musl": "0.3.1", "@astrojs/compiler-binding-wasm32-wasi": "0.3.1", "@astrojs/compiler-binding-win32-arm64-msvc": "0.3.1", "@astrojs/compiler-binding-win32-x64-msvc": "0.3.1" } }, "sha512-DaAUj29AIBU2XdJ8uwcab8lW5O2pk9pY8AXkcMw0sw77nVa3oeTYRcO+Dvbbpoexf6ThMc0FMWYCQ/wN1/T7oQ=="],
 
@@ -116,6 +122,8 @@
 
     "@astrojs/internal-helpers": ["@astrojs/internal-helpers@0.10.1", "", { "dependencies": { "@types/hast": "^3.0.4", "@types/mdast": "^4.0.4", "js-yaml": "^4.1.1", "picomatch": "^4.0.4", "retext-smartypants": "^6.2.0", "shiki": "^4.0.2", "smol-toml": "^1.6.0", "unified": "^11.0.5" } }, "sha512-5phcroT/vmOOrYuuAxtkbPixy5hePtlz9i8K4OeDv3dNK6/UQRuXPOSRTxIOBbUY5Sonw2UaxjbuVc43Mcir6Q=="],
 
+    "@astrojs/language-server": ["@astrojs/language-server@2.16.12", "", { "dependencies": { "@astrojs/compiler": "^2.13.1", "@astrojs/yaml2ts": "^0.2.4", "@jridgewell/sourcemap-codec": "^1.5.5", "@volar/kit": "~2.4.28", "@volar/language-core": "~2.4.28", "@volar/language-server": "~2.4.28", "@volar/language-service": "~2.4.28", "muggle-string": "^0.4.1", "tinyglobby": "^0.2.16", "volar-service-css": "0.0.71", "volar-service-emmet": "0.0.71", "volar-service-html": "0.0.71", "volar-service-prettier": "0.0.71", "volar-service-typescript": "0.0.71", "volar-service-typescript-twoslash-queries": "0.0.71", "volar-service-yaml": "0.0.71", "vscode-html-languageservice": "^5.6.2", "vscode-uri": "^3.1.0" }, "peerDependencies": { "prettier": "^3.0.0", "prettier-plugin-astro": ">=0.11.0" }, "optionalPeers": ["prettier", "prettier-plugin-astro"], "bin": { "astro-ls": "./bin/nodeServer.js" } }, "sha512-3LpFphBCzveUgm5ZVDINB/v3YA4TgPa1EMOEFn3Zt/Ww6jojR25iN+kmzeUz7v/b9xkmq+hMACTX4hizN3VCEQ=="],
+
     "@astrojs/markdown-satteri": ["@astrojs/markdown-satteri@0.3.4", "", { "dependencies": { "@astrojs/internal-helpers": "0.10.1", "@astrojs/prism": "4.0.2", "github-slugger": "^2.0.0", "hast-util-from-html": "^2.0.3", "satteri": "^0.9.1" } }, "sha512-6Lvt/bQZEBW+zzdhPblvfZEy5PGEYJaUsUqaCgwHeRPxZJL1gc9I+DRLKWJjjYTWDzVUTzXlMq4WwSK+X34CVw=="],
 
     "@astrojs/prism": ["@astrojs/prism@4.0.2", "", { "dependencies": { "prismjs": "^1.30.0" } }, "sha512-KTivpmnz6lDsC6o9H4+DNm2SrE/GHzw8cNAvEJwAvUT+eoaEnn/4NtbDNfRRaxaJHdp15gf+tfHAWiXR4wB3BA=="],
@@ -123,6 +131,8 @@
     "@astrojs/react": ["@astrojs/react@6.0.1", "", { "dependencies": { "@astrojs/internal-helpers": "0.10.1", "@vitejs/plugin-react": "^5.2.0", "devalue": "^5.8.1", "ultrahtml": "^1.6.0", "vite": "^8.0.13" }, "peerDependencies": { "@types/react": "^17.0.50 || ^18.0.21 || ^19.0.0", "@types/react-dom": "^17.0.17 || ^18.0.6 || ^19.0.0", "react": "^17.0.2 || ^18.0.0 || ^19.0.0", "react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0" } }, "sha512-Afs1sEm72P2plDnrOGxmIteJ7bjx/VqxlcaQLNip5eHJ5tIvKUORQetC9UKcvgwKnj51t60HWl5mOANkOsWs4w=="],
 
     "@astrojs/telemetry": ["@astrojs/telemetry@3.3.3", "", { "dependencies": { "ci-info": "^4.4.0", "dset": "^3.1.4", "is-docker": "^4.0.0", "package-manager-detector": "^1.6.0" } }, "sha512-C1TLn5sPJr0x4vk56piHWKbnqlEB8BKyte5Y45V02U+D7BGO5eMqZDH5aPjnkXQWJggvmsTXxH03QMZ9NgWLzQ=="],
+
+    "@astrojs/yaml2ts": ["@astrojs/yaml2ts@0.2.4", "", { "dependencies": { "yaml": "^2.8.3" } }, "sha512-8oddpOae35pJsXPQXhTkM0ypfKPskVsh2bCxRtbf7e+/Epw2nReakFYpLKjZMEr75CsoF203PMnCocpfz0s69A=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
@@ -211,6 +221,20 @@
     "@elysiajs/cors": ["@elysiajs/cors@1.4.1", "", { "peerDependencies": { "elysia": ">= 1.4.0" } }, "sha512-lQfad+F3r4mNwsxRKbXyJB8Jg43oAOXjRwn7sKUL6bcOW3KjUqUimTS+woNpO97efpzjtDE0tEjGk9DTw8lqTQ=="],
 
     "@elysiajs/swagger": ["@elysiajs/swagger@1.3.1", "", { "dependencies": { "@scalar/themes": "^0.9.52", "@scalar/types": "^0.0.12", "openapi-types": "^12.1.3", "pathe": "^1.1.2" }, "peerDependencies": { "elysia": ">= 1.3.0" } }, "sha512-LcbLHa0zE6FJKWPWKsIC/f+62wbDv3aXydqcNPVPyqNcaUgwvCajIi+5kHEU6GO3oXUCpzKaMsb3gsjt8sLzFQ=="],
+
+    "@emmetio/abbreviation": ["@emmetio/abbreviation@2.3.3", "", { "dependencies": { "@emmetio/scanner": "^1.0.4" } }, "sha512-mgv58UrU3rh4YgbE/TzgLQwJ3pFsHHhCLqY20aJq+9comytTXUDNGG/SMtSeMJdkpxgXSXunBGLD8Boka3JyVA=="],
+
+    "@emmetio/css-abbreviation": ["@emmetio/css-abbreviation@2.1.8", "", { "dependencies": { "@emmetio/scanner": "^1.0.4" } }, "sha512-s9yjhJ6saOO/uk1V74eifykk2CBYi01STTK3WlXWGOepyKa23ymJ053+DNQjpFcy1ingpaO7AxCcwLvHFY9tuw=="],
+
+    "@emmetio/css-parser": ["@emmetio/css-parser@0.4.1", "", { "dependencies": { "@emmetio/stream-reader": "^2.2.0", "@emmetio/stream-reader-utils": "^0.1.0" } }, "sha512-2bC6m0MV/voF4CTZiAbG5MWKbq5EBmDPKu9Sb7s7nVcEzNQlrZP6mFFFlIaISM8X6514H9shWMme1fCm8cWAfQ=="],
+
+    "@emmetio/html-matcher": ["@emmetio/html-matcher@1.3.0", "", { "dependencies": { "@emmetio/scanner": "^1.0.0" } }, "sha512-NTbsvppE5eVyBMuyGfVu2CRrLvo7J4YHb6t9sBFLyY03WYhXET37qA4zOYUjBWFCRHO7pS1B9khERtY0f5JXPQ=="],
+
+    "@emmetio/scanner": ["@emmetio/scanner@1.0.4", "", {}, "sha512-IqRuJtQff7YHHBk4G8YZ45uB9BaAGcwQeVzgj/zj8/UdOhtQpEIupUhSk8dys6spFIWVZVeK20CzGEnqR5SbqA=="],
+
+    "@emmetio/stream-reader": ["@emmetio/stream-reader@2.2.0", "", {}, "sha512-fXVXEyFA5Yv3M3n8sUGT7+fvecGrZP4k6FnWWMSZVQf69kAq0LLpaBQLGcPR30m3zMmKYhECP4k/ZkzvhEW5kw=="],
+
+    "@emmetio/stream-reader-utils": ["@emmetio/stream-reader-utils@0.1.0", "", {}, "sha512-ZsZ2I9Vzso3Ho/pjZFsmmZ++FWeEd/txqybHTm4OgaZzdS8V9V/YYWQwg5TC38Z7uLWUV1vavpLLbjJtKubR1A=="],
 
     "@emnapi/core": ["@emnapi/core@1.11.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],
 
@@ -578,6 +602,46 @@
 
     "@typescript/native-preview-win32-x64": ["@typescript/native-preview-win32-x64@7.0.0-dev.20260406.1", "", { "os": "win32", "cpu": "x64" }, "sha512-Jk7wP6SPaELTGY+ijvpude+dmXX9WeuLQLk9qjevQXTusFVcT8vjvepxJVshSJ1+Thmxy1t9v4l1pHnM3XUMjw=="],
 
+    "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
+
+    "@typescript/typescript-darwin-arm64": ["@typescript/typescript-darwin-arm64@7.0.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA=="],
+
+    "@typescript/typescript-darwin-x64": ["@typescript/typescript-darwin-x64@7.0.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA=="],
+
+    "@typescript/typescript-freebsd-arm64": ["@typescript/typescript-freebsd-arm64@7.0.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ=="],
+
+    "@typescript/typescript-freebsd-x64": ["@typescript/typescript-freebsd-x64@7.0.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw=="],
+
+    "@typescript/typescript-linux-arm": ["@typescript/typescript-linux-arm@7.0.2", "", { "os": "linux", "cpu": "arm" }, "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ=="],
+
+    "@typescript/typescript-linux-arm64": ["@typescript/typescript-linux-arm64@7.0.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ=="],
+
+    "@typescript/typescript-linux-loong64": ["@typescript/typescript-linux-loong64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ=="],
+
+    "@typescript/typescript-linux-mips64el": ["@typescript/typescript-linux-mips64el@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA=="],
+
+    "@typescript/typescript-linux-ppc64": ["@typescript/typescript-linux-ppc64@7.0.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA=="],
+
+    "@typescript/typescript-linux-riscv64": ["@typescript/typescript-linux-riscv64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ=="],
+
+    "@typescript/typescript-linux-s390x": ["@typescript/typescript-linux-s390x@7.0.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw=="],
+
+    "@typescript/typescript-linux-x64": ["@typescript/typescript-linux-x64@7.0.2", "", { "os": "linux", "cpu": "x64" }, "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A=="],
+
+    "@typescript/typescript-netbsd-arm64": ["@typescript/typescript-netbsd-arm64@7.0.2", "", { "os": "none", "cpu": "arm64" }, "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA=="],
+
+    "@typescript/typescript-netbsd-x64": ["@typescript/typescript-netbsd-x64@7.0.2", "", { "os": "none", "cpu": "x64" }, "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA=="],
+
+    "@typescript/typescript-openbsd-arm64": ["@typescript/typescript-openbsd-arm64@7.0.2", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ=="],
+
+    "@typescript/typescript-openbsd-x64": ["@typescript/typescript-openbsd-x64@7.0.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg=="],
+
+    "@typescript/typescript-sunos-x64": ["@typescript/typescript-sunos-x64@7.0.2", "", { "os": "sunos", "cpu": "x64" }, "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g=="],
+
+    "@typescript/typescript-win32-arm64": ["@typescript/typescript-win32-arm64@7.0.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ=="],
+
+    "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
+
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
 
     "@unhead/schema": ["@unhead/schema@1.11.20", "", { "dependencies": { "hookable": "^5.5.3", "zhead": "^2.2.4" } }, "sha512-0zWykKAaJdm+/Y7yi/Yds20PrUK7XabLe9c3IRcjnwYmSWY6z0Cr19VIs3ozCj8P+GhR+/TI2mwtGlueCEYouA=="],
@@ -585,6 +649,22 @@
     "@vercel/oidc": ["@vercel/oidc@3.2.0", "", {}, "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug=="],
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@5.2.0", "", { "dependencies": { "@babel/core": "^7.29.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-rc.3", "@types/babel__core": "^7.20.5", "react-refresh": "^0.18.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw=="],
+
+    "@volar/kit": ["@volar/kit@2.4.28", "", { "dependencies": { "@volar/language-service": "2.4.28", "@volar/typescript": "2.4.28", "typesafe-path": "^0.2.2", "vscode-languageserver-textdocument": "^1.0.11", "vscode-uri": "^3.0.8" }, "peerDependencies": { "typescript": "*" } }, "sha512-cKX4vK9dtZvDRaAzeoUdaAJEew6IdxHNCRrdp5Kvcl6zZOqb6jTOfk3kXkIkG3T7oTFXguEMt5+9ptyqYR84Pg=="],
+
+    "@volar/language-core": ["@volar/language-core@2.4.28", "", { "dependencies": { "@volar/source-map": "2.4.28" } }, "sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ=="],
+
+    "@volar/language-server": ["@volar/language-server@2.4.28", "", { "dependencies": { "@volar/language-core": "2.4.28", "@volar/language-service": "2.4.28", "@volar/typescript": "2.4.28", "path-browserify": "^1.0.1", "request-light": "^0.7.0", "vscode-languageserver": "^9.0.1", "vscode-languageserver-protocol": "^3.17.5", "vscode-languageserver-textdocument": "^1.0.11", "vscode-uri": "^3.0.8" } }, "sha512-NqcLnE5gERKuS4PUFwlhMxf6vqYo7hXtbMFbViXcbVkbZ905AIVWhnSo0ZNBC2V127H1/2zP7RvVOVnyITFfBw=="],
+
+    "@volar/language-service": ["@volar/language-service@2.4.28", "", { "dependencies": { "@volar/language-core": "2.4.28", "vscode-languageserver-protocol": "^3.17.5", "vscode-languageserver-textdocument": "^1.0.11", "vscode-uri": "^3.0.8" } }, "sha512-Rh/wYCZJrI5vCwMk9xyw/Z+MsWxlJY1rmMZPsxUoJKfzIRjS/NF1NmnuEcrMbEVGja00aVpCsInJfixQTMdvLw=="],
+
+    "@volar/source-map": ["@volar/source-map@2.4.28", "", {}, "sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ=="],
+
+    "@volar/typescript": ["@volar/typescript@2.4.28", "", { "dependencies": { "@volar/language-core": "2.4.28", "path-browserify": "^1.0.1", "vscode-uri": "^3.0.8" } }, "sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw=="],
+
+    "@vscode/emmet-helper": ["@vscode/emmet-helper@2.11.0", "", { "dependencies": { "emmet": "^2.4.3", "jsonc-parser": "^2.3.0", "vscode-languageserver-textdocument": "^1.0.1", "vscode-languageserver-types": "^3.15.1", "vscode-uri": "^3.0.8" } }, "sha512-QLxjQR3imPZPQltfbWRnHU6JecWTF1QSWhx3GAKQpslx7y3Dp6sIIXhKjiUJ/BR9FX8PVthjr9PD6pNwOJfAzw=="],
+
+    "@vscode/l10n": ["@vscode/l10n@0.0.18", "", {}, "sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ=="],
 
     "a-sync-waterfall": ["a-sync-waterfall@1.0.1", "", {}, "sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA=="],
 
@@ -595,6 +675,12 @@
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
     "ai": ["ai@6.0.168", "", { "dependencies": { "@ai-sdk/gateway": "3.0.104", "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.23", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-2HqCJuO+1V2aV7vfYs5LFEUfxbkGX+5oa54q/gCCTL7KLTdbxcCu5D7TdLA5kwsrs3Szgjah9q6D9tpjHM3hUQ=="],
+
+    "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
+    "ajv-draft-04": ["ajv-draft-04@1.0.0", "", { "peerDependencies": { "ajv": "^8.5.0" }, "optionalPeers": ["ajv"] }, "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw=="],
+
+    "ajv-i18n": ["ajv-i18n@4.2.0", "", { "peerDependencies": { "ajv": "^8.0.0-beta.0" } }, "sha512-v/ei2UkCEeuKNXh8RToiFsUclmU+G57LO1Oo22OagNMENIw+Yb8eMwvHu7Vn9fmkjJyv6XclhJ8TbuigSglPkg=="],
 
     "am-i-vibing": ["am-i-vibing@0.4.0", "", { "dependencies": { "process-ancestry": "^0.1.0" }, "bin": { "am-i-vibing": "dist/cli.mjs" } }, "sha512-MxT4XZL7pzLHpuvhDKdMaQHMGGkJDLluKBLsbstn+8wv9sWcFT6h+0ve9qkml95amVTZtZV83gQe2hY+ojgHLg=="],
 
@@ -656,7 +742,7 @@
 
     "character-entities-legacy": ["character-entities-legacy@3.0.0", "", {}, "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="],
 
-    "chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
+    "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
     "ci-info": ["ci-info@4.4.0", "", {}, "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg=="],
 
@@ -665,6 +751,8 @@
     "cli-cursor": ["cli-cursor@5.0.0", "", { "dependencies": { "restore-cursor": "^5.0.0" } }, "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw=="],
 
     "cli-spinners": ["cli-spinners@2.9.2", "", {}, "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg=="],
+
+    "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
@@ -752,6 +840,8 @@
 
     "elysia": ["elysia@1.4.28", "", { "dependencies": { "cookie": "^1.1.1", "exact-mirror": "^0.2.7", "fast-decode-uri-component": "^1.0.1", "memoirist": "^0.4.0" }, "peerDependencies": { "@sinclair/typebox": ">= 0.34.0 < 1", "@types/bun": ">= 1.2.0", "file-type": ">= 20.0.0", "openapi-types": ">= 12.0.0", "typescript": ">= 5.0.0" }, "optionalPeers": ["@types/bun", "typescript"] }, "sha512-Vrx8sBnvq8squS/3yNBzR1jBXI+SgmnmvwawPjNuEHndUe5l1jV2Gp6JJ4ulDkEB8On6bWmmuyPpA+bq4t+WYg=="],
 
+    "emmet": ["emmet@2.4.11", "", { "dependencies": { "@emmetio/abbreviation": "^2.3.3", "@emmetio/css-abbreviation": "^2.1.8" } }, "sha512-23QPJB3moh/U9sT4rQzGgeyyGIrcM+GH5uVYg2C6wZIxAIJq7Ng3QLT79tl8FUwDXhyq9SusfknOrofAKqvgyQ=="],
+
     "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
     "emoji-regex-xs": ["emoji-regex-xs@2.0.1", "", {}, "sha512-1QFuh8l7LqUcKe24LsPUNzjrzJQ7pgRwp1QMcZ5MX6mFplk2zQ08NVCM84++1cveaUUYtcCYHmeFEuNg16sU4g=="],
@@ -802,6 +892,8 @@
 
     "fast-sha256": ["fast-sha256@1.3.0", "", {}, "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ=="],
 
+    "fast-uri": ["fast-uri@3.1.4", "", {}, "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw=="],
+
     "fast-xml-builder": ["fast-xml-builder@1.1.5", "", { "dependencies": { "path-expression-matcher": "^1.1.3" } }, "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA=="],
 
     "fast-xml-parser": ["fast-xml-parser@5.7.1", "", { "dependencies": { "@nodable/entities": "^2.1.0", "fast-xml-builder": "^1.1.5", "path-expression-matcher": "^1.5.0", "strnum": "^2.2.3" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA=="],
@@ -835,6 +927,8 @@
     "gcp-metadata": ["gcp-metadata@8.1.2", "", { "dependencies": { "gaxios": "^7.0.0", "google-logging-utils": "^1.0.0", "json-bigint": "^1.0.0" } }, "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg=="],
 
     "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
+
+    "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
 
     "get-east-asian-width": ["get-east-asian-width@1.5.0", "", {}, "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA=="],
 
@@ -924,6 +1018,8 @@
 
     "json-schema": ["json-schema@0.4.0", "", {}, "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="],
 
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
     "jsonc-parser": ["jsonc-parser@3.3.1", "", {}, "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="],
@@ -933,6 +1029,8 @@
     "jws": ["jws@4.0.1", "", { "dependencies": { "jwa": "^2.0.1", "safe-buffer": "^5.0.1" } }, "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA=="],
 
     "kind-of": ["kind-of@6.0.3", "", {}, "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="],
+
+    "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
 
     "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 
@@ -998,6 +1096,8 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
+    "muggle-string": ["muggle-string@0.4.1", "", {}, "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ=="],
+
     "mustache": ["mustache@4.2.0", "", { "bin": { "mustache": "bin/mustache" } }, "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ=="],
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
@@ -1060,6 +1160,8 @@
 
     "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
+    "path-browserify": ["path-browserify@1.0.1", "", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
+
     "path-expression-matcher": ["path-expression-matcher@1.5.0", "", {}, "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ=="],
 
     "pathe": ["pathe@1.1.2", "", {}, "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="],
@@ -1079,6 +1181,8 @@
     "postcss": ["postcss@8.5.8", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg=="],
 
     "postcss-value-parser": ["postcss-value-parser@4.2.0", "", {}, "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="],
+
+    "prettier": ["prettier@3.9.5", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg=="],
 
     "pretty-format": ["pretty-format@29.7.0", "", { "dependencies": { "@jest/schemas": "^29.6.3", "ansi-styles": "^5.0.0", "react-is": "^18.0.0" } }, "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ=="],
 
@@ -1106,13 +1210,19 @@
 
     "readable-stream": ["readable-stream@4.7.0", "", { "dependencies": { "abort-controller": "^3.0.0", "buffer": "^6.0.3", "events": "^3.3.0", "process": "^0.11.10", "string_decoder": "^1.3.0" } }, "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg=="],
 
-    "readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
+    "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 
     "regex": ["regex@6.1.0", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg=="],
 
     "regex-recursion": ["regex-recursion@6.0.2", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg=="],
 
     "regex-utilities": ["regex-utilities@2.3.0", "", {}, "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng=="],
+
+    "request-light": ["request-light@0.7.0", "", {}, "sha512-lMbBMrDoxgsyO+yB3sDcrDuX85yYt7sS8BfQd11jtbW/z5ZWgLZRcEGLsLoYw7I0WSUGQBs8CC8ScIxkTX1+6Q=="],
+
+    "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
     "resend": ["resend@6.10.0", "", { "dependencies": { "postal-mime": "2.7.4", "svix": "1.88.0" }, "peerDependencies": { "@react-email/render": "*" }, "optionalPeers": ["@react-email/render"] }, "sha512-i7CwZpYj4Oho1RxsTpLcCUkO08+HiL4NXrm6jLJ2WzJ89UGI8eROSieLONJA3hnUrf1OYnCyfq5F6POnHUMv1Q=="],
 
@@ -1212,7 +1322,11 @@
 
     "type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
+    "typesafe-path": ["typesafe-path@0.2.2", "", {}, "sha512-OJabfkAg1WLZSqJAJ0Z6Sdt3utnbzr/jh+NAHoyWHJe8CMSy79Gm085094M9nvTPy22KzTVn5Zq5mbapCI/hPA=="],
+
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "typescript-auto-import-cache": ["typescript-auto-import-cache@0.3.6", "", { "dependencies": { "semver": "^7.3.8" } }, "sha512-RpuHXrknHdVdK7wv/8ug3Fr0WNsNi5l5aB8MYYuXhq2UH5lnEB1htJ1smhtD5VeCsGr2p8mUDtd83LCQDFVgjQ=="],
 
     "uc.micro": ["uc.micro@2.1.0", "", {}, "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="],
 
@@ -1262,6 +1376,40 @@
 
     "vitefu": ["vitefu@1.1.2", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-beta.0" }, "optionalPeers": ["vite"] }, "sha512-zpKATdUbzbsycPFBN71nS2uzBUQiVnFoOrr2rvqv34S1lcAgMKKkjWleLGeiJlZ8lwCXvtWaRn7R3ZC16SYRuw=="],
 
+    "volar-service-css": ["volar-service-css@0.0.71", "", { "dependencies": { "vscode-css-languageservice": "^6.3.0", "vscode-languageserver-textdocument": "^1.0.11", "vscode-uri": "^3.0.8" }, "peerDependencies": { "@volar/language-service": "~2.4.0" }, "optionalPeers": ["@volar/language-service"] }, "sha512-wRRFt9BpjMKCazcgOh67MSjUjiWUCAh99DyYSDIOTuxaRjEtDC7PpB0k1Y1wbJIW/pVtMUSVbpPo3UGSm0Byxw=="],
+
+    "volar-service-emmet": ["volar-service-emmet@0.0.71", "", { "dependencies": { "@emmetio/css-parser": "^0.4.1", "@emmetio/html-matcher": "^1.3.0", "@vscode/emmet-helper": "^2.9.3", "vscode-uri": "^3.0.8" }, "peerDependencies": { "@volar/language-service": "~2.4.0" }, "optionalPeers": ["@volar/language-service"] }, "sha512-zqjzt6bN95e3CUstBm0PBFAJnrfz0ZAARka87fart46/gNCLLuP3Vujy8V/J8HEziTFLnfkgIASLFYPUhonJcA=="],
+
+    "volar-service-html": ["volar-service-html@0.0.71", "", { "dependencies": { "vscode-html-languageservice": "^5.3.0", "vscode-languageserver-textdocument": "^1.0.11", "vscode-uri": "^3.0.8" }, "peerDependencies": { "@volar/language-service": "~2.4.0" }, "optionalPeers": ["@volar/language-service"] }, "sha512-e8tHPhgQ7ooLfudAEIku+kgd9pWkq3SSz8RbnQDI1+Eb8wbenkLGHqoirLqz5ORLV6wIMr2Iv08RWBG5eOcgpw=="],
+
+    "volar-service-prettier": ["volar-service-prettier@0.0.71", "", { "dependencies": { "vscode-uri": "^3.0.8" }, "peerDependencies": { "@volar/language-service": "~2.4.0", "prettier": "^2.2 || ^3.0" }, "optionalPeers": ["@volar/language-service", "prettier"] }, "sha512-Rz7JVH3qD108UCdmIEiZvOBNljMt2nLFdbN8AXcDfn7xD9F5I2aCIsDVqBbXw21PsnxG0b7MfwtNF+zPS/NKUg=="],
+
+    "volar-service-typescript": ["volar-service-typescript@0.0.71", "", { "dependencies": { "path-browserify": "^1.0.1", "semver": "^7.6.2", "typescript-auto-import-cache": "^0.3.5", "vscode-languageserver-textdocument": "^1.0.11", "vscode-nls": "^5.2.0", "vscode-uri": "^3.0.8" }, "peerDependencies": { "@volar/language-service": "~2.4.0" }, "optionalPeers": ["@volar/language-service"] }, "sha512-yTtM/BVT6hoyEYnDtaCyAtNhdNeS/mhTTABlBOdw3NNiRBUin3IznFJpgfjer4c6RYopiPjjQjc9VFhxVl1mLw=="],
+
+    "volar-service-typescript-twoslash-queries": ["volar-service-typescript-twoslash-queries@0.0.71", "", { "dependencies": { "vscode-uri": "^3.0.8" }, "peerDependencies": { "@volar/language-service": "~2.4.0" }, "optionalPeers": ["@volar/language-service"] }, "sha512-9K2k72s4n7rV9s4bX0MyjbX9iBribvKZbBJKuEmTCZfeWJXs6Yh7bGpY4eoc7UufAjvpheBqwyZCOIPBvxCv0A=="],
+
+    "volar-service-yaml": ["volar-service-yaml@0.0.71", "", { "dependencies": { "vscode-uri": "^3.0.8", "yaml-language-server": "~1.23.0" }, "peerDependencies": { "@volar/language-service": "~2.4.0" }, "optionalPeers": ["@volar/language-service"] }, "sha512-qYGWGuVpUTnZGu5P/CR4KLK4aIR8RrcVnmfZ2eRcj9q/I8VZCoC5yy9FtEvfNvnDp4MU17yhdJcvpQPIqhJS2Q=="],
+
+    "vscode-css-languageservice": ["vscode-css-languageservice@6.3.10", "", { "dependencies": { "@vscode/l10n": "^0.0.18", "vscode-languageserver-textdocument": "^1.0.12", "vscode-languageserver-types": "3.17.5", "vscode-uri": "^3.1.0" } }, "sha512-eq5N9Er3fC4vA9zd9EFhyBG90wtCCuXgRSpAndaOgXMh1Wgep5lBgRIeDgjZBW9pa+332yC9+49cZMW8jcL3MA=="],
+
+    "vscode-html-languageservice": ["vscode-html-languageservice@5.6.2", "", { "dependencies": { "@vscode/l10n": "^0.0.18", "vscode-languageserver-textdocument": "^1.0.12", "vscode-languageserver-types": "^3.17.5", "vscode-uri": "^3.1.0" } }, "sha512-ulCrSnFnfQ16YzvwnYUgEbUEl/ZG7u2eV27YhvLObSHKkb8fw1Z9cgsnUwjTEeDIdJDoTDTDpxuhQwoenoLNMg=="],
+
+    "vscode-json-languageservice": ["vscode-json-languageservice@4.1.8", "", { "dependencies": { "jsonc-parser": "^3.0.0", "vscode-languageserver-textdocument": "^1.0.1", "vscode-languageserver-types": "^3.16.0", "vscode-nls": "^5.0.0", "vscode-uri": "^3.0.2" } }, "sha512-0vSpg6Xd9hfV+eZAaYN63xVVMOTmJ4GgHxXnkLCh+9RsQBkWKIghzLhW2B9ebfG+LQQg8uLtsQ2aUKjTgE+QOg=="],
+
+    "vscode-jsonrpc": ["vscode-jsonrpc@9.0.1", "", {}, "sha512-rfuA6T75H6m5EkbhtEPzre9pT0HPcDI2MMy4+nPFIBks5J8JBAUHD4tRYSgaBOijIEC7SRkC1kKyXTLqbmh9jw=="],
+
+    "vscode-languageserver": ["vscode-languageserver@9.0.1", "", { "dependencies": { "vscode-languageserver-protocol": "3.17.5" }, "bin": { "installServerIntoExtension": "bin/installServerIntoExtension" } }, "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g=="],
+
+    "vscode-languageserver-protocol": ["vscode-languageserver-protocol@3.18.2", "", { "dependencies": { "vscode-jsonrpc": "9.0.1", "vscode-languageserver-types": "3.18.0" } }, "sha512-XRyDbT0Pp3sSNti3JmxVEUMySWCSi1hhM+/KUlCy1hV1zmrqpM1OwO12EAki8blhmLuIMpaJrYbo0OzGVfK2Qg=="],
+
+    "vscode-languageserver-textdocument": ["vscode-languageserver-textdocument@1.0.12", "", {}, "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA=="],
+
+    "vscode-languageserver-types": ["vscode-languageserver-types@3.18.0", "", {}, "sha512-8TsGPNMIMiiBdkORgRSvLjuiEIiAFtO+KssmYWxQ+uSVvlf7RjK8YKCOjPzZ+YA04jXEV7+7LvkSmHkhpNS99g=="],
+
+    "vscode-nls": ["vscode-nls@5.2.0", "", {}, "sha512-RAaHx7B14ZU04EU31pT+rKz2/zSl7xMsfIZuo8pd+KZO6PXtQmpevpq3vxvWNcrGbdmhM/rr5Uw5Mz+NBfhVng=="],
+
+    "vscode-uri": ["vscode-uri@3.1.0", "", {}, "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ=="],
+
     "web-namespaces": ["web-namespaces@2.0.1", "", {}, "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="],
 
     "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
@@ -1272,7 +1420,15 @@
 
     "xxhash-wasm": ["xxhash-wasm@1.1.0", "", {}, "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA=="],
 
+    "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
+
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+
+    "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
+
+    "yaml-language-server": ["yaml-language-server@1.23.0", "", { "dependencies": { "@vscode/l10n": "^0.0.18", "ajv": "^8.17.1", "ajv-draft-04": "^1.0.0", "ajv-i18n": "^4.2.0", "prettier": "^3.8.1", "request-light": "^0.5.7", "vscode-json-languageservice": "4.1.8", "vscode-languageserver": "^9.0.0", "vscode-languageserver-textdocument": "^1.0.1", "vscode-languageserver-types": "^3.16.0", "vscode-uri": "^3.0.2", "yaml": "2.8.3" }, "bin": { "yaml-language-server": "bin/yaml-language-server" } }, "sha512-3qVyCOexLCWw06PQa5kRPwvMWMZ/eZeCRWUvgD6a0OkqL/4iCnxy2WumbWifa937Uo5xhyWJ0uxlU39ljhNh7A=="],
+
+    "yargs": ["yargs@17.7.3", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g=="],
 
     "yargs-parser": ["yargs-parser@22.0.0", "", {}, "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw=="],
 
@@ -1298,11 +1454,15 @@
 
     "@jest/schemas/@sinclair/typebox": ["@sinclair/typebox@0.27.10", "", {}, "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA=="],
 
+    "@leyabierta/web/typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
+
     "@rolldown/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
 
     "@rollup/pluginutils/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
     "@scalar/themes/@scalar/types": ["@scalar/types@0.1.7", "", { "dependencies": { "@scalar/openapi-types": "0.2.0", "@unhead/schema": "^1.11.11", "nanoid": "^5.1.5", "type-fest": "^4.20.0", "zod": "^3.23.8" } }, "sha512-irIDYzTQG2KLvFbuTI8k2Pz/R4JR+zUUSykVTbEMatkzMmVFnn1VzNSMlODbadycwZunbnL2tA27AXed9URVjw=="],
+
+    "@vscode/emmet-helper/jsonc-parser": ["jsonc-parser@2.3.1", "", {}, "sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg=="],
 
     "ansi-align/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
@@ -1311,6 +1471,12 @@
     "astro/js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
     "buffer/base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+
+    "cliui/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
     "csso/css-tree": ["css-tree@2.2.1", "", { "dependencies": { "mdn-data": "2.0.28", "source-map-js": "^1.0.1" } }, "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA=="],
 
@@ -1324,6 +1490,8 @@
 
     "log-symbols/is-unicode-supported": ["is-unicode-supported@1.3.0", "", {}, "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ=="],
 
+    "nunjucks/chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
+
     "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
@@ -1334,7 +1502,21 @@
 
     "svix/uuid": ["uuid@10.0.0", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="],
 
+    "unstorage/chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
+
     "vite/postcss": ["postcss@8.5.19", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ=="],
+
+    "vscode-css-languageservice/vscode-languageserver-types": ["vscode-languageserver-types@3.17.5", "", {}, "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="],
+
+    "vscode-languageserver/vscode-languageserver-protocol": ["vscode-languageserver-protocol@3.17.5", "", { "dependencies": { "vscode-jsonrpc": "8.2.0", "vscode-languageserver-types": "3.17.5" } }, "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg=="],
+
+    "yaml-language-server/request-light": ["request-light@0.5.8", "", {}, "sha512-3Zjgh+8b5fhRJBQZoy+zbVKpAQGLyka0MPgW3zruTF4dFFJ8Fqcfu9YsAvi/rvdcaTeWG3MkbZv4WKxAn/84Lg=="],
+
+    "yaml-language-server/yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
+
+    "yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "yargs/yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
 
     "@scalar/themes/@scalar/types/@scalar/openapi-types": ["@scalar/openapi-types@0.2.0", "", { "dependencies": { "zod": "^3.23.8" } }, "sha512-waiKk12cRCqyUCWTOX0K1WEVX46+hVUK+zRPzAahDJ7G0TApvbNkuy5wx7aoUyEk++HHde0XuQnshXnt8jsddA=="],
 
@@ -1346,14 +1528,34 @@
 
     "ansi-align/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
+    "cliui/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
     "csso/css-tree/mdn-data": ["mdn-data@2.0.28", "", {}, "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g=="],
 
     "gray-matter/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
     "jest-diff/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
+    "nunjucks/chokidar/readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
+
+    "unstorage/chokidar/readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
+
     "vite/postcss/nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
 
+    "vscode-languageserver/vscode-languageserver-protocol/vscode-jsonrpc": ["vscode-jsonrpc@8.2.0", "", {}, "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA=="],
+
+    "vscode-languageserver/vscode-languageserver-protocol/vscode-languageserver-types": ["vscode-languageserver-types@3.17.5", "", {}, "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="],
+
+    "yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "yargs/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
     "ansi-align/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
   }
 }

--- a/packages/api/src/__tests__/build-manifest.test.ts
+++ b/packages/api/src/__tests__/build-manifest.test.ts
@@ -89,10 +89,10 @@ describe("getBuildManifest()", () => {
 
 		const result = svc.getBuildManifest();
 		expect(Object.keys(result.citizens)).toHaveLength(2);
-		expect(result.citizens["BOE-A-2024-001"].summary).toBe(
+		expect(result.citizens["BOE-A-2024-001"]!.summary).toBe(
 			"This law affects taxes",
 		);
-		expect(result.citizens["BOE-A-2024-003"].summary).toBe(
+		expect(result.citizens["BOE-A-2024-003"]!.summary).toBe(
 			"This law affects housing",
 		);
 		expect(result.citizens["BOE-A-2024-002"]).toBeUndefined();
@@ -105,7 +105,7 @@ describe("getBuildManifest()", () => {
 		insertCitizenTag("BOE-A-2024-001", "article-tag", "art-1"); // article-level
 
 		const result = svc.getBuildManifest();
-		expect(result.citizens["BOE-A-2024-001"].tags).toEqual([
+		expect(result.citizens["BOE-A-2024-001"]!.tags).toEqual([
 			"autonomo",
 			"inquilino",
 		]);
@@ -132,7 +132,7 @@ describe("getBuildManifest()", () => {
 		insertMateria("BOE-A-2024-002", "Empleo");
 
 		const result = svc.getBuildManifest();
-		expect(result.citizens["BOE-A-2024-001"].materias).toEqual([
+		expect(result.citizens["BOE-A-2024-001"]!.materias).toEqual([
 			"Alquiler",
 			"Vivienda",
 		]);
@@ -153,10 +153,10 @@ describe("getBuildManifest()", () => {
 		const result = svc.getBuildManifest();
 		expect(Object.keys(result.omnibus)).toHaveLength(2);
 		expect(result.omnibus["BOE-A-2024-001"]).toHaveLength(2);
-		expect(result.omnibus["BOE-A-2024-001"][0].topic_label).toBe(
+		expect(result.omnibus["BOE-A-2024-001"]![0]!.topic_label).toBe(
 			"Fiscal reform",
 		);
-		expect(result.omnibus["BOE-A-2024-001"][1].topic_label).toBe(
+		expect(result.omnibus["BOE-A-2024-001"]![1]!.topic_label).toBe(
 			"Labor changes",
 		);
 		expect(result.omnibus["BOE-A-2024-002"]).toHaveLength(1);
@@ -167,7 +167,7 @@ describe("getBuildManifest()", () => {
 		insertOmnibusTopic("BOE-A-2024-001", 0, "Topic A");
 
 		const result = svc.getBuildManifest();
-		const topic = result.omnibus["BOE-A-2024-001"][0];
+		const topic = result.omnibus["BOE-A-2024-001"]![0]!;
 		expect(topic).toHaveProperty("topic_label");
 		expect(topic).toHaveProperty("article_count");
 		expect(topic).toHaveProperty("headline");

--- a/packages/api/src/__tests__/db-service.test.ts
+++ b/packages/api/src/__tests__/db-service.test.ts
@@ -145,7 +145,7 @@ describe("searchLaws", () => {
 
 		const { laws, total } = svc.searchLaws(undefined, { country: "es" }, 20, 0);
 		expect(total).toBe(1);
-		expect(laws[0].id).toBe("N1");
+		expect(laws[0]?.id).toBe("N1");
 	});
 
 	it("filters by rank", () => {
@@ -154,7 +154,7 @@ describe("searchLaws", () => {
 
 		const { laws } = svc.searchLaws(undefined, { rank: "ley" }, 20, 0);
 		expect(laws).toHaveLength(1);
-		expect(laws[0].id).toBe("N1");
+		expect(laws[0]?.id).toBe("N1");
 	});
 
 	it("filters by status", () => {
@@ -163,7 +163,7 @@ describe("searchLaws", () => {
 
 		const { laws } = svc.searchLaws(undefined, { status: "vigente" }, 20, 0);
 		expect(laws).toHaveLength(1);
-		expect(laws[0].id).toBe("N1");
+		expect(laws[0]?.id).toBe("N1");
 	});
 
 	it("combines multiple filters", () => {
@@ -188,7 +188,7 @@ describe("searchLaws", () => {
 			0,
 		);
 		expect(laws).toHaveLength(1);
-		expect(laws[0].id).toBe("N1");
+		expect(laws[0]?.id).toBe("N1");
 	});
 
 	it("respects limit and offset for pagination", () => {
@@ -206,7 +206,7 @@ describe("searchLaws", () => {
 		const page2 = svc.searchLaws(undefined, {}, 2, 2);
 		expect(page2.laws).toHaveLength(2);
 		// Pages should not overlap
-		expect(page1.laws[0].id).not.toBe(page2.laws[0].id);
+		expect(page1.laws[0]?.id).not.toBe(page2.laws[0]?.id);
 	});
 
 	it("searches via FTS5 when query is provided", () => {
@@ -217,7 +217,7 @@ describe("searchLaws", () => {
 
 		const { laws } = svc.searchLaws("Constitucion", {}, 20, 0);
 		expect(laws).toHaveLength(1);
-		expect(laws[0].id).toBe("N1");
+		expect(laws[0]?.id).toBe("N1");
 	});
 
 	it("ranks title matches higher than content-only matches", () => {
@@ -243,7 +243,7 @@ describe("searchLaws", () => {
 		const { laws } = svc.searchLaws("codigo penal", {}, 20, 0);
 		expect(laws).toHaveLength(3);
 		// The law with "codigo penal" in the title should come first
-		expect(laws[0].id).toBe("CP");
+		expect(laws[0]?.id).toBe("CP");
 	});
 
 	it("returns empty when FTS query has no matches", () => {
@@ -263,7 +263,7 @@ describe("searchLaws", () => {
 
 		const { laws } = svc.searchLaws("Codigo", { status: "vigente" }, 20, 0);
 		expect(laws).toHaveLength(1);
-		expect(laws[0].id).toBe("N1");
+		expect(laws[0]?.id).toBe("N1");
 	});
 });
 
@@ -302,9 +302,9 @@ describe("getBlocks", () => {
 
 		const blocks = svc.getBlocks("N1");
 		expect(blocks).toHaveLength(3);
-		expect(blocks[0].block_id).toBe("art-1");
-		expect(blocks[1].block_id).toBe("art-2");
-		expect(blocks[2].block_id).toBe("art-3");
+		expect(blocks[0]?.block_id).toBe("art-1");
+		expect(blocks[1]?.block_id).toBe("art-2");
+		expect(blocks[2]?.block_id).toBe("art-3");
 	});
 });
 
@@ -344,8 +344,8 @@ describe("getReforms", () => {
 
 		const reforms = svc.getReforms("N1");
 		expect(reforms).toHaveLength(2);
-		expect(reforms[0].date).toBe("2020-06-15");
-		expect(reforms[1].date).toBe("2024-01-01");
+		expect(reforms[0]?.date).toBe("2020-06-15");
+		expect(reforms[1]?.date).toBe("2024-01-01");
 	});
 });
 
@@ -390,8 +390,8 @@ describe("getVersions", () => {
 
 		const versions = svc.getVersions("N1", "art-1");
 		expect(versions).toHaveLength(2);
-		expect(versions[0].date).toBe("1978-12-29");
-		expect(versions[1].text).toBe("Version 2");
+		expect(versions[0]?.date).toBe("1978-12-29");
+		expect(versions[1]?.text).toBe("Version 2");
 	});
 });
 
@@ -411,10 +411,10 @@ describe("getRanks", () => {
 
 		const ranks = svc.getRanks();
 		expect(ranks).toHaveLength(2);
-		expect(ranks[0].rank).toBe("ley");
-		expect(ranks[0].count).toBe(2);
-		expect(ranks[1].rank).toBe("constitucion");
-		expect(ranks[1].count).toBe(1);
+		expect(ranks[0]?.rank).toBe("ley");
+		expect(ranks[0]?.count).toBe(2);
+		expect(ranks[1]?.rank).toBe("constitucion");
+		expect(ranks[1]?.count).toBe(1);
 	});
 });
 
@@ -430,8 +430,8 @@ describe("getRecentReforms", () => {
 
 		const recent = svc.getRecentReforms(1);
 		expect(recent).toHaveLength(1);
-		expect(recent[0].title).toBe("Law A");
-		expect(recent[0].date).toBe("2024-01-01");
+		expect(recent[0]?.title).toBe("Law A");
+		expect(recent[0]?.date).toBe("2024-01-01");
 	});
 });
 
@@ -509,12 +509,12 @@ describe("getReferencias", () => {
 
 		const anterior = svc.getReferencias("N1", "anterior");
 		expect(anterior).toHaveLength(1);
-		expect(anterior[0].relation).toBe("SE MODIFICA");
-		expect(anterior[0].target_id).toBe("BOE-X-123");
+		expect(anterior[0]?.relation).toBe("SE MODIFICA");
+		expect(anterior[0]?.target_id).toBe("BOE-X-123");
 
 		const posterior = svc.getReferencias("N1", "posterior");
 		expect(posterior).toHaveLength(1);
-		expect(posterior[0].relation).toBe("DEROGA");
+		expect(posterior[0]?.relation).toBe("DEROGA");
 	});
 });
 
@@ -582,7 +582,7 @@ describe("getRecentReformsByMaterias — base materia filter", () => {
 			"2026-01-01",
 		);
 		expect(results.length).toBe(1);
-		expect(results[0].id).toBe("N1");
+		expect(results[0]?.id).toBe("N1");
 	});
 
 	it("excludes reform matching only base materias when user has non-base", () => {
@@ -623,7 +623,7 @@ describe("getRecentReformsByMaterias — base materia filter", () => {
 			"2026-01-01",
 		);
 		expect(results.length).toBe(1);
-		expect(results[0].materia_count).toBe(3);
+		expect(results[0]?.materia_count).toBe(3);
 	});
 
 	it("orders results by match_ratio DESC (high density first)", () => {
@@ -681,9 +681,9 @@ describe("getRecentReformsByMaterias — base materia filter", () => {
 
 		expect(results.length).toBe(2);
 		// Specific law (ratio 0.6) should come before omnibus (ratio 0.15), even though omnibus is more recent
-		expect(results[0].id).toBe(specificId);
-		expect(results[1].id).toBe(omnibusId);
-		expect(results[0].match_ratio).toBeGreaterThan(results[1].match_ratio);
+		expect(results[0]?.id).toBe(specificId);
+		expect(results[1]?.id).toBe(omnibusId);
+		expect(results[0]?.match_ratio).toBeGreaterThan(results[1]!.match_ratio);
 	});
 
 	it("returns match_ratio in results", () => {
@@ -694,7 +694,7 @@ describe("getRecentReformsByMaterias — base materia filter", () => {
 			"2026-01-01",
 		);
 		expect(results.length).toBe(1);
-		expect(results[0].match_ratio).toBe(0.5); // 1 match out of 2 total
+		expect(results[0]?.match_ratio).toBe(0.5); // 1 match out of 2 total
 	});
 
 	it("returns empty for invalid jurisdiction", () => {
@@ -722,12 +722,13 @@ describe("omnibus DB functions", () => {
 			articleCount: 5,
 			isSneaked: false,
 			relatedMaterias: "[]",
+			blockIds: "[]",
 			model: "test",
 		});
 
 		let topics = svc.getOmnibusTopics("O1");
 		expect(topics).toHaveLength(1);
-		expect(topics[0].topic_label).toBe("Fiscalidad");
+		expect(topics[0]?.topic_label).toBe("Fiscalidad");
 
 		// Replace
 		svc.upsertOmnibusTopic("O1", 0, {
@@ -737,13 +738,14 @@ describe("omnibus DB functions", () => {
 			articleCount: 8,
 			isSneaked: true,
 			relatedMaterias: '["IRPF"]',
+			blockIds: "[]",
 			model: "test2",
 		});
 
 		topics = svc.getOmnibusTopics("O1");
 		expect(topics).toHaveLength(1);
-		expect(topics[0].topic_label).toBe("Fiscalidad v2");
-		expect(topics[0].is_sneaked).toBe(1);
+		expect(topics[0]?.topic_label).toBe("Fiscalidad v2");
+		expect(topics[0]?.is_sneaked).toBe(1);
 	});
 
 	it("getOmnibusTopics returns empty array for norm without topics", () => {
@@ -772,6 +774,7 @@ describe("omnibus DB functions", () => {
 			articleCount: 3,
 			isSneaked: false,
 			relatedMaterias: "[]",
+			blockIds: "[]",
 			model: "t",
 		});
 
@@ -795,14 +798,15 @@ describe("omnibus DB functions", () => {
 			articleCount: 1,
 			isSneaked: false,
 			relatedMaterias: "[]",
+			blockIds: "[]",
 			model: "t",
 		});
 
 		const results = svc.listRecentOmnibus(10);
 		expect(results.length).toBe(1);
-		expect(results[0].id).toBe("O3");
-		expect(results[0].materia_count).toBe(16);
-		expect(results[0].topic_count).toBe(1);
+		expect(results[0]?.id).toBe("O3");
+		expect(results[0]?.materia_count).toBe(16);
+		expect(results[0]?.topic_count).toBe(1);
 	});
 
 	it("getOmnibusDetail returns null for unknown norm", () => {
@@ -822,6 +826,7 @@ describe("omnibus DB functions", () => {
 			articleCount: 10,
 			isSneaked: false,
 			relatedMaterias: "[]",
+			blockIds: "[]",
 			model: "t",
 		});
 		svc.upsertOmnibusTopic("O5", 1, {
@@ -831,6 +836,7 @@ describe("omnibus DB functions", () => {
 			articleCount: 1,
 			isSneaked: true,
 			relatedMaterias: "[]",
+			blockIds: "[]",
 			model: "t",
 		});
 
@@ -838,8 +844,8 @@ describe("omnibus DB functions", () => {
 		expect(detail).not.toBeNull();
 		expect(detail!.title).toBe("Detail Test");
 		expect(detail!.topics).toHaveLength(2);
-		expect(detail!.topics[0].topic_label).toBe("Energía");
-		expect(detail!.topics[1].is_sneaked).toBe(1);
+		expect(detail!.topics[0]?.topic_label).toBe("Energía");
+		expect(detail!.topics[1]?.is_sneaked).toBe(1);
 	});
 });
 
@@ -857,6 +863,7 @@ describe("getMatchedTopics", () => {
 			articleCount: 5,
 			isSneaked: false,
 			model: "test",
+			blockIds: "[]",
 			relatedMaterias: JSON.stringify(["Trabajadores", "IRPF"]),
 		});
 		svc.upsertOmnibusTopic("MT1", 1, {
@@ -866,6 +873,7 @@ describe("getMatchedTopics", () => {
 			articleCount: 3,
 			isSneaked: true,
 			model: "test",
+			blockIds: "[]",
 			relatedMaterias: JSON.stringify(["Energía eléctrica"]),
 		});
 
@@ -882,6 +890,7 @@ describe("getMatchedTopics", () => {
 			articleCount: 5,
 			isSneaked: false,
 			model: "test",
+			blockIds: "[]",
 			relatedMaterias: JSON.stringify(["IRPF"]),
 		});
 
@@ -903,6 +912,7 @@ describe("getMatchedTopics", () => {
 			articleCount: 1,
 			isSneaked: false,
 			model: "test",
+			blockIds: "[]",
 			relatedMaterias: "not-json",
 		});
 

--- a/packages/api/src/__tests__/materia-mappings.test.ts
+++ b/packages/api/src/__tests__/materia-mappings.test.ts
@@ -39,7 +39,7 @@ describe("computeMaterias", () => {
 
 	test("work status autonomo adds the right materias", () => {
 		const result = computeMaterias(makeAnswers({ workStatus: "autonomo" }));
-		for (const m of WORK_STATUS_MATERIAS.autonomo) {
+		for (const m of WORK_STATUS_MATERIAS.autonomo!) {
 			expect(result).toContain(m);
 		}
 	});
@@ -49,11 +49,11 @@ describe("computeMaterias", () => {
 		const withoutSector = computeMaterias(makeAnswers({ sector: null }));
 
 		// Sanidad materias should only be in the with-sector result
-		for (const m of SECTOR_MATERIAS.sanidad) {
+		for (const m of SECTOR_MATERIAS.sanidad!) {
 			expect(withSector).toContain(m);
 		}
 		// At least one sanidad-specific materia should be absent without sector
-		const sanidadOnly = SECTOR_MATERIAS.sanidad.filter(
+		const sanidadOnly = SECTOR_MATERIAS.sanidad!.filter(
 			(m) => !BASE_MATERIAS.includes(m),
 		);
 		expect(sanidadOnly.some((m) => !withoutSector.includes(m))).toBe(true);
@@ -63,10 +63,10 @@ describe("computeMaterias", () => {
 		const result = computeMaterias(
 			makeAnswers({ family: ["hijos_menores", "dependiente"] }),
 		);
-		for (const m of FAMILY_MATERIAS.hijos_menores) {
+		for (const m of FAMILY_MATERIAS.hijos_menores!) {
 			expect(result).toContain(m);
 		}
-		for (const m of FAMILY_MATERIAS.dependiente) {
+		for (const m of FAMILY_MATERIAS.dependiente!) {
 			expect(result).toContain(m);
 		}
 	});
@@ -75,10 +75,10 @@ describe("computeMaterias", () => {
 		const result = computeMaterias(
 			makeAnswers({ extras: ["coche", "mascotas"] }),
 		);
-		for (const m of EXTRAS_MATERIAS.coche) {
+		for (const m of EXTRAS_MATERIAS.coche!) {
 			expect(result).toContain(m);
 		}
-		for (const m of EXTRAS_MATERIAS.mascotas) {
+		for (const m of EXTRAS_MATERIAS.mascotas!) {
 			expect(result).toContain(m);
 		}
 	});
@@ -112,7 +112,7 @@ describe("computeMaterias", () => {
 		];
 		for (const key of originalKeys) {
 			expect(SECTOR_MATERIAS[key]).toBeDefined();
-			expect(SECTOR_MATERIAS[key].length).toBeGreaterThan(0);
+			expect(SECTOR_MATERIAS[key]?.length).toBeGreaterThan(0);
 		}
 	});
 
@@ -127,7 +127,7 @@ describe("computeMaterias", () => {
 		];
 		for (const key of newKeys) {
 			expect(SECTOR_MATERIAS[key]).toBeDefined();
-			expect(SECTOR_MATERIAS[key].length).toBeGreaterThan(0);
+			expect(SECTOR_MATERIAS[key]?.length).toBeGreaterThan(0);
 		}
 	});
 
@@ -186,7 +186,7 @@ describe("computeMaterias", () => {
 
 	test("housing materias are included", () => {
 		const result = computeMaterias(makeAnswers({ housing: "hipoteca" }));
-		for (const m of HOUSING_MATERIAS.hipoteca) {
+		for (const m of HOUSING_MATERIAS.hipoteca!) {
 			expect(result).toContain(m);
 		}
 	});

--- a/packages/api/src/__tests__/reforms-route.test.ts
+++ b/packages/api/src/__tests__/reforms-route.test.ts
@@ -5,8 +5,12 @@ import { Elysia } from "elysia";
 import { reformRoutes } from "../routes/reforms.ts";
 import { DbService } from "../services/db.ts";
 
+function buildApp(dbService: DbService) {
+	return new Elysia().use(reformRoutes(dbService));
+}
+
 let db: Database;
-let app: Elysia;
+let app: ReturnType<typeof buildApp>;
 
 function seedTestData(database: Database) {
 	// Insert a norm with a national ELI source URL
@@ -89,7 +93,7 @@ beforeEach(() => {
 	seedTestData(db);
 
 	const dbService = new DbService(db);
-	app = new Elysia().use(reformRoutes(dbService));
+	app = buildApp(dbService);
 });
 
 afterEach(() => {
@@ -100,18 +104,26 @@ function request(path: string) {
 	return app.handle(new Request(`http://localhost${path}`));
 }
 
+interface PersonalReformsResponse {
+	error?: string;
+	reforms: Array<{ id: string; [key: string]: unknown }>;
+	materias: string[];
+	limit: number;
+	offset: number;
+}
+
 describe("GET /v1/reforms/personal", () => {
 	test("missing materias param returns 400", async () => {
 		const res = await request("/v1/reforms/personal");
 		expect(res.status).toBe(400);
-		const body = await res.json();
+		const body = (await res.json()) as PersonalReformsResponse;
 		expect(body.error).toContain("materias");
 	});
 
 	test("empty materias param returns 400", async () => {
 		const res = await request("/v1/reforms/personal?materias=");
 		expect(res.status).toBe(400);
-		const body = await res.json();
+		const body = (await res.json()) as PersonalReformsResponse;
 		expect(body.error).toContain("materias");
 	});
 
@@ -120,7 +132,7 @@ describe("GET /v1/reforms/personal", () => {
 			"/v1/reforms/personal?materias=Seguridad%20Social",
 		);
 		expect(res.status).toBe(200);
-		const body = await res.json();
+		const body = (await res.json()) as PersonalReformsResponse;
 		expect(body).toHaveProperty("reforms");
 		expect(body).toHaveProperty("materias");
 		expect(body).toHaveProperty("limit");
@@ -136,7 +148,7 @@ describe("GET /v1/reforms/personal", () => {
 			"/v1/reforms/personal?materias=Seguridad%20Social&limit=1&offset=0",
 		);
 		expect(res.status).toBe(200);
-		const body = await res.json();
+		const body = (await res.json()) as PersonalReformsResponse;
 		expect(body.reforms.length).toBeLessThanOrEqual(1);
 		expect(body.limit).toBe(1);
 		expect(body.offset).toBe(0);
@@ -147,7 +159,7 @@ describe("GET /v1/reforms/personal", () => {
 			"/v1/reforms/personal?materias=Seguridad%20Social&limit=100",
 		);
 		expect(res.status).toBe(200);
-		const body = await res.json();
+		const body = (await res.json()) as PersonalReformsResponse;
 		// Should include both the recent (7 days ago) and old (90 days ago) reforms
 		expect(body.reforms.length).toBe(2);
 	});
@@ -158,10 +170,10 @@ describe("GET /v1/reforms/personal", () => {
 			"/v1/reforms/personal?materias=Educaci%C3%B3n&jurisdiccion=es-pv&limit=100",
 		);
 		expect(res.status).toBe(200);
-		const body = await res.json();
+		const body = (await res.json()) as PersonalReformsResponse;
 		// Should find the Basque norm
 		expect(body.reforms.length).toBeGreaterThanOrEqual(1);
-		expect(body.reforms[0].id).toBe("BOE-A-2024-2000");
+		expect(body.reforms[0]?.id).toBe("BOE-A-2024-2000");
 	});
 
 	test("returns empty reforms array when no matches", async () => {
@@ -169,7 +181,7 @@ describe("GET /v1/reforms/personal", () => {
 			"/v1/reforms/personal?materias=NonexistentMateria&weeks=4",
 		);
 		expect(res.status).toBe(200);
-		const body = await res.json();
+		const body = (await res.json()) as PersonalReformsResponse;
 		expect(body.reforms).toEqual([]);
 	});
 
@@ -180,7 +192,7 @@ describe("GET /v1/reforms/personal", () => {
 			"/v1/reforms/personal?materias=Educaci%C3%B3n&jurisdiccion=es&limit=100",
 		);
 		expect(res.status).toBe(200);
-		const body = await res.json();
+		const body = (await res.json()) as PersonalReformsResponse;
 		expect(body.reforms).toEqual([]);
 	});
 });

--- a/packages/api/src/__tests__/routes.test.ts
+++ b/packages/api/src/__tests__/routes.test.ts
@@ -17,9 +17,35 @@ import { DbService } from "../services/db.ts";
 import type { GitService } from "../services/git.ts";
 import type { HybridSearcher } from "../services/hybrid-search.ts";
 
+function buildApp(
+	dbService: DbService,
+	gitService: GitService,
+	diffCache: LruCache<string>,
+	citizenSummaryService: CitizenSummaryService,
+	searchCache: LruCache<SearchResponse>,
+	hybridSearcher: HybridSearcher | null,
+) {
+	return new Elysia()
+		.use(
+			lawRoutes(
+				dbService,
+				gitService,
+				diffCache,
+				citizenSummaryService,
+				searchCache,
+				hybridSearcher,
+			),
+		)
+		.use(omnibusRoutes(dbService))
+		.get("/health", () => ({
+			status: "ok",
+			laws: dbService.searchLaws(undefined, {}, 0, 0).total,
+		}));
+}
+
 let db: Database;
 let dbService: DbService;
-let app: Elysia;
+let app: ReturnType<typeof buildApp>;
 
 // Minimal GitService stub — route tests focus on DB-backed endpoints
 const gitStub: GitService = {
@@ -59,22 +85,14 @@ beforeEach(() => {
 	const diffCache = new LruCache<string>(100);
 	const searchCache = new LruCache<SearchResponse>(100);
 
-	app = new Elysia()
-		.use(
-			lawRoutes(
-				dbService,
-				gitStub,
-				diffCache,
-				citizenSummaryStub,
-				searchCache,
-				hybridStub,
-			),
-		)
-		.use(omnibusRoutes(dbService))
-		.get("/health", () => ({
-			status: "ok",
-			laws: dbService.searchLaws(undefined, {}, 0, 0).total,
-		}));
+	app = buildApp(
+		dbService,
+		gitStub,
+		diffCache,
+		citizenSummaryStub,
+		searchCache,
+		hybridStub,
+	);
 });
 
 afterEach(() => {
@@ -156,7 +174,8 @@ async function req(path: string): Promise<Response> {
 	return app.handle(new Request(`http://localhost${path}`));
 }
 
-async function json(path: string) {
+// biome-ignore lint/suspicious/noExplicitAny: response shape varies per endpoint; tests assert on ad-hoc fields, a shared `any` beats per-call casts across ~70 sites.
+async function json(path: string): Promise<{ status: number; body: any }> {
 	const res = await req(path);
 	return { status: res.status, body: await res.json() };
 }
@@ -616,6 +635,7 @@ describe("GET /v1/omnibus", () => {
 			articleCount: 5,
 			isSneaked: false,
 			relatedMaterias: "[]",
+			blockIds: "[]",
 			model: "t",
 		});
 		dbService.upsertOmnibusTopic("OT1", 1, {
@@ -625,6 +645,7 @@ describe("GET /v1/omnibus", () => {
 			articleCount: 1,
 			isSneaked: true,
 			relatedMaterias: "[]",
+			blockIds: "[]",
 			model: "t",
 		});
 
@@ -657,6 +678,7 @@ describe("GET /v1/omnibus/:normId", () => {
 			articleCount: 8,
 			isSneaked: false,
 			relatedMaterias: "[]",
+			blockIds: "[]",
 			model: "t",
 		});
 
@@ -690,6 +712,7 @@ describe("GET /v1/feed-omnibus.xml", () => {
 			articleCount: 3,
 			isSneaked: false,
 			relatedMaterias: "[]",
+			blockIds: "[]",
 			model: "t",
 		});
 

--- a/packages/api/src/__tests__/status-route.test.ts
+++ b/packages/api/src/__tests__/status-route.test.ts
@@ -12,8 +12,12 @@ import { Elysia } from "elysia";
 import { statusRoutes } from "../routes/status.ts";
 import { StatusService } from "../services/status.ts";
 
+function buildApp(statusService: StatusService) {
+	return new Elysia().use(statusRoutes(statusService));
+}
+
 let db: Database;
-let app: Elysia;
+let app: ReturnType<typeof buildApp>;
 let dataDir: string;
 
 beforeEach(() => {
@@ -34,7 +38,7 @@ beforeEach(() => {
 	);
 
 	const statusService = new StatusService(db, dataDir);
-	app = new Elysia().use(statusRoutes(statusService));
+	app = buildApp(statusService);
 });
 
 afterEach(() => {
@@ -51,7 +55,15 @@ describe("GET /v1/status", () => {
 		const res = await request("/v1/status");
 		expect(res.status).toBe(200);
 
-		const body = await res.json();
+		const body = (await res.json()) as {
+			norms_count: number;
+			reforms_count: number;
+			corpus_max_published_at: string;
+			last_reform_date: string;
+			days_since_last_reform: number;
+			last_sync?: unknown;
+			last_sync_source?: unknown;
+		};
 		expect(body.norms_count).toBe(1);
 		expect(body.reforms_count).toBe(2);
 		expect(body.corpus_max_published_at).toBe("2024-01-01");
@@ -63,7 +75,7 @@ describe("GET /v1/status", () => {
 
 	test("never leaks the corrupt 2929-11-19 date as last_reform_date", async () => {
 		const res = await request("/v1/status");
-		const body = await res.json();
+		const body = (await res.json()) as { last_reform_date: string };
 		expect(body.last_reform_date).not.toBe("2929-11-19");
 	});
 

--- a/packages/api/src/__tests__/vector-pool-smoke.test.ts
+++ b/packages/api/src/__tests__/vector-pool-smoke.test.ts
@@ -93,11 +93,7 @@ describe("vectorSearchPooled smoke", () => {
 
 			// Run all 6 in parallel — pool must serialize internally.
 			const pooledAll = await Promise.all(
-				queries.map((q) =>
-					vectorSearchPooled(q, meta, index, DIMS, TOP_K, {
-						workerCount: 2,
-					}),
-				),
+				queries.map((q) => vectorSearchPooled(q, meta, index, DIMS, TOP_K)),
 			);
 
 			for (let qi = 0; qi < queries.length; qi++) {

--- a/packages/api/src/scripts/ab-thinking-on-off.ts
+++ b/packages/api/src/scripts/ab-thinking-on-off.ts
@@ -24,7 +24,7 @@ const N = args.includes("--n")
 	? Number(args[args.indexOf("--n") + 1] ?? 20)
 	: 20;
 const OUT = args.includes("--out")
-	? args[args.indexOf("--out") + 1]
+	? (args[args.indexOf("--out") + 1] ?? "tmp/thinking-ab.json")
 	: "tmp/thinking-ab.json";
 
 mkdirSync("tmp", { recursive: true });
@@ -246,6 +246,7 @@ async function worker() {
 		const idx = cursor++;
 		if (idx >= articles.length) return;
 		const a = articles[idx];
+		if (!a) continue;
 		// Sequential per article so the same upstream queue handles both;
 		// concurrency across articles uses CONC workers.
 		const on = await callQwen(a, true);

--- a/packages/api/src/scripts/backfill-citizen-summaries.ts
+++ b/packages/api/src/scripts/backfill-citizen-summaries.ts
@@ -474,9 +474,11 @@ async function fillMissingWithSingles(
 ): Promise<(BatchSummary | null)[]> {
 	for (let i = 0; i < articles.length; i++) {
 		if (outputs[i] !== null) continue;
+		const article = articles[i];
+		if (!article) continue;
 		// Single-article batch retains the same prompt/schema and lets the
 		// id-based mapping resolve the result back into position i.
-		const single = await callQwenBatch([articles[i]]);
+		const single = await callQwenBatch([article]);
 		if (!single.error && single.outputs[0]) {
 			outputs[i] = single.outputs[0];
 		}
@@ -605,7 +607,8 @@ async function mapPool<T, R>(
 			while (true) {
 				const i = cursor++;
 				if (i >= items.length) return;
-				results[i] = await fn(items[i], i);
+				// Bounds already checked above, so items[i] is always defined here.
+				results[i] = await fn(items[i]!, i);
 				completed++;
 
 				if (onProgress) {
@@ -753,7 +756,7 @@ async function main() {
 		? { norm_id: checkpoint.last_norm_id, block_id: checkpoint.last_block_id }
 		: undefined;
 
-	if (startFrom) {
+	if (startFrom && checkpoint) {
 		console.log(
 			`Resuming from checkpoint: ${startFrom.norm_id}::${startFrom.block_id} (processed ${checkpoint.processed_count})`,
 		);
@@ -846,8 +849,10 @@ async function main() {
 
 		await mapPool(apiBatches, CONCURRENCY, async (apiBatch, idx) => {
 			const result = await callQwenBatchWithRetry(apiBatch);
+			const firstArticle = apiBatch[0];
+			if (!firstArticle) throw new Error("apiBatch must not be empty");
 			allResults[idx] = {
-				article: apiBatch[0],
+				article: firstArticle,
 				outputs: result.outputs,
 				error: result.error,
 			};
@@ -862,11 +867,15 @@ async function main() {
 		}[] = [];
 		for (let apiBatchIdx = 0; apiBatchIdx < allResults.length; apiBatchIdx++) {
 			const apiBatch = apiBatches[apiBatchIdx];
-			const { outputs, error } = allResults[apiBatchIdx];
+			const batchResult = allResults[apiBatchIdx];
+			if (!apiBatch || !batchResult) continue;
+			const { outputs, error } = batchResult;
 
 			for (let i = 0; i < apiBatch.length; i++) {
+				const article = apiBatch[i];
+				if (!article) continue;
 				flatResults.push({
-					article: apiBatch[i],
+					article,
 					output: outputs[i] ?? null,
 					error: error ?? null,
 				});
@@ -917,7 +926,7 @@ async function main() {
 
 		// Checkpoint
 		const lastArticle = batch[batch.length - 1];
-		if (!DRY_RUN) {
+		if (!DRY_RUN && lastArticle) {
 			const totalProcessed = (checkpoint?.processed_count ?? 0) + batchEnd;
 			stmtUpsertCheckpoint.run(
 				lastArticle.norm_id,
@@ -966,8 +975,8 @@ async function main() {
 const ERROR_LOG = "data/backfill-error-debug.log";
 function logError(msg: string) {
 	try {
-		Bun.write(ERROR_LOG, `[${new Date().toISOString()}] ${msg}\n`, {
-			append: true,
+		writeFileSync(ERROR_LOG, `[${new Date().toISOString()}] ${msg}\n`, {
+			flag: "a",
 		});
 	} catch {}
 }

--- a/packages/api/src/scripts/compare-citizen-models.ts
+++ b/packages/api/src/scripts/compare-citizen-models.ts
@@ -36,7 +36,7 @@ const N = args.includes("--n")
 	? Number(args[args.indexOf("--n") + 1] ?? 50)
 	: 50;
 const OUT = args.includes("--out")
-	? args[args.indexOf("--out") + 1]
+	? (args[args.indexOf("--out") + 1] ?? "tmp/v10-pairs.json")
 	: "tmp/v10-pairs.json";
 
 mkdirSync("tmp", { recursive: true });
@@ -374,6 +374,7 @@ async function worker() {
 		const idx = cursor++;
 		if (idx >= articles.length) return;
 		const a = articles[idx];
+		if (!a) continue;
 		const [q, g] = await Promise.all([callQwen(a), callGemini(a)]);
 		rows[idx] = { article: a, qwen: q, gemini: g };
 		done++;

--- a/packages/eval/src/enrich-citations.ts
+++ b/packages/eval/src/enrich-citations.ts
@@ -182,10 +182,14 @@ for await (const line of rl) {
 
 // Close writers and wait for flush
 await new Promise<void>((res, rej) =>
-	outWriter.end((err) => (err ? rej(err) : res())),
+	outWriter.end((err?: NodeJS.ErrnoException | null) =>
+		err ? rej(err) : res(),
+	),
 );
 await new Promise<void>((res, rej) =>
-	auditWriter.end((err) => (err ? rej(err) : res())),
+	auditWriter.end((err?: NodeJS.ErrnoException | null) =>
+		err ? rej(err) : res(),
+	),
 );
 
 const total = processed;

--- a/packages/eval/src/sources/scrape-dgt-consultas.ts
+++ b/packages/eval/src/sources/scrape-dgt-consultas.ts
@@ -222,7 +222,7 @@ function extractTotalPages(html: string): number {
 
 async function fetchDetail(
 	docId: string,
-	category: string,
+	category: "generales" | "vinculantes",
 ): Promise<ConsultaEntry | null> {
 	const tab = category === "vinculantes" ? 2 : 1;
 	const url = `${BASE}/consultas/do/document?query=.T&doc=${docId}&tab=${tab}`;
@@ -271,7 +271,7 @@ let totalKept = seen.size;
 let totalSkipped = 0;
 let totalDocsFetched = 0;
 
-const categories = [
+const categories: { name: "generales" | "vinculantes"; url: string }[] = [
 	// { name: "generales", url: SEARCH_URLS.generales },  // skipped: all ~19.7k docIds already scraped
 	{ name: "vinculantes", url: SEARCH_URLS.vinculantes },
 ];

--- a/packages/pipeline/src/bootstrap-test.ts
+++ b/packages/pipeline/src/bootstrap-test.ts
@@ -23,8 +23,8 @@ async function main() {
 	// Discover norm IDs
 	console.log(`Discovering up to ${limit} norms from BOE...`);
 	const normIds: string[] = [];
-	for await (const id of spain.discovery().discoverAll(client)) {
-		normIds.push(id);
+	for await (const norm of spain.discovery().discoverAll(client)) {
+		normIds.push(norm.id);
 		if (normIds.length >= limit) break;
 	}
 	console.log(`Found ${normIds.length} norms.\n`);

--- a/packages/pipeline/src/scripts/generate-citizen-tags.ts
+++ b/packages/pipeline/src/scripts/generate-citizen-tags.ts
@@ -235,6 +235,15 @@ interface LlmResponse {
 	cost: number;
 }
 
+interface ChatCompletionResponse {
+	choices?: Array<{ message?: { content?: string } }>;
+	usage?: {
+		prompt_tokens?: number;
+		completion_tokens?: number;
+		cost?: number;
+	};
+}
+
 async function callLlm(
 	systemPrompt: string,
 	userPrompt: string,
@@ -286,7 +295,7 @@ async function callLlm(
 				return null;
 			}
 
-			const data = await response.json();
+			const data = (await response.json()) as ChatCompletionResponse;
 			const usage = data.usage ?? {};
 			const content = data.choices?.[0]?.message?.content ?? "";
 
@@ -324,6 +333,7 @@ function parseJson(raw: string): unknown | null {
 
 for (let i = 0; i < norms.length; i++) {
 	const norm = norms[i];
+	if (!norm) continue;
 	const jsonPath = join(WORKSPACE_ROOT, "data", "json", `${norm.id}.json`);
 
 	// Read article text from JSON cache

--- a/packages/pipeline/tests/ingest.test.ts
+++ b/packages/pipeline/tests/ingest.test.ts
@@ -266,7 +266,7 @@ describe("ingestJsonDir", () => {
 			.query("SELECT * FROM norms_fts WHERE norms_fts MATCH 'Pruebas'")
 			.all() as Array<Record<string, unknown>>;
 		expect(ftsResult).toHaveLength(1);
-		expect(ftsResult[0].norm_id).toBe("BOE-A-2024-1234");
+		expect(ftsResult[0]?.norm_id).toBe("BOE-A-2024-1234");
 	});
 
 	test("re-ingesting same norm does not create duplicates (upsert)", async () => {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -5,7 +5,8 @@
 	"scripts": {
 		"dev": "astro dev",
 		"build": "astro build",
-		"preview": "astro preview"
+		"preview": "astro preview",
+		"check": "astro check"
 	},
 	"dependencies": {
 		"@astrojs/react": "^6.0.1",
@@ -20,11 +21,13 @@
 		"zod": "^4.4.3"
 	},
 	"devDependencies": {
+		"@astrojs/check": "^0.9.9",
 		"@cloudflare/workers-types": "^5.20260718.1",
 		"@types/markdown-it": "^14.1.2",
 		"@types/react": "^19.2.14",
 		"@types/react-dom": "^19.2.3",
 		"@types/sanitize-html": "^2.16.1",
-		"gray-matter": "^4.0.3"
+		"gray-matter": "^4.0.3",
+		"typescript": "^7.0.2"
 	}
 }

--- a/packages/web/src/components/Navbar.astro
+++ b/packages/web/src/components/Navbar.astro
@@ -487,8 +487,11 @@ const NAV_LINKS = [
 
 <script>
 	// ─── Hamburguesa mobile ──────────────────────────────────
-	var menuBtn = document.getElementById("menu-toggle");
-	var navCollapse = document.getElementById("nav-collapse");
+	// const (not var) so the `menuBtn && navCollapse` narrowing below is
+	// preserved inside the event-listener closures — a reassignable var would
+	// widen back to `HTMLElement | null` and trip noUncheckedIndexedAccess.
+	const menuBtn = document.getElementById("menu-toggle");
+	const navCollapse = document.getElementById("nav-collapse");
 	if (menuBtn && navCollapse) {
 		menuBtn.addEventListener("click", function () {
 			var isOpen = navCollapse.classList.toggle("open");

--- a/packages/web/src/lib/schemas.ts
+++ b/packages/web/src/lib/schemas.ts
@@ -22,6 +22,9 @@ export const LawDetailSchema = z.object({
 	department: z.string(),
 	source_url: z.string(),
 	citizen_summary: z.string(),
+	// Law-level citizen tags (GET /v1/laws/:id returns `citizen_tags`).
+	// Defaulted so an older API response without the field still validates.
+	citizen_tags: z.array(z.string()).default([]),
 });
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,10 +11,16 @@
 	//
 	// research/archive is excluded because it is exactly that: archived,
 	// one-shot scripts kept for the record and not maintained (178 errors).
+	//
+	// research/ab is active experimentation (A/B search tuning), not
+	// production code. It is excluded for the same reason as archive: these
+	// are throwaway benchmark scripts (64 errors) and type-checking them adds
+	// noise without protecting anything citizens or the API depend on. See #140.
 	"exclude": [
 		"node_modules",
 		"packages/web",
 		"packages/api/research/archive",
+		"packages/api/research/ab",
 		"**/dist"
 	],
 	"compilerOptions": {


### PR DESCRIPTION
Cierra #140.

Deja `bunx tsgo --noEmit` en **0 errores** (venía de 273) en los paquetes del lado Bun, añade `astro check` para `packages/web`, y cablea ambos en CI para que el type-checker vuelva a ser una señal que signifique algo.

## Decisiones de alcance (ver #140)
- **Excluir `packages/api/research/ab`** (64 errores) del tsconfig: scripts activos de benchmarking A/B, mismo criterio que el ya-excluido `research/archive`. Comentado en `tsconfig.json`.
- **Arreglar de verdad los scripts operativos** (`generate-citizen-tags`, `backfill-citizen-summaries`, `compare-citizen-models`, `ab-thinking-on-off`, `enrich-citations`, `scrape-dgt-consultas`, `bootstrap-test`) — guards sobre aserciones. Esto destapó un **bug latente** en `backfill-citizen-summaries`: una llamada `Bun.write(path, data, {append})` inválida (no existe ese overload), ahora `writeFileSync(..., {flag:"a"})`.
- **Arreglar 167 errores de tests** (mayoría `noUncheckedIndexedAccess` + cuerpos de respuesta `unknown`). Los desajustes de tipo de Elysia se resuelven con el patrón `buildApp()` + `ReturnType<typeof buildApp>`. `vector-pool-smoke` tenía un 6º argumento obsoleto (el worker count ahora es interno) — drift real test/API.

## packages/web
- Añade devDeps `@astrojs/check` + `typescript` y script `check`.
- `Navbar.astro`: `const` (no `var`) para que el narrowing de DOM-null sobreviva dentro de los closures de los listeners.
- `schemas.ts`: añade `citizen_tags` a nivel de ley (la API ya lo devuelve en `GET /v1/laws/:id`).

## CI
- **Nuevo `typecheck.yml`**: gate ligero de `tsgo` en cualquier cambio de TS (sin checkout de leyes).
- **`pr-checks.yml` (build-and-smoke)**: corre `astro check` reutilizando el contenido de leyes + Node 24 que ese job ya prepara.

## Verificación
- `bunx tsgo --noEmit` → 0 errores
- `astro check` (web) → 0 errores
- `bun run check` (Biome) → exit 0 (8 warnings preexistentes en research/eval)
- `bun test` → 816 pass, 10 skip, 0 fail

## Criterios de aceptación
- [x] `bun run typecheck` en verde (con exclusiones cortas y justificadas)
- [x] `packages/web` comprobado con `astro check` en CI
- [x] Check de tipos añadido a CI (`typecheck.yml` + paso en `pr-checks.yml`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)