### PR TITLE
feat(#135): banco short-domain + boost troncal default-off (medido net-negativo)

### DIFF
--- a/packages/api/research/datasets/short-domain-troncal.json
+++ b/packages/api/research/datasets/short-domain-troncal.json
@@ -1,0 +1,29 @@
+{
+  "_comment": "Short domain-area queries (2-4 words naming an area of law) whose intent is 'take me to the backbone norm of this area'. Gold = the consolidating/troncal norm (texto refundido, código, ley general...). Built for #135. Troncal IDs verified vigente against the DB; ranks are all in the boost gate {ley, ley_organica, real_decreto_legislativo, constitucion} except where noted.",
+  "results": [
+    { "question": "seguridad social", "expectedNorms": ["BOE-A-2015-11724"], "category": "short-domain" },
+    { "question": "estatuto de los trabajadores", "expectedNorms": ["BOE-A-2015-11430"], "category": "short-domain" },
+    { "question": "proteccion de datos", "expectedNorms": ["BOE-A-2018-16673"], "category": "short-domain" },
+    { "question": "impuesto sobre la renta", "expectedNorms": ["BOE-A-2006-20764"], "category": "short-domain" },
+    { "question": "impuesto de sociedades", "expectedNorms": ["BOE-A-2014-12328"], "category": "short-domain" },
+    { "question": "enjuiciamiento civil", "expectedNorms": ["BOE-A-2000-323"], "category": "short-domain" },
+    { "question": "codigo penal", "expectedNorms": ["BOE-A-1995-25444"], "category": "short-domain" },
+    { "question": "propiedad intelectual", "expectedNorms": ["BOE-A-1996-8930"], "category": "short-domain" },
+    { "question": "impuesto sobre el valor anadido", "expectedNorms": ["BOE-A-1992-28740"], "category": "short-domain" },
+    { "question": "procedimiento administrativo", "expectedNorms": ["BOE-A-2015-10565"], "category": "short-domain" },
+    { "question": "arrendamientos urbanos", "expectedNorms": ["BOE-A-1994-26003"], "category": "short-domain" },
+    { "question": "consumidores y usuarios", "expectedNorms": ["BOE-A-2007-20555"], "category": "short-domain" },
+    { "question": "extranjeria", "expectedNorms": ["BOE-A-2000-544"], "category": "short-domain" },
+    { "question": "impuesto sobre la renta de no residentes", "expectedNorms": ["BOE-A-2004-4527"], "category": "short-domain" },
+    { "question": "transparencia", "expectedNorms": ["BOE-A-2013-12887"], "category": "short-domain" },
+    { "question": "ley general tributaria", "expectedNorms": ["BOE-A-2003-23186"], "category": "short-domain" },
+    { "question": "sociedades de capital", "expectedNorms": ["BOE-A-2010-10544"], "category": "short-domain" },
+    { "question": "ley concursal", "expectedNorms": ["BOE-A-2020-4859"], "category": "short-domain" },
+    { "question": "contratos del sector publico", "expectedNorms": ["BOE-A-2017-12902"], "category": "short-domain" },
+    { "question": "propiedad horizontal", "expectedNorms": ["BOE-A-1960-10906"], "category": "short-domain" },
+    { "question": "poder judicial", "expectedNorms": ["BOE-A-1985-12666"], "category": "short-domain" },
+    { "question": "estatuto basico del empleado publico", "expectedNorms": ["BOE-A-2015-11719"], "category": "short-domain" },
+    { "question": "bases del regimen local", "expectedNorms": ["BOE-A-1985-5392"], "category": "short-domain" },
+    { "question": "trafico y seguridad vial", "expectedNorms": ["BOE-A-2015-11722"], "category": "short-domain" }
+  ]
+}

--- a/packages/api/src/services/hybrid-search.ts
+++ b/packages/api/src/services/hybrid-search.ts
@@ -183,7 +183,7 @@ function troncalFactor(
 ): number {
 	if (weight <= 0 || !TRONCAL_RANKS.has(rank)) return 1;
 	const marker = TRONCAL_MARKER_RE.test(title) ? 1 : 0;
-	const size = Math.min(1, blocks / sat);
+	const size = sat > 0 ? Math.min(1, blocks / sat) : 1;
 	const signal = 0.5 * marker + 0.5 * size;
 	return 1 + weight * signal;
 }
@@ -263,10 +263,12 @@ export class HybridSearcherImpl implements HybridSearcher {
 		const rrfK = options.rrfK ?? 60;
 		const pool = options.pool ?? "max+sum";
 		const boostByRank = options.boostByRank ?? true;
-		const troncalBoost =
-			options.troncalBoost ?? Number(process.env.TRONCAL_BOOST ?? 0);
-		const troncalSat =
-			options.troncalSat ?? Number(process.env.TRONCAL_SAT ?? 300);
+		// Guard against a mistyped env var (`Number("abc")` → NaN): fall back to
+		// the safe default rather than silently disabling / corrupting the boost.
+		const rawBoost = options.troncalBoost ?? Number(process.env.TRONCAL_BOOST);
+		const troncalBoost = Number.isFinite(rawBoost) ? rawBoost : 0;
+		const rawSat = options.troncalSat ?? Number(process.env.TRONCAL_SAT);
+		const troncalSat = Number.isFinite(rawSat) ? rawSat : 300;
 
 		const trimmed = query.trim();
 
@@ -477,7 +479,8 @@ export class HybridSearcherImpl implements HybridSearcher {
 								troncalSat,
 							)
 						: 1;
-					return (1 / (rrfK + pos)) * factor;
+					// +1 to match the RRF convention in rrf.ts (1/(k+rank+1)).
+					return (1 / (rrfK + pos + 1)) * factor;
 				};
 				fused = fused
 					.map((r, pos) => ({ r, s: boosted(r, pos) }))

--- a/packages/api/src/services/hybrid-search.ts
+++ b/packages/api/src/services/hybrid-search.ts
@@ -34,7 +34,11 @@ import {
 	embedQuery,
 	type VectorSearchResult,
 } from "./rag/embeddings.ts";
-import { type RankedItem, reciprocalRankFusion } from "./rag/rrf.ts";
+import {
+	type RankedItem,
+	type RRFResult,
+	reciprocalRankFusion,
+} from "./rag/rrf.ts";
 import { startHybridTrace } from "./rag/tracing.ts";
 import { getSharedVectorIndex } from "./rag/vector-index-singleton.ts";
 import { vectorSearchPooled } from "./rag/vector-pool.ts";
@@ -93,6 +97,15 @@ export interface HybridSearchOptions {
 	pool?: "max" | "mean" | "max+sum";
 	/** Apply per-norm rank boost to vector scores. Default true. */
 	boostByRank?: boolean;
+	/**
+	 * Post-fusion "troncal" boost magnitude (#135). 0 disables. Lifts the
+	 * backbone norm of a legal area (large, ley-family) above the many short
+	 * "de medidas" laws that share its vocabulary. Default from env
+	 * `TRONCAL_BOOST`.
+	 */
+	troncalBoost?: number;
+	/** Block count at which the size signal saturates. Default env `TRONCAL_SAT` or 300. */
+	troncalSat?: number;
 }
 
 /**
@@ -130,6 +143,49 @@ function rankFactor(rank: string, jurisdiction: string): number {
 		default:
 			return 0.7;
 	}
+}
+
+/**
+ * Ranks eligible for the troncal boost (#135). Deliberately excludes
+ * `real_decreto` — that rank holds both implementing regulations (which must
+ * not outrank the law they develop) and the ancient codes approved by royal
+ * decree (Código Civil 1889, LECrim 1882), which are large but should not be
+ * pulled up by a domain-area query for a different code. The backbone norms of
+ * a legal area are always ley-family or a texto refundido.
+ */
+const TRONCAL_RANKS = new Set([
+	"constitucion",
+	"ley_organica",
+	"ley",
+	"real_decreto_legislativo",
+]);
+
+/**
+ * Linguistic markers of a consolidating/backbone norm. Precise on purpose:
+ * "de medidas" / "de disposiciones" laws never match these.
+ */
+const TRONCAL_MARKER_RE =
+	/texto refundido|texto articulado|ley general|\bcódigo\b|constitución/i;
+
+/**
+ * Bounded troncal factor in [1, 1+W]. Combines a title marker with the norm's
+ * size (block count), both gated to ley-family ranks. Size is the dominant,
+ * cheap discriminator: a backbone norm has hundreds of preceptos, a "de
+ * medidas" law a handful. Bounded and applied post-fusion so it breaks ties
+ * among similar-relevance candidates rather than overriding strong relevance.
+ */
+function troncalFactor(
+	rank: string,
+	blocks: number,
+	title: string,
+	weight: number,
+	sat: number,
+): number {
+	if (weight <= 0 || !TRONCAL_RANKS.has(rank)) return 1;
+	const marker = TRONCAL_MARKER_RE.test(title) ? 1 : 0;
+	const size = Math.min(1, blocks / sat);
+	const signal = 0.5 * marker + 0.5 * size;
+	return 1 + weight * signal;
 }
 
 /**
@@ -207,6 +263,10 @@ export class HybridSearcherImpl implements HybridSearcher {
 		const rrfK = options.rrfK ?? 60;
 		const pool = options.pool ?? "max+sum";
 		const boostByRank = options.boostByRank ?? true;
+		const troncalBoost =
+			options.troncalBoost ?? Number(process.env.TRONCAL_BOOST ?? 0);
+		const troncalSat =
+			options.troncalSat ?? Number(process.env.TRONCAL_SAT ?? 300);
 
 		const trimmed = query.trim();
 
@@ -384,7 +444,47 @@ export class HybridSearcherImpl implements HybridSearcher {
 			lists.set("bm25", bm25Ranked);
 			lists.set("vector_max", vectorMaxRanked);
 			if (vectorSumRanked) lists.set("vector_sum", vectorSumRanked);
-			const fused = reciprocalRankFusion(lists, rrfK, normTopK);
+			let fused = reciprocalRankFusion(lists, rrfK, normTopK);
+
+			// Post-fusion troncal boost (#135). Re-score the fused list by
+			// 1/(rrfK + position) × troncalFactor and re-sort. Applied here (not
+			// pre-fusion) so a bounded factor breaks ties among similar-relevance
+			// candidates instead of overriding relevance. Single batched metadata
+			// query over the fused set (≤ normTopK rows).
+			if (troncalBoost > 0 && fused.length > 1) {
+				const fusedIds = fused.map((r) => r.key);
+				const ph = fusedIds.map(() => "?").join(",");
+				const rows = this.db
+					.query<
+						{ id: string; rank: string; title: string; blocks: number },
+						string[]
+					>(
+						`SELECT n.id, n.rank, n.title,
+						  (SELECT COUNT(*) FROM blocks b
+						     WHERE b.norm_id = n.id AND b.block_type = 'precepto') AS blocks
+						 FROM norms n WHERE n.id IN (${ph})`,
+					)
+					.all(...fusedIds);
+				const info = new Map(rows.map((r) => [r.id, r]));
+				const boosted = (r: RRFResult, pos: number): number => {
+					const m = info.get(r.key);
+					const factor = m
+						? troncalFactor(
+								m.rank ?? "",
+								m.blocks ?? 0,
+								m.title ?? "",
+								troncalBoost,
+								troncalSat,
+							)
+						: 1;
+					return (1 / (rrfK + pos)) * factor;
+				};
+				fused = fused
+					.map((r, pos) => ({ r, s: boosted(r, pos) }))
+					.sort((a, b) => b.s - a.s)
+					.map(({ r }) => r);
+			}
+
 			const fusionMs = performance.now() - fusionStart;
 			fusionSpan.end({
 				n_lists: nLists,


### PR DESCRIPTION
Investiga #135. Añade el instrumento de medición que faltaba y un mecanismo de boost **deshabilitado por defecto** — se deja apagado porque **no pasa el eval**.

## Resultado medido (sim offline sobre la lista fusionada de prod)

**Baseline short-domain (n=24, orden real de prod):**
| R@1 | R@5 | MRR |
|---|---|---|
| **83,3%** | **95,8%** | 0,903 |

El problema es mucho más estrecho de lo asumido: 20/24 troncales ya están en #1. Solo "seguridad social" está de verdad enterrada (#6); otras 3 en #2.

**El boost troncal (tamaño + marcadores, gate por rango) es net-negativo en toda magnitud:**
| Config | short R@1 | general R@1 |
|---|---|---|
| baseline | 83,3 | 19,7 |
| boost W=0.5 | 70,8 | 12,1 |
| marker-only W=0.5 | 62,5 | 10,6 |
| solo ≥400 bloques | 50,0 | 16,7 |

Sube R@5 (mete enterradas al top-5) pero **hunde R@1**: desplaza troncales pequeñas correctas ya en #1 (p.ej. Ley de Propiedad Horizontal #1→#6). No distingue la troncal del dominio de una ley grande de dominio contiguo en el pool. Es el aviso de #131 con números.

**Caveat:** medición offline con score-proxy `1/(K+pos)` (prod no expone scores RRF reales); probablemente exagera reordenamientos. Veredicto definitivo pediría A/B en vivo (bloqueado por `NAN_API_KEY` local caducado). El baseline exacto + margen minúsculo hacen que la conclusión aguante.

## Qué incluye
- **`short-domain-troncal.json`** — banco de 24 consultas de área → troncal verificada (el instrumento que #135 no tenía).
- **`hybrid-search.ts`** — boost post-fusión tras `TRONCAL_BOOST` (**default 0 = off**). Gate a `{constitucion, ley_organica, ley, real_decreto_legislativo}`; excluye `real_decreto` para no promocionar reglamentos ni los códigos por RD (Código Civil 1889, LECrim 1882). Se deja como palanca para un A/B en vivo futuro.

**No shippea ningún cambio de ranking** (flag apagado). Merge = adquirir el dataset + la palanca; el ranking de prod no cambia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)