### PR TITLE
SEO: URLs con path para las reformas de 2026 (experimento de rastreo)

### DIFF
--- a/packages/web/src/__tests__/reform-experiment.test.ts
+++ b/packages/web/src/__tests__/reform-experiment.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from "bun:test";
+import {
+	isPathFormReform,
+	reformCanonicalPath,
+} from "../lib/reform-experiment.ts";
+import { parseReformRef } from "../worker/index.ts";
+
+const url = (u: string) => new URL(u, "https://leyabierta.es");
+
+describe("isPathFormReform", () => {
+	test("only the experiment year is in the treatment group", () => {
+		expect(isPathFormReform("2026-02-20")).toBe(true);
+		expect(isPathFormReform("2025-12-31")).toBe(false);
+		expect(isPathFormReform("1983-07-01")).toBe(false);
+	});
+
+	// "2026" must not match a date that merely contains it.
+	test("matches on the year field, not a substring", () => {
+		expect(isPathFormReform("1926-02-20")).toBe(false);
+	});
+});
+
+describe("parseReformRef", () => {
+	test("reads the query form", () => {
+		expect(
+			parseReformRef(
+				url("/cambios/reforma/?id=BOE-A-1978-31229&date=2024-02-17"),
+			),
+		).toEqual({ normId: "BOE-A-1978-31229", date: "2024-02-17" });
+	});
+
+	test("reads the path form", () => {
+		expect(
+			parseReformRef(url("/cambios/reforma/BOE-A-1978-31229/2024-02-17/")),
+		).toEqual({ normId: "BOE-A-1978-31229", date: "2024-02-17" });
+	});
+
+	test("path form works without the trailing slash", () => {
+		expect(
+			parseReformRef(url("/cambios/reforma/BOE-A-1978-31229/2024-02-17")),
+		).toEqual({ normId: "BOE-A-1978-31229", date: "2024-02-17" });
+	});
+
+	test("the bare shell has no reference", () => {
+		expect(parseReformRef(url("/cambios/reforma/"))).toBeNull();
+	});
+
+	// A non-date second segment is a stray path, not a reform address. Without
+	// this the worker would call the API with garbage on every 404-ish URL
+	// under the prefix.
+	test("rejects a second segment that isn't an ISO date", () => {
+		expect(
+			parseReformRef(url("/cambios/reforma/BOE-A-1978-31229/foo/")),
+		).toBeNull();
+		expect(
+			parseReformRef(url("/cambios/reforma/BOE-A-1978-31229/2024-2-17/")),
+		).toBeNull();
+	});
+
+	test("rejects the wrong number of segments", () => {
+		expect(
+			parseReformRef(url("/cambios/reforma/BOE-A-1978-31229/")),
+		).toBeNull();
+		expect(
+			parseReformRef(url("/cambios/reforma/a/2024-02-17/extra/")),
+		).toBeNull();
+	});
+
+	test("decodes a percent-encoded id", () => {
+		expect(
+			parseReformRef(url("/cambios/reforma/BORM-s-2001-90010/2024-02-17/")),
+		).toEqual({ normId: "BORM-s-2001-90010", date: "2024-02-17" });
+	});
+
+	// Query params win so an existing link keeps resolving exactly as before,
+	// whatever the path happens to look like.
+	test("query form takes precedence over the path", () => {
+		expect(
+			parseReformRef(
+				url("/cambios/reforma/OTHER-ID/1999-01-01/?id=BOE-A-1&date=2024-02-17"),
+			),
+		).toEqual({ normId: "BOE-A-1", date: "2024-02-17" });
+	});
+});
+
+describe("reformCanonicalPath", () => {
+	test("experiment reforms canonicalise to the path form", () => {
+		expect(reformCanonicalPath("BOE-A-2026-3212", "2026-02-20")).toBe(
+			"/cambios/reforma/BOE-A-2026-3212/2026-02-20/",
+		);
+	});
+
+	test("control reforms keep the query form", () => {
+		expect(reformCanonicalPath("BOE-A-1978-31229", "2024-02-17")).toBe(
+			"/cambios/reforma/?id=BOE-A-1978-31229&date=2024-02-17",
+		);
+	});
+
+	// The whole point of one canonical per reform: whichever URL a crawler
+	// arrives through must round-trip to the same canonical.
+	test("both URL forms round-trip to the same canonical", () => {
+		for (const u of [
+			"/cambios/reforma/BOE-A-2026-3212/2026-02-20/",
+			"/cambios/reforma/?id=BOE-A-2026-3212&date=2026-02-20",
+		]) {
+			const ref = parseReformRef(url(u));
+			expect(ref).not.toBeNull();
+			expect(reformCanonicalPath(ref!.normId, ref!.date)).toBe(
+				"/cambios/reforma/BOE-A-2026-3212/2026-02-20/",
+			);
+		}
+	});
+});

--- a/packages/web/src/__tests__/reform-experiment.test.ts
+++ b/packages/web/src/__tests__/reform-experiment.test.ts
@@ -179,3 +179,31 @@ describe("REFORM_PATH_PREFIX", () => {
 		);
 	});
 });
+
+describe("client shell stays in sync with the shared prefix", () => {
+	// The shell's script is inline browser JS: it can't import the module, so it
+	// hardcodes the route in a regex. If REFORM_PATH_PREFIX ever changes and the
+	// regex doesn't, the script stops recognising path URLs, writes "Faltan
+	// parámetros" over the server-rendered content, and every treatment URL
+	// renders as an error page for users and Googlebot alike. That exact bug
+	// shipped once; this test is what makes it loud instead of silent.
+	test("the shell's path regex matches REFORM_PATH_PREFIX", async () => {
+		const shell = await Bun.file(
+			new URL("../pages/cambios/reforma/index.astro", import.meta.url).pathname,
+		).text();
+
+		const escaped = REFORM_PATH_PREFIX.replaceAll("/", "\\/");
+		expect(shell).toContain(
+			`/^${escaped}([^/]+)\\/(\\d{4}-\\d{2}-\\d{2})\\/?$/`,
+		);
+	});
+
+	// Guards the other half of the fix: without the data-ssr bail-out the script
+	// would re-fetch and re-render over content the worker already injected.
+	test("the shell bails out on server-rendered content", async () => {
+		const shell = await Bun.file(
+			new URL("../pages/cambios/reforma/index.astro", import.meta.url).pathname,
+		).text();
+		expect(shell).toContain('contentDiv.dataset.ssr === "1"');
+	});
+});

--- a/packages/web/src/__tests__/reform-experiment.test.ts
+++ b/packages/web/src/__tests__/reform-experiment.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+	isExperimentReform,
 	isPathFormReform,
 	REFORM_PATH_PREFIX,
 	reformCanonicalPath,
@@ -8,16 +9,54 @@ import { parseReformRef } from "../worker/index.ts";
 
 const url = (u: string) => new URL(u, "https://leyabierta.es");
 
-describe("isPathFormReform", () => {
-	test("only the experiment year is in the treatment group", () => {
-		expect(isPathFormReform("2026-02-20")).toBe(true);
-		expect(isPathFormReform("2025-12-31")).toBe(false);
-		expect(isPathFormReform("1983-07-01")).toBe(false);
+describe("isExperimentReform", () => {
+	test("only the experiment year takes part", () => {
+		expect(isExperimentReform("2026-02-20")).toBe(true);
+		expect(isExperimentReform("2025-12-31")).toBe(false);
+		expect(isExperimentReform("1983-07-01")).toBe(false);
 	});
 
 	// "2026" must not match a date that merely contains it.
 	test("matches on the year field, not a substring", () => {
-		expect(isPathFormReform("1926-02-20")).toBe(false);
+		expect(isExperimentReform("1926-02-20")).toBe(false);
+	});
+});
+
+describe("isPathFormReform", () => {
+	test("nothing outside the experiment year is treatment", () => {
+		expect(isPathFormReform("BOE-A-1978-31229", "2024-02-17")).toBe(false);
+		expect(isPathFormReform("BOE-A-1978-31229", "1983-07-01")).toBe(false);
+	});
+
+	// Every caller (worker, sitemap, law page) computes assignment independently.
+	// Non-determinism would have them advertise one URL and canonicalise another.
+	test("assignment is deterministic", () => {
+		const first = isPathFormReform("BOE-A-2026-3212", "2026-02-20");
+		for (let i = 0; i < 100; i++) {
+			expect(isPathFormReform("BOE-A-2026-3212", "2026-02-20")).toBe(first);
+		}
+	});
+
+	// The split must actually split. A hash that sent everything one way would
+	// leave the experiment with no matched control and no way to notice.
+	test("splits the experiment year into two non-trivial arms", () => {
+		let path = 0;
+		const n = 400;
+		for (let i = 0; i < n; i++) {
+			if (isPathFormReform(`BOE-A-2026-${i}`, "2026-03-15")) path++;
+		}
+		// Not asserting 50/50 — just that neither arm collapsed.
+		expect(path).toBeGreaterThan(n * 0.3);
+		expect(path).toBeLessThan(n * 0.7);
+	});
+
+	test("the same reform on a different date is assigned independently", () => {
+		// Assignment keys on id AND date, so one law's reforms can land in
+		// different arms — that's intended, it's per-URL not per-law.
+		const a = isPathFormReform("BOE-A-1978-31229", "2026-01-01");
+		const b = isPathFormReform("BOE-A-1978-31229", "2026-01-02");
+		expect(typeof a).toBe("boolean");
+		expect(typeof b).toBe("boolean");
 	});
 });
 
@@ -84,14 +123,24 @@ describe("parseReformRef", () => {
 	});
 });
 
+/** A 2026 reform id that the hash puts in the path arm. */
+function pathArmId(): string {
+	for (let i = 0; i < 1000; i++) {
+		if (isPathFormReform(`BOE-A-2026-${i}`, "2026-02-20"))
+			return `BOE-A-2026-${i}`;
+	}
+	throw new Error("no path-arm id found — the split is broken");
+}
+
 describe("reformCanonicalPath", () => {
-	test("experiment reforms canonicalise to the path form", () => {
-		expect(reformCanonicalPath("BOE-A-2026-3212", "2026-02-20")).toBe(
-			"/cambios/reforma/BOE-A-2026-3212/2026-02-20/",
+	test("path-arm reforms canonicalise to the path form", () => {
+		const id = pathArmId();
+		expect(reformCanonicalPath(id, "2026-02-20")).toBe(
+			`/cambios/reforma/${id}/2026-02-20/`,
 		);
 	});
 
-	test("control reforms keep the query form", () => {
+	test("everything outside the path arm keeps the query form", () => {
 		expect(reformCanonicalPath("BOE-A-1978-31229", "2024-02-17")).toBe(
 			"/cambios/reforma/?id=BOE-A-1978-31229&date=2024-02-17",
 		);
@@ -100,14 +149,15 @@ describe("reformCanonicalPath", () => {
 	// The whole point of one canonical per reform: whichever URL a crawler
 	// arrives through must round-trip to the same canonical.
 	test("both URL forms round-trip to the same canonical", () => {
+		const id = pathArmId();
 		for (const u of [
-			"/cambios/reforma/BOE-A-2026-3212/2026-02-20/",
-			"/cambios/reforma/?id=BOE-A-2026-3212&date=2026-02-20",
+			`/cambios/reforma/${id}/2026-02-20/`,
+			`/cambios/reforma/?id=${id}&date=2026-02-20`,
 		]) {
 			const ref = parseReformRef(url(u));
 			expect(ref).not.toBeNull();
 			expect(reformCanonicalPath(ref!.normId, ref!.date)).toBe(
-				"/cambios/reforma/BOE-A-2026-3212/2026-02-20/",
+				`/cambios/reforma/${id}/2026-02-20/`,
 			);
 		}
 	});
@@ -119,6 +169,9 @@ describe("REFORM_PATH_PREFIX", () => {
 	// stop intercepting path URLs — crawlers would get 404s with no error.
 	test("every canonical URL starts with the shared prefix", () => {
 		expect(reformCanonicalPath("BOE-A-2026-1", "2026-01-01")).toStartWith(
+			REFORM_PATH_PREFIX,
+		);
+		expect(reformCanonicalPath(pathArmId(), "2026-02-20")).toStartWith(
 			REFORM_PATH_PREFIX,
 		);
 		expect(reformCanonicalPath("BOE-A-2020-1", "2020-01-01")).toStartWith(

--- a/packages/web/src/__tests__/reform-experiment.test.ts
+++ b/packages/web/src/__tests__/reform-experiment.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
 	isPathFormReform,
+	REFORM_PATH_PREFIX,
 	reformCanonicalPath,
 } from "../lib/reform-experiment.ts";
 import { parseReformRef } from "../worker/index.ts";
@@ -109,5 +110,19 @@ describe("reformCanonicalPath", () => {
 				"/cambios/reforma/BOE-A-2026-3212/2026-02-20/",
 			);
 		}
+	});
+});
+
+describe("REFORM_PATH_PREFIX", () => {
+	// The worker imports this rather than keeping its own copy: a local
+	// redefinition would let the base path drift, and the worker would silently
+	// stop intercepting path URLs — crawlers would get 404s with no error.
+	test("every canonical URL starts with the shared prefix", () => {
+		expect(reformCanonicalPath("BOE-A-2026-1", "2026-01-01")).toStartWith(
+			REFORM_PATH_PREFIX,
+		);
+		expect(reformCanonicalPath("BOE-A-2020-1", "2020-01-01")).toStartWith(
+			REFORM_PATH_PREFIX,
+		);
 	});
 });

--- a/packages/web/src/__tests__/worker-reform-routing.test.ts
+++ b/packages/web/src/__tests__/worker-reform-routing.test.ts
@@ -92,7 +92,7 @@ describe("worker reform routing", () => {
 		);
 	});
 
-	test("query form still renders, canonical stays query form for a control reform", async () => {
+	test("query form still renders, canonical stays query form outside the path arm", async () => {
 		stubApi(200, {
 			...REFORM,
 			reform: { ...REFORM.reform, date: "2024-02-17" },
@@ -119,6 +119,24 @@ describe("worker reform routing", () => {
 		expect(html).toContain("Detalle de reforma");
 		// Fallback keeps the noindex — an empty shell must not be indexed.
 		expect(html).toContain('name="robots"');
+	});
+
+	// The gap that let the P0 through: asserting on the Response HTML alone says
+	// nothing about what the shell's client script does to it afterwards, and
+	// Googlebot runs that script. The script bails on data-ssr, so the rendered
+	// content survives.
+	test("server-rendered content is flagged so the client script won't overwrite it", async () => {
+		stubApi(200);
+		const res = await get("/cambios/reforma/BOE-A-1978-31229/2026-05-20/");
+		const html = await res.text();
+		expect(html).toContain('<div id="reforma-content" data-ssr="1">');
+	});
+
+	test("the fallback shell is NOT flagged — the client script must take over", async () => {
+		stubApi(404, { error: "not found" });
+		const res = await get("/cambios/reforma/BOE-A-9999-9999/2026-01-01/");
+		const html = await res.text();
+		expect(html).not.toContain('data-ssr="1"');
 	});
 
 	test("the bare shell is served 200 with its noindex", async () => {

--- a/packages/web/src/__tests__/worker-reform-routing.test.ts
+++ b/packages/web/src/__tests__/worker-reform-routing.test.ts
@@ -1,0 +1,137 @@
+// Integration test for the worker's reform routing, with ASSETS and the API
+// both stubbed. `wrangler dev` can't stand in for this: it needs the real API
+// (and the 12k-file dist trips its asset watcher), so the path-form route would
+// otherwise only ever be exercised in production.
+import { afterEach, describe, expect, test } from "bun:test";
+import worker, { type Env } from "../worker/index.ts";
+
+const SHELL = `<!DOCTYPE html><html><head><title>Detalle de reforma — Ley Abierta</title>
+<meta name="description" content="Qué ha cambiado en esta ley y por qué te importa." />
+<meta name="robots" content="noindex, follow" />
+<link rel="icon" href="/favicon.png" />
+<meta property="og:title" content="Detalle de reforma — Ley Abierta" />
+<meta property="og:description" content="x" /><meta property="og:url" content="x" />
+<meta name="twitter:title" content="x" /><meta name="twitter:description" content="x" />
+</head><body><div id="reforma-content"><div>cargando…</div></div></body></html>`;
+
+// Shape mirrors GET /v1/reforms/:id/:date — trimmed, but the same fields the
+// renderer reads. A hand-invented shape silently falls back to the shell.
+const REFORM = {
+	law: {
+		id: "BOE-A-1978-31229",
+		title: "Constitución Española",
+		short_title: "Constitución Española",
+		rank: "constitucion",
+		status: "vigente",
+		source_url: "https://www.boe.es/eli/es/c/1978/12/27/(1)",
+		last_reform_date: "2026-05-20",
+	},
+	reform: {
+		norm_id: "BOE-A-1978-31229",
+		date: "2026-05-20",
+		source_id: "BOE-A-2026-10881",
+		headline: "Modificación del Artículo 69",
+		summary: "Cambia la asignación de Senadores en provincias insulares.",
+		importance: "medium",
+	},
+	affected_blocks: [
+		{
+			block_id: "a69",
+			block_type: "precepto",
+			title: "Artículo 69",
+			before_text: "Artículo 69\n\n1. El Senado es la Cámara territorial.",
+			after_text:
+				"Artículo 69\n\n1. El Senado es la Cámara de representación territorial.",
+		},
+	],
+	prev_reform_date: "2024-02-17",
+	next_reform_date: null,
+	source_url: "https://www.boe.es/diario_boe/txt.php?id=BOE-A-2026-10881",
+};
+
+/** ASSETS binding that always returns the shell, like the real one does. */
+const assets = {
+	fetch: async () =>
+		new Response(SHELL, {
+			status: 200,
+			headers: { "content-type": "text/html" },
+		}),
+} as unknown as Fetcher;
+
+const env: Env = { ASSETS: assets, PUBLIC_API_URL: "https://api.test" };
+
+const realFetch = globalThis.fetch;
+afterEach(() => {
+	globalThis.fetch = realFetch;
+});
+
+function stubApi(status: number, body: unknown = REFORM) {
+	globalThis.fetch = (async () =>
+		new Response(JSON.stringify(body), {
+			status,
+			headers: { "content-type": "application/json" },
+		})) as unknown as typeof fetch;
+}
+
+const get = (path: string) =>
+	worker.fetch(new Request(`https://leyabierta.es${path}`), env);
+
+describe("worker reform routing", () => {
+	test("path form renders and becomes indexable", async () => {
+		stubApi(200);
+		const res = await get("/cambios/reforma/BOE-A-1978-31229/2026-05-20/");
+		expect(res.status).toBe(200);
+		const html = await res.text();
+
+		expect(html).toContain("Modificación del Artículo 69");
+		// The shell's noindex must be gone — this is real content now.
+		expect(html).not.toContain('name="robots"');
+		// ...and it must point at itself, in path form.
+		expect(html).toContain(
+			'<link rel="canonical" href="https://leyabierta.es/cambios/reforma/BOE-A-1978-31229/2026-05-20/" />',
+		);
+	});
+
+	test("query form still renders, canonical stays query form for a control reform", async () => {
+		stubApi(200, {
+			...REFORM,
+			reform: { ...REFORM.reform, date: "2024-02-17" },
+		});
+		const res = await get(
+			"/cambios/reforma/?id=BOE-A-1978-31229&date=2024-02-17",
+		);
+		expect(res.status).toBe(200);
+		const html = await res.text();
+		expect(html).not.toContain('name="robots"');
+		expect(html).toContain(
+			'href="https://leyabierta.es/cambios/reforma/?id=BOE-A-1978-31229&amp;date=2024-02-17"',
+		);
+	});
+
+	// The regression this guards: forwarding the inbound request to ASSETS for a
+	// path-form URL would 404 (no such asset), handing crawlers a hard 404 for a
+	// reform that merely failed to render. It must fall back to the shell.
+	test("path form falls back to the shell when the API 404s", async () => {
+		stubApi(404, { error: "not found" });
+		const res = await get("/cambios/reforma/BOE-A-9999-9999/2026-01-01/");
+		expect(res.status).toBe(404);
+		const html = await res.text();
+		expect(html).toContain("Detalle de reforma");
+		// Fallback keeps the noindex — an empty shell must not be indexed.
+		expect(html).toContain('name="robots"');
+	});
+
+	test("the bare shell is served 200 with its noindex", async () => {
+		stubApi(200);
+		const res = await get("/cambios/reforma/");
+		expect(res.status).toBe(200);
+		expect(await res.text()).toContain('name="robots"');
+	});
+
+	test("a stray path under the prefix serves the shell, not a render", async () => {
+		stubApi(200);
+		const res = await get("/cambios/reforma/not-a-reform/");
+		expect(res.status).toBe(200);
+		expect(await res.text()).toContain('name="robots"');
+	});
+});

--- a/packages/web/src/lib/reform-experiment.ts
+++ b/packages/web/src/lib/reform-experiment.ts
@@ -5,42 +5,75 @@
  * ~35k `/cambios/reforma/?id=&date=` URLs. A URL Inspection sweep of 600 found
  * 339 "Discovered - currently not indexed", 261 unknown to Google, and zero
  * with a `lastCrawlTime`. Meanwhile law pages under `/leyes/<id>/` — same site,
- * same shell, real paths — are crawled routinely (median 74 days) even though
- * most aren't indexed. The difference between the two cohorts is the URL shape.
+ * same shell, real paths — are crawled routinely (99.1%) even though most
+ * aren't indexed. The difference between the two cohorts is the URL shape.
  *
  * Hypothesis: 35k URLs differing only in query string read as faceted
  * navigation, and Google won't spend crawl budget on that for a domain with
  * our authority. Path URLs should get crawled.
  *
- * Rather than migrate all 35k at once on an untested hypothesis, only reforms
- * from `EXPERIMENT_YEAR` (688 URLs) switch to the path form. They are the
- * treatment group; the other ~34.3k keep the query form and act as control.
- * If Googlebot starts crawling the treatment group and not the control, the
- * hypothesis holds and the rest can follow.
+ * ## Why the split is random within one year, not "2026 vs older"
  *
- * Both URL forms are always *served* — this only decides which one is canonical
+ * The obvious design — migrate 2026, keep the rest as control — confounds URL
+ * shape with recency. Google prefers fresh content and recently-changed laws
+ * carry more internal links, so 2026 URLs could start getting crawled for
+ * reasons that have nothing to do with their shape. That result would look like
+ * success and would justify migrating the other 34k on a false premise.
+ *
+ * So the split is *within* 2026: each reform is assigned to path or query form
+ * by a hash of its identity, giving two arms of ~331 that are identical in
+ * freshness, link structure and law mix. The only systematic difference left is
+ * the URL shape, which is the thing under test. Pre-2026 reforms stay on the
+ * query form and are reported separately as historical background, never as the
+ * control the verdict rests on.
+ *
+ * Assignment must be deterministic: the worker, the sitemap and the law page
+ * each compute it independently, and a random assignment would put them in
+ * disagreement — advertising one URL while canonicalising another.
+ *
+ * Both URL forms are always *served*. This only decides which one is canonical
  * and which one goes in the sitemap. Nothing breaks for existing links.
  */
 
-/** Reforms dated in this year use path-form URLs. */
+/** Reforms dated in this year take part in the experiment. */
 export const EXPERIMENT_YEAR = "2026";
-
-/** True when a reform's date puts it in the path-form treatment group. */
-export function isPathFormReform(date: string): boolean {
-	return date.startsWith(`${EXPERIMENT_YEAR}-`);
-}
 
 /** Base path for reform detail pages, both URL forms. */
 export const REFORM_PATH_PREFIX = "/cambios/reforma/";
 
+/** True when a reform's date falls in the experiment year (either arm). */
+export function isExperimentReform(date: string): boolean {
+	return date.startsWith(`${EXPERIMENT_YEAR}-`);
+}
+
 /**
- * Canonical URL for a reform. Reforms in the path-form experiment canonicalise
- * to the path; every other reform keeps the query form. Serving one canonical
- * per reform matters more than which form wins — two indexable URLs for the
- * same content is the failure mode to avoid while both are live.
+ * FNV-1a over `<normId>|<date>`. Any stable hash would do; what matters is that
+ * it depends only on the reform's identity, so every caller agrees without
+ * sharing state.
+ */
+function hash(normId: string, date: string): number {
+	let h = 0x811c9dc5;
+	const key = `${normId}|${date}`;
+	for (let i = 0; i < key.length; i++) {
+		h ^= key.charCodeAt(i);
+		h = Math.imul(h, 0x01000193) >>> 0;
+	}
+	return h;
+}
+
+/** True when this reform is in the path-form (treatment) arm. */
+export function isPathFormReform(normId: string, date: string): boolean {
+	return isExperimentReform(date) && hash(normId, date) % 2 === 0;
+}
+
+/**
+ * Canonical URL for a reform: path form for the treatment arm, query form for
+ * everything else. Serving one canonical per reform matters more than which
+ * form wins — two indexable URLs for the same content is the failure mode to
+ * avoid while both are live.
  */
 export function reformCanonicalPath(normId: string, date: string): string {
-	return isPathFormReform(date)
+	return isPathFormReform(normId, date)
 		? `${REFORM_PATH_PREFIX}${encodeURIComponent(normId)}/${date}/`
 		: `${REFORM_PATH_PREFIX}?id=${encodeURIComponent(normId)}&date=${encodeURIComponent(date)}`;
 }

--- a/packages/web/src/lib/reform-experiment.ts
+++ b/packages/web/src/lib/reform-experiment.ts
@@ -1,0 +1,46 @@
+/**
+ * Path-form reform URLs — a scoped crawlability experiment.
+ *
+ * Background: as of 2026-07-28 Google had never crawled a single one of the
+ * ~35k `/cambios/reforma/?id=&date=` URLs. A URL Inspection sweep of 600 found
+ * 339 "Discovered - currently not indexed", 261 unknown to Google, and zero
+ * with a `lastCrawlTime`. Meanwhile law pages under `/leyes/<id>/` — same site,
+ * same shell, real paths — are crawled routinely (median 74 days) even though
+ * most aren't indexed. The difference between the two cohorts is the URL shape.
+ *
+ * Hypothesis: 35k URLs differing only in query string read as faceted
+ * navigation, and Google won't spend crawl budget on that for a domain with
+ * our authority. Path URLs should get crawled.
+ *
+ * Rather than migrate all 35k at once on an untested hypothesis, only reforms
+ * from `EXPERIMENT_YEAR` (688 URLs) switch to the path form. They are the
+ * treatment group; the other ~34.3k keep the query form and act as control.
+ * If Googlebot starts crawling the treatment group and not the control, the
+ * hypothesis holds and the rest can follow.
+ *
+ * Both URL forms are always *served* — this only decides which one is canonical
+ * and which one goes in the sitemap. Nothing breaks for existing links.
+ */
+
+/** Reforms dated in this year use path-form URLs. */
+export const EXPERIMENT_YEAR = "2026";
+
+/** True when a reform's date puts it in the path-form treatment group. */
+export function isPathFormReform(date: string): boolean {
+	return date.startsWith(`${EXPERIMENT_YEAR}-`);
+}
+
+/** Base path for reform detail pages, both URL forms. */
+export const REFORM_PATH_PREFIX = "/cambios/reforma/";
+
+/**
+ * Canonical URL for a reform. Reforms in the path-form experiment canonicalise
+ * to the path; every other reform keeps the query form. Serving one canonical
+ * per reform matters more than which form wins — two indexable URLs for the
+ * same content is the failure mode to avoid while both are live.
+ */
+export function reformCanonicalPath(normId: string, date: string): string {
+	return isPathFormReform(date)
+		? `${REFORM_PATH_PREFIX}${encodeURIComponent(normId)}/${date}/`
+		: `${REFORM_PATH_PREFIX}?id=${encodeURIComponent(normId)}&date=${encodeURIComponent(date)}`;
+}

--- a/packages/web/src/pages/cambios/reforma/index.astro
+++ b/packages/web/src/pages/cambios/reforma/index.astro
@@ -210,6 +210,21 @@ import Base from "../../../layouts/Base.astro";
 
 	<script is:inline>
 		(function () {
+			// A reform is addressable two ways — /cambios/reforma/<id>/<date>/ and
+			// /cambios/reforma/?id=&date=. This MUST stay in sync with
+			// parseReformRef() in src/worker/index.ts: if the two disagree, the
+			// worker renders one reform server-side and this script fetches
+			// another (or none, blanking the page).
+			function reformRef() {
+				var q = new URLSearchParams(window.location.search);
+				var qId = q.get("id"), qDate = q.get("date");
+				if (qId && qDate) return { id: qId, date: qDate };
+				var m = window.location.pathname.match(
+					/^\/cambios\/reforma\/([^/]+)\/(\d{4}-\d{2}-\d{2})\/?$/
+				);
+				return m ? { id: decodeURIComponent(m[1]), date: m[2] } : null;
+			}
+
 			// Generic LCS-based sequence diff (works for both token arrays and paragraph arrays)
 			function seqDiff(a, b, eq) {
 				var n = a.length, m = b.length;
@@ -343,7 +358,8 @@ import Base from "../../../layouts/Base.astro";
 			if (backLink) {
 				var params = new URLSearchParams(window.location.search);
 				var from = params.get("from");
-				var normId = params.get("id") || "";
+				var backRef = reformRef();
+				var normId = backRef ? backRef.id : "";
 
 				if (from === "cambios") {
 					backLink.innerHTML = "&larr; Volver a cambios recientes";
@@ -394,14 +410,19 @@ import Base from "../../../layouts/Base.astro";
 			};
 
 			var qParams = new URLSearchParams(window.location.search);
-			var normId = qParams.get("id") || "";
-			var date = qParams.get("date");
+			var ref = reformRef();
+			var normId = ref ? ref.id : "";
+			var date = ref ? ref.date : null;
 			var topicParam = qParams.get("topic");
 			var topicIndex = topicParam !== null ? parseInt(topicParam, 10) : NaN;
 			var fromOmnibus = qParams.get("from") === "omnibus";
 
 			var API = document.documentElement.dataset.api;
 			var contentDiv = document.getElementById("reforma-content");
+
+			// The worker already rendered this server-side: leave it alone. Re-fetching
+			// would flash the content and, worse, replace it if anything failed here.
+			if (contentDiv && contentDiv.dataset.ssr === "1") return;
 
 			if (!normId || !date) {
 				contentDiv.innerHTML = '<div class="error-state"><p>Faltan parámetros.</p></div>';
@@ -580,11 +601,13 @@ import Base from "../../../layouts/Base.astro";
 				.catch(function () {
 					var params2 = new URLSearchParams(window.location.search);
 					var from2 = params2.get("from") || "";
+					var errRef = reformRef();
+					var errId = errRef ? errRef.id : "";
 					var errorBackHref = "/cambios/para-mi/";
 					var errorBackLabel = "Volver a mis cambios";
 					if (from2 === "cambios") { errorBackHref = "/cambios/recientes/"; errorBackLabel = "Volver a cambios recientes"; }
-					else if (from2 === "omnibus") { errorBackHref = "/leyes/" + encodeURIComponent(params2.get("id") || "") + "/"; errorBackLabel = "Volver a la ley"; }
-					else if (from2 === "law") { errorBackHref = "/leyes/" + encodeURIComponent(params2.get("id") || "") + "/"; errorBackLabel = "Volver a la ley"; }
+					else if (from2 === "omnibus") { errorBackHref = "/leyes/" + encodeURIComponent(errId) + "/"; errorBackLabel = "Volver a la ley"; }
+					else if (from2 === "law") { errorBackHref = "/leyes/" + encodeURIComponent(errId) + "/"; errorBackLabel = "Volver a la ley"; }
 					contentDiv.innerHTML = '<div class="error-state"><p>No se pudo cargar la reforma.</p><a href="' + errorBackHref + '" style="color:var(--accent)">' + errorBackLabel + '</a></div>';
 				});
 		})();

--- a/packages/web/src/pages/leyes/[id].astro
+++ b/packages/web/src/pages/leyes/[id].astro
@@ -965,8 +965,9 @@ const seoDescription = [
 					// experiment cohort, query for the rest) so internal links and
 					// the sitemap agree. `from=law` stays a UI-only param — it
 					// drives the back link and is absent from the canonical.
+					const canonical = reformCanonicalPath(id, reform.fecha);
 					const reformaUrl = !isOriginal
-						? `${reformCanonicalPath(id, reform.fecha)}${reformCanonicalPath(id, reform.fecha).includes("?") ? "&" : "?"}from=law`
+						? `${canonical}${canonical.includes("?") ? "&" : "?"}from=law`
 						: null;
 					return (
 						<li class="timeline-item">

--- a/packages/web/src/pages/leyes/[id].astro
+++ b/packages/web/src/pages/leyes/[id].astro
@@ -7,6 +7,7 @@ import Base from "../../layouts/Base.astro";
 import { safeJsonLd } from "../../lib/escape";
 import { getLaw } from "../../lib/api.ts";
 import { bakeArticleSummaries } from "../../lib/article-summaries.ts";
+import { reformCanonicalPath } from "../../lib/reform-experiment.ts";
 import { loadArticleSummaries, loadManifest } from "../../lib/manifest.ts";
 
 // Shift all heading levels down by 1 (h1→h2, h2→h3, etc.) so the page
@@ -960,7 +961,13 @@ const seoDescription = [
 			<ul class="timeline">
 				{reforms.map((reform, i) => {
 					const isOriginal = i === reforms.length - 1;
-					const reformaUrl = !isOriginal ? `/cambios/reforma/?id=${id}&date=${reform.fecha}&from=law` : null;
+					// Link to the reform's canonical URL form (path for the
+					// experiment cohort, query for the rest) so internal links and
+					// the sitemap agree. `from=law` stays a UI-only param — it
+					// drives the back link and is absent from the canonical.
+					const reformaUrl = !isOriginal
+						? `${reformCanonicalPath(id, reform.fecha)}${reformCanonicalPath(id, reform.fecha).includes("?") ? "&" : "?"}from=law`
+						: null;
 					return (
 						<li class="timeline-item">
 							<div class="timeline-dot"></div>

--- a/packages/web/src/pages/sitemap-reformas.xml.ts
+++ b/packages/web/src/pages/sitemap-reformas.xml.ts
@@ -18,6 +18,7 @@
 
 import { getCollection } from "astro:content";
 import type { APIRoute } from "astro";
+import { reformCanonicalPath } from "../lib/reform-experiment.ts";
 import { clampLastmod, isPlausibleReformDate } from "../lib/sitemap-dates.ts";
 
 export const prerender = true;
@@ -45,7 +46,14 @@ export const GET: APIRoute = async () => {
 
 			// lastmod must never be in the future (Google flags it as invalid).
 			const lastmod = clampLastmod(reforma.fecha, TODAY_ISO);
-			const loc = `${SITE_URL}/cambios/reforma/?id=${encodeURIComponent(d.identificador)}&amp;date=${encodeURIComponent(reforma.fecha)}`;
+			// Path form for the experiment cohort, query form for the rest. The
+			// sitemap must advertise exactly the URL the worker calls canonical,
+			// or we'd be asking Google to index a URL that points elsewhere.
+			const loc =
+				`${SITE_URL}${reformCanonicalPath(d.identificador, reforma.fecha)}`.replace(
+					/&(?!amp;)/g,
+					"&amp;",
+				);
 			urls.push(`  <url>
     <loc>${loc}</loc>
     <lastmod>${lastmod}</lastmod>

--- a/packages/web/src/worker/index.ts
+++ b/packages/web/src/worker/index.ts
@@ -15,6 +15,7 @@
 // based (fast, complete) while still giving crawlers real SSR content on the
 // one route that needs it for SEO.
 
+import { reformCanonicalPath } from "../lib/reform-experiment.ts";
 import type {
 	AffectedBlock,
 	OmnibusResponse,
@@ -234,15 +235,50 @@ async function fetchJson<T>(
 
 type RenderFailure = { ok: false; status: number };
 
+/**
+ * A reform is addressable two ways:
+ *
+ *   /cambios/reforma/<normId>/<date>/     ← path form (preferred)
+ *   /cambios/reforma/?id=<normId>&date=<date>   ← legacy query form
+ *
+ * The query form is the original one, and as of 2026-07-28 Google had crawled
+ * exactly zero of its ~35k URLs: a URL Inspection sweep of 600 of them found
+ * 339 "Discovered - currently not indexed" and 261 unknown, with no
+ * `lastCrawlTime` on any. The working hypothesis is that 35k URLs differing
+ * only in query string read as faceted navigation, which Google declines to
+ * spend crawl budget on for a low-authority domain. The path form tests that.
+ *
+ * Both are accepted: the query form must keep working for existing links,
+ * bookmarks and the client-side shell, and it stays canonical for reforms not
+ * in the experiment — see `reformCanonicalPath`.
+ */
+export function parseReformRef(
+	url: URL,
+): { normId: string; date: string } | null {
+	const qId = url.searchParams.get("id");
+	const qDate = url.searchParams.get("date");
+	if (qId && qDate) return { normId: qId, date: qDate };
+
+	const rest = url.pathname.slice(REFORM_PATH_PREFIX.length).replace(/\/$/, "");
+	if (!rest) return null;
+	const parts = rest.split("/");
+	if (parts.length !== 2) return null;
+	const [rawId, rawDate] = parts;
+	if (!rawId || !rawDate) return null;
+	// Only ISO dates — anything else is a stray path, not a reform address.
+	if (!/^\d{4}-\d{2}-\d{2}$/.test(rawDate)) return null;
+	return { normId: decodeURIComponent(rawId), date: rawDate };
+}
+
 async function renderReformResponse(
 	env: Env,
 	url: URL,
 ): Promise<Response | RenderFailure> {
-	const normId = url.searchParams.get("id");
-	const date = url.searchParams.get("date");
-	// No params → the bare shell is a valid (noindex) page; serve it at 200,
+	const ref = parseReformRef(url);
+	// No id/date → the bare shell is a valid (noindex) page; serve it at 200,
 	// not 404, and let the client-side script show "Faltan parámetros".
-	if (!normId || !date) return { ok: false, status: 200 };
+	if (!ref) return { ok: false, status: 200 };
+	const { normId, date } = ref;
 
 	const apiBase = env.PUBLIC_API_URL || DEFAULT_API_BASE;
 	const headers: HeadersInit = env.API_BYPASS_KEY
@@ -331,7 +367,7 @@ async function renderReformResponse(
 		// Canonical intentionally omits `from`/`topic` — those are navigation
 		// context, not a distinct piece of content, and would otherwise create
 		// duplicate-content variants of the same reform for search engines.
-		const canonicalPath = `/cambios/reforma/?id=${encodeURIComponent(normId)}&date=${encodeURIComponent(date)}`;
+		const canonicalPath = reformCanonicalPath(normId, date);
 
 		html = injectMeta(injected, { title, description, canonicalPath });
 	} catch {
@@ -372,7 +408,17 @@ export default {
 			// static shell as-is (keeps its `noindex`, lets the existing
 			// client-side fetch script take over), mirroring the resolved
 			// status onto the response.
-			const shellRes = await env.ASSETS.fetch(request);
+			//
+			// Always request SHELL_PATH explicitly, never the inbound request:
+			// path-form URLs (/cambios/reforma/<id>/<date>/) have no asset of
+			// their own, so forwarding the request would 404 the fallback and
+			// hand crawlers a hard 404 for a reform that merely failed to
+			// render. The shell is the one asset that exists for every reform.
+			const shellRes = await env.ASSETS.fetch(
+				new Request(new URL(SHELL_PATH, url).toString(), {
+					headers: request.headers,
+				}),
+			);
 			if (result.status === shellRes.status) return shellRes;
 			return new Response(shellRes.body, {
 				status: result.status,

--- a/packages/web/src/worker/index.ts
+++ b/packages/web/src/worker/index.ts
@@ -15,7 +15,10 @@
 // based (fast, complete) while still giving crawlers real SSR content on the
 // one route that needs it for SEO.
 
-import { reformCanonicalPath } from "../lib/reform-experiment.ts";
+import {
+	REFORM_PATH_PREFIX,
+	reformCanonicalPath,
+} from "../lib/reform-experiment.ts";
 import type {
 	AffectedBlock,
 	OmnibusResponse,
@@ -34,8 +37,9 @@ export interface Env {
 }
 
 const DEFAULT_API_BASE = "https://api.leyabierta.es";
-const REFORM_PATH_PREFIX = "/cambios/reforma/";
-const SHELL_PATH = "/cambios/reforma/";
+// The static shell asset lives at the prefix itself — every reform, whichever
+// URL form it uses, falls back to this one file.
+const SHELL_PATH = REFORM_PATH_PREFIX;
 
 // --- Markdown for Agents ---------------------------------------------------
 // Content negotiation: requests carrying `Accept: text/markdown` get the

--- a/packages/web/src/worker/index.ts
+++ b/packages/web/src/worker/index.ts
@@ -143,8 +143,15 @@ function injectContent(shellHtml: string, contentHtml: string): string | null {
 	const contentStart = startIdx + marker.length;
 	const closeIdx = findMatchingDivClose(shellHtml, contentStart);
 	if (closeIdx === -1) return null;
+	// Flag the container as server-rendered. The shell's client script bails out
+	// when it sees this, so it can't overwrite real content with its own fetch
+	// (or, on a path-form URL it fails to parse, with "Faltan parámetros").
+	// Googlebot executes that script, so without the flag the treatment cohort
+	// would render as an error page and the experiment would measure nothing.
 	return (
-		shellHtml.slice(0, contentStart) + contentHtml + shellHtml.slice(closeIdx)
+		`${shellHtml.slice(0, startIdx)}<div id="reforma-content" data-ssr="1">` +
+		contentHtml +
+		shellHtml.slice(closeIdx)
 	);
 }
 

--- a/scripts/seo/README.md
+++ b/scripts/seo/README.md
@@ -73,10 +73,32 @@ has rather than burning the day's allowance on retries.
 | `SEO_INSPECT_CONCURRENCY` | 5 | In-flight requests |
 | `SEO_INSPECT_PACE_MS` | 120 | Delay per worker between calls |
 | `SEO_INSPECT_REFRESH_DAYS` | 14 | Re-inspect only after this many days |
+| `SEO_INSPECT_REFORM_SAMPLE` | 600 | Cap on reform URLs per run (strided) |
 
 `index-coverage.json` reports `indexedRate`, `medianCrawlAgeDays`,
 `neverCrawled`, breakdowns by verdict / coverage state / fetch state,
 canonical mismatches, and the worst offenders.
+
+### Cohorts
+
+`byCohort` splits every rate by page type, because the aggregate hides the
+thing you need to act on. It reports **`crawlRate` alongside `rate`**: Google
+must fetch a page before it can judge it, so a cohort stuck at zero crawls is a
+different problem from one that's crawled and rejected.
+
+| Cohort | What it is |
+|--------|-----------|
+| `ley` | `/leyes/<id>/` — the 12k law pages |
+| `reforma-path` | 2026 reforms on `/cambios/reforma/<id>/<date>/` (treatment) |
+| `reforma-query` | Everything else on `?id=&date=` (control) |
+| `clave` | The hand-picked entry points |
+
+The reform split is the **URL-shape experiment** (see
+`packages/web/src/lib/reform-experiment.ts`). Baseline on 2026-07-28, before the
+change: `ley` 13.2% indexed / 99% crawled, reforms 0% indexed and **0% crawled**
+— not one of 600 had ever been fetched. If `reforma-path` starts getting crawled
+while `reforma-query` stays at zero, the query-string URL shape was the blocker
+and the remaining ~34k should follow.
 
 > `sitemaps[].contents[].indexed` is always `0`. Google stopped populating it
 > through the API years ago but still returns the field. Never read it as a

--- a/scripts/seo/README.md
+++ b/scripts/seo/README.md
@@ -6,6 +6,8 @@ implement them, verifies the build, and **opens a PR** — it never deploys on i
 own. Governance lives in [`.goals/seo/`](../../.goals/seo/).
 
 ```
+inspect-urls.ts ─► index-coverage.json ─┐
+                                        ▼
 pull-gsc.ts ─┐
              ├─► plan.ts ─► claude -p (implement) ─► verify ─► gh pr create
 pull-umami.ts┘   (model)      apply plan            tsgo/biome/build
@@ -17,12 +19,68 @@ pull-umami.ts┘   (model)      apply plan            tsgo/biome/build
 
 | File | Role |
 |------|------|
-| `lib.ts` | Shared config, GSC auth (RS256 JWT), GSC query, Umami psql, model chat client (`claude`/`nan`), PLAYBOOK path guard, types |
-| `pull-gsc.ts` | Search Console → `data/seo/gsc-<date>.json` (deltas, striking-distance, low-CTR, rising, zero-click) |
+| `lib.ts` | Shared config, GSC auth (RS256 JWT), Search Analytics (paginated), Sitemaps API, URL Inspection API, Umami psql, model chat client (`claude`/`nan`), PLAYBOOK path guard, types |
+| `pull-gsc.ts` | Search Console → `data/seo/gsc-<date>.json` |
+| `inspect-urls.ts` | URL Inspection sweep → `data/seo/inspections.json` + `index-coverage.json` |
 | `pull-umami.ts` | Umami Postgres → `data/seo/umami-<date>.json` (pages, referrers, entries, countries) |
 | `plan.ts` | `MODEL=provider:model` → structured JSON action plan (pure inference) |
 | `benchmark.ts` | Run N models on one snapshot, gate + judge, write a leaderboard |
 | `seo-loop.sh` | Orchestrator for the cron |
+
+## What the GSC snapshot contains
+
+`pull-gsc.ts` pulls the full Search Analytics surface, not a top-N slice —
+query and page tables are paginated to exhaustion (25k rows/response).
+
+| Block | What it answers |
+|-------|-----------------|
+| `totals` / `prevTotals` | 28-day window vs the previous one |
+| `daily` | Day-by-day series — a trend, not just an average |
+| `topQueries` / `risingQueries` / `fallingQueries` | What we rank for and which way it's moving |
+| `strikingDistance` | Position 8–20 with real impressions — cheapest wins |
+| `lowCtrQueries` | Ranking well, nobody clicks → title/meta problem |
+| `topPages` / `zeroClickPages` / `lostPages` | Pages winning, pages seen but unclicked, pages that dropped out entirely |
+| `pageQueries` | page × query pairs — what each page actually ranks for |
+| `devices` / `countries` / `searchAppearance` | Audience splits and rich-result surfaces |
+| `searchTypes` | Totals per surface (web/image/video/news/discover), zeros omitted |
+| `sitemaps` | Submitted sitemaps with error and warning counts |
+| `indexCoverage` | Rollup folded in from the last `inspect-urls.ts` run |
+
+Every block past `zeroClickPages` is optional and degrades to `undefined` if the
+API rejects it — a dimension Google stops supporting must not cost us the pull.
+
+## Index coverage (`inspect-urls.ts`)
+
+Search Analytics only sees pages that earn impressions. With ~12k law pages,
+most earn none — and it cannot tell "not indexed" from "indexed but never
+surfaced". The Inspection API can, so this script samples it.
+
+Quota is **2000 inspections/day, 600/minute** per property, so a full sweep is
+impossible in one run. It inspects three cohorts and rotates across runs via a
+persistent cache (`inspections.json`):
+
+1. **Key pages** — the hand-picked entry points, every run
+2. **Ranking pages** — whatever `gsc-latest.json` currently gives impressions to
+3. **Corpus sample** — law pages from `sitemap-leyes.xml`, oldest-inspected first
+
+URLs checked within `SEO_INSPECT_REFRESH_DAYS` (default 14) are skipped so the
+budget goes to unseen pages. On a 429 the run stops cleanly and saves what it
+has rather than burning the day's allowance on retries.
+
+| Env | Default | Purpose |
+|-----|---------|---------|
+| `SEO_INSPECT_BUDGET` | 500 | Max inspections per run |
+| `SEO_INSPECT_CONCURRENCY` | 5 | In-flight requests |
+| `SEO_INSPECT_PACE_MS` | 120 | Delay per worker between calls |
+| `SEO_INSPECT_REFRESH_DAYS` | 14 | Re-inspect only after this many days |
+
+`index-coverage.json` reports `indexedRate`, `medianCrawlAgeDays`,
+`neverCrawled`, breakdowns by verdict / coverage state / fetch state,
+canonical mismatches, and the worst offenders.
+
+> `sitemaps[].contents[].indexed` is always `0`. Google stopped populating it
+> through the API years ago but still returns the field. Never read it as a
+> coverage signal — that's what `indexCoverage` is for.
 
 ## Models (no OpenRouter — no metered spend)
 
@@ -56,6 +114,7 @@ Production contest: **`claude:sonnet` vs `nan:deepseek-v4-flash`**, judged by `c
 ```bash
 # One snapshot + a plan (local)
 SEO_GSC_SA_JSON=~/Downloads/…json bun run scripts/seo/pull-gsc.ts
+SEO_INSPECT_BUDGET=400 bun run scripts/seo/inspect-urls.ts   # coverage sweep
 bun run scripts/seo/pull-umami.ts                 # on the server, or SEO_UMAMI_ARGV to ssh
 MODEL=openrouter:x-ai/grok-4.5 bun run scripts/seo/plan.ts
 

--- a/scripts/seo/__tests__/cohort.test.ts
+++ b/scripts/seo/__tests__/cohort.test.ts
@@ -9,8 +9,20 @@ describe("cohortOf", () => {
 			"reforma-path",
 		);
 		expect(
-			cohortOf(`${O}/cambios/reforma/?id=BOE-A-1978-31229&date=2024-02-17`),
+			cohortOf(`${O}/cambios/reforma/?id=BOE-A-2026-9&date=2026-02-20`),
 		).toBe("reforma-query");
+	});
+
+	// Only same-year query URLs are the matched control. Pre-experiment reforms
+	// differ in freshness and link structure too, so folding them into the
+	// control would make the verdict compare unlike with unlike.
+	test("pre-experiment reforms are background, not the control", () => {
+		expect(
+			cohortOf(`${O}/cambios/reforma/?id=BOE-A-1978-31229&date=2024-02-17`),
+		).toBe("reforma-query-historica");
+		expect(
+			cohortOf(`${O}/cambios/reforma/?id=BOE-A-1983-1&date=1983-07-01`),
+		).toBe("reforma-query-historica");
 	});
 
 	// The bare shell has no id/date, so it isn't a reform URL at all. Counting it

--- a/scripts/seo/__tests__/cohort.test.ts
+++ b/scripts/seo/__tests__/cohort.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import { cohortOf } from "../lib.ts";
+
+const O = "https://leyabierta.es";
+
+describe("cohortOf", () => {
+	test("splits reforms by URL form — that split is the experiment", () => {
+		expect(cohortOf(`${O}/cambios/reforma/BOE-A-2026-1/2026-02-20/`)).toBe(
+			"reforma-path",
+		);
+		expect(
+			cohortOf(`${O}/cambios/reforma/?id=BOE-A-1978-31229&date=2024-02-17`),
+		).toBe("reforma-query");
+	});
+
+	// The bare shell has no id/date, so it isn't a reform URL at all. Counting it
+	// as treatment would dilute the cohort the experiment is measured on.
+	test("the bare shell is not counted as treatment", () => {
+		expect(cohortOf(`${O}/cambios/reforma/`)).toBe("otra");
+		expect(cohortOf(`${O}/cambios/reforma/?from=law`)).toBe("otra");
+	});
+
+	test("laws and key pages keep their own cohorts", () => {
+		expect(cohortOf(`${O}/leyes/BOE-A-1978-31229/`)).toBe("ley");
+		expect(cohortOf(`${O}/pregunta/`)).toBe("clave");
+		expect(cohortOf(`${O}/`)).toBe("clave");
+		expect(cohortOf(`${O}/algo-que-no-listamos/`)).toBe("otra");
+	});
+});

--- a/scripts/seo/experiment-report.ts
+++ b/scripts/seo/experiment-report.ts
@@ -82,9 +82,17 @@ function main() {
 	}
 	if (tRate > SUCCESS_TREATMENT_CRAWL && cRate < SUCCESS_CONTROL_CRAWL) {
 		console.log("\n✅ ÉXITO: la forma de URL era el bloqueo. Migrar el resto.");
+	} else if (tRate === 0 && cRate === 0) {
+		// Both flat at zero is an absence of signal, not evidence against the
+		// hypothesis: with a 74-day median crawl age site-wide, Googlebot may
+		// simply not have come back yet. Calling this a failure would retire a
+		// live hypothesis on no data.
+		console.log(
+			"\n⏳ SIN SEÑAL: ninguna cohorte se ha rastreado. Googlebot aún no ha vuelto — ampliar la ventana, no concluir.",
+		);
 	} else if (tRate < SUCCESS_CONTROL_CRAWL) {
 		console.log(
-			"\n❌ FRACASO: el path no desbloquea el rastreo. El problema es autoridad o presupuesto de rastreo, no la URL.",
+			"\n❌ FRACASO: el control se mueve y el tratamiento no. El problema es autoridad o presupuesto de rastreo, no la URL.",
 		);
 	} else {
 		console.log(

--- a/scripts/seo/experiment-report.ts
+++ b/scripts/seo/experiment-report.ts
@@ -17,6 +17,9 @@ import { cohortOf, DATA_DIR, type UrlInspection } from "./lib.ts";
 // reports a verdict instead of leaving it to whoever reads the numbers.
 const SUCCESS_TREATMENT_CRAWL = 0.2;
 const SUCCESS_CONTROL_CRAWL = 0.05;
+// Below this the control is indistinguishable from "Googlebot hasn't returned",
+// so a low treatment rate proves nothing either way.
+const CONTROL_ALIVE = 0.05;
 const MIN_SAMPLE = 200;
 
 const pct = (n: number) => `${(n * 100).toFixed(1)}%`;
@@ -82,17 +85,17 @@ function main() {
 	}
 	if (tRate > SUCCESS_TREATMENT_CRAWL && cRate < SUCCESS_CONTROL_CRAWL) {
 		console.log("\n✅ ÉXITO: la forma de URL era el bloqueo. Migrar el resto.");
-	} else if (tRate === 0 && cRate === 0) {
-		// Both flat at zero is an absence of signal, not evidence against the
-		// hypothesis: with a 74-day median crawl age site-wide, Googlebot may
-		// simply not have come back yet. Calling this a failure would retire a
-		// live hypothesis on no data.
-		console.log(
-			"\n⏳ SIN SEÑAL: ninguna cohorte se ha rastreado. Googlebot aún no ha vuelto — ampliar la ventana, no concluir.",
-		);
-	} else if (tRate < SUCCESS_CONTROL_CRAWL) {
+	} else if (tRate < SUCCESS_CONTROL_CRAWL && cRate >= CONTROL_ALIVE) {
+		// Failure requires the control to actually move. A treatment that sits low
+		// while the control is also flat is an absence of signal, not evidence
+		// against the hypothesis — with a 74-day median crawl age site-wide,
+		// Googlebot may simply not have come back yet.
 		console.log(
 			"\n❌ FRACASO: el control se mueve y el tratamiento no. El problema es autoridad o presupuesto de rastreo, no la URL.",
+		);
+	} else if (tRate < SUCCESS_TREATMENT_CRAWL && cRate < CONTROL_ALIVE) {
+		console.log(
+			"\n⏳ SIN SEÑAL: ninguna cohorte se mueve lo bastante. Googlebot aún no ha vuelto — ampliar la ventana, no concluir.",
 		);
 	} else {
 		console.log(

--- a/scripts/seo/experiment-report.ts
+++ b/scripts/seo/experiment-report.ts
@@ -1,0 +1,96 @@
+#!/usr/bin/env bun
+// Read the URL-shape experiment off the inspection cache.
+//
+//   bun run scripts/seo/experiment-report.ts
+//
+// Treatment (2026 reforms, path URLs) vs control (older reforms, query URLs).
+// The metric that decides it is `crawlRate`, not `indexedRate`: Google has to
+// fetch a page before it can judge it, and the reform cohort is stuck at the
+// fetch step. See packages/web/src/lib/reform-experiment.ts for the hypothesis
+// and the vault note 2026-07-28-reform-url-shape for the success criteria.
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { cohortOf, DATA_DIR, type UrlInspection } from "./lib.ts";
+
+// Pre-registered thresholds — see the vault note. Stated here so the script
+// reports a verdict instead of leaving it to whoever reads the numbers.
+const SUCCESS_TREATMENT_CRAWL = 0.2;
+const SUCCESS_CONTROL_CRAWL = 0.05;
+const MIN_SAMPLE = 200;
+
+const pct = (n: number) => `${(n * 100).toFixed(1)}%`;
+
+function main() {
+	const path = join(DATA_DIR, "inspections.json");
+	if (!existsSync(path)) {
+		console.error(`No inspection cache at ${path}. Run inspect-urls.ts first.`);
+		process.exit(1);
+	}
+	const all = (
+		JSON.parse(readFileSync(path, "utf8")) as UrlInspection[]
+	).filter((i) => !i.error);
+
+	const groups = new Map<string, UrlInspection[]>();
+	for (const i of all) {
+		const c = cohortOf(i.url);
+		const bucket = groups.get(c);
+		if (bucket) bucket.push(i);
+		else groups.set(c, [i]);
+	}
+
+	console.log(`Inspecciones en caché: ${all.length}\n`);
+	console.log(
+		`${"cohorte".padEnd(15)}${"n".padStart(6)}${"rastreadas".padStart(14)}${"indexadas".padStart(13)}`,
+	);
+	console.log("─".repeat(48));
+
+	for (const [name, items] of [...groups].sort()) {
+		const crawled = items.filter((i) => i.lastCrawlTime).length;
+		const indexed = items.filter((i) => i.verdict === "PASS").length;
+		console.log(
+			name.padEnd(15) +
+				String(items.length).padStart(6) +
+				`${crawled} (${pct(crawled / items.length)})`.padStart(14) +
+				`${indexed} (${pct(indexed / items.length)})`.padStart(13),
+		);
+	}
+
+	const treatment = groups.get("reforma-path") ?? [];
+	const control = groups.get("reforma-query") ?? [];
+	if (!treatment.length || !control.length) {
+		console.log("\nAún no hay ambas cohortes en la caché — nada que comparar.");
+		return;
+	}
+
+	const tRate =
+		treatment.filter((i) => i.lastCrawlTime).length / treatment.length;
+	const cRate = control.filter((i) => i.lastCrawlTime).length / control.length;
+
+	console.log(
+		`\nTratamiento (path): ${pct(tRate)} rastreadas de ${treatment.length}`,
+	);
+	console.log(
+		`Control (query):    ${pct(cRate)} rastreadas de ${control.length}`,
+	);
+
+	if (treatment.length < MIN_SAMPLE || control.length < MIN_SAMPLE) {
+		console.log(
+			`\n⏳ Muestra insuficiente (mínimo ${MIN_SAMPLE} por cohorte). Sigue midiendo.`,
+		);
+		return;
+	}
+	if (tRate > SUCCESS_TREATMENT_CRAWL && cRate < SUCCESS_CONTROL_CRAWL) {
+		console.log("\n✅ ÉXITO: la forma de URL era el bloqueo. Migrar el resto.");
+	} else if (tRate < SUCCESS_CONTROL_CRAWL) {
+		console.log(
+			"\n❌ FRACASO: el path no desbloquea el rastreo. El problema es autoridad o presupuesto de rastreo, no la URL.",
+		);
+	} else {
+		console.log(
+			"\n🤔 AMBIGUO: ni éxito claro ni fracaso claro. Ampliar la ventana antes de concluir.",
+		);
+	}
+}
+
+main();

--- a/scripts/seo/inspect-urls.ts
+++ b/scripts/seo/inspect-urls.ts
@@ -24,11 +24,13 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import {
+	cohortOf,
 	DATA_DIR,
 	GscQuotaError,
 	type GscSnapshot,
 	gscInspect,
 	type IndexCoverageSummary,
+	KEY_PAGES,
 	SITE_ORIGIN,
 	type UrlInspection,
 } from "./lib.ts";
@@ -44,19 +46,6 @@ const REFRESH_AFTER_DAYS = Number(process.env.SEO_INSPECT_REFRESH_DAYS ?? 14);
 // Reform URLs outnumber laws ~3:1; cap their share so one cohort can't eat the
 // whole budget. Sampled with a stride, so the cap still spans the full range.
 const REFORM_SAMPLE = Number(process.env.SEO_INSPECT_REFORM_SAMPLE ?? 600);
-
-const KEY_PAGES = [
-	"/",
-	"/pregunta/",
-	"/datos/",
-	"/cambios/",
-	"/cambios/recientes/",
-	"/omnibus/",
-	"/alertas/",
-	"/mi-situacion/",
-	"/sobre/",
-	"/mis-cambios/",
-];
 
 const CACHE_PATH = join(DATA_DIR, "inspections.json");
 const ROLLUP_PATH = join(DATA_DIR, "index-coverage.json");
@@ -114,13 +103,15 @@ function rankingUrls(): string[] {
 const daysSince = (iso?: string): number | null =>
 	iso ? (Date.now() - new Date(iso).getTime()) / 864e5 : null;
 
-/** Which cohort a URL belongs to — drives the per-cohort coverage breakdown. */
-export function cohortOf(url: string): string {
-	if (url.includes("/leyes/")) return "ley";
-	if (url.includes("/cambios/reforma")) return "reforma";
-	const path = url.replace(SITE_ORIGIN, "");
-	return KEY_PAGES.includes(path) ? "clave" : "otra";
-}
+/**
+ * Which cohort a URL belongs to — drives the per-cohort coverage breakdown.
+ *
+ * Reforms split by URL form because that split IS the experiment: `reforma-path`
+ * is the treatment group (2026 reforms on `/cambios/reforma/<id>/<date>/`) and
+ * `reforma-query` the control (everything else, still on `?id=&date=`). If the
+ * treatment group starts getting crawled and the control doesn't, the URL shape
+ * was the blocker.
+ */
 
 function buildQueue(
 	cache: Map<string, UrlInspection>,
@@ -190,15 +181,32 @@ function rollup(all: UrlInspection[]): IndexCoverageSummary {
 	// or reform pages are the ones dragging, and they need different fixes.
 	const byCohort: Record<
 		string,
-		{ sampled: number; indexed: number; rate: number }
+		{
+			sampled: number;
+			crawled: number;
+			indexed: number;
+			crawlRate: number;
+			rate: number;
+		}
 	> = {};
 	for (const i of all) {
 		const c = cohortOf(i.url);
-		const b = (byCohort[c] ??= { sampled: 0, indexed: 0, rate: 0 });
+		const b = (byCohort[c] ??= {
+			sampled: 0,
+			crawled: 0,
+			indexed: 0,
+			crawlRate: 0,
+			rate: 0,
+		});
 		b.sampled++;
+		// `crawled` leads `indexed`: Google must fetch a page before it can
+		// judge it, and the reform cohort is stuck at the fetch step. For the
+		// URL-shape experiment this is the metric that moves first.
+		if (i.lastCrawlTime) b.crawled++;
 		if (i.verdict === "PASS") b.indexed++;
 	}
 	for (const b of Object.values(byCohort)) {
+		b.crawlRate = b.sampled ? b.crawled / b.sampled : 0;
 		b.rate = b.sampled ? b.indexed / b.sampled : 0;
 	}
 
@@ -309,7 +317,11 @@ async function main() {
 	);
 }
 
-main().catch((e) => {
-	console.error(e instanceof Error ? e.message : e);
-	process.exit(1);
-});
+// Guarded: `experiment-report.ts` imports from this file's siblings, and an
+// unguarded main() would fire a full 500-URL sweep on any import.
+if (import.meta.main) {
+	main().catch((e) => {
+		console.error(e instanceof Error ? e.message : e);
+		process.exit(1);
+	});
+}

--- a/scripts/seo/inspect-urls.ts
+++ b/scripts/seo/inspect-urls.ts
@@ -43,9 +43,14 @@ const CONCURRENCY = Number(process.env.SEO_INSPECT_CONCURRENCY ?? 5);
 const PACE_MS = Number(process.env.SEO_INSPECT_PACE_MS ?? 120);
 // Don't re-inspect a URL we already checked recently — spend on unseen ones.
 const REFRESH_AFTER_DAYS = Number(process.env.SEO_INSPECT_REFRESH_DAYS ?? 14);
-// Reform URLs outnumber laws ~3:1; cap their share so one cohort can't eat the
-// whole budget. Sampled with a stride, so the cap still spans the full range.
-const REFORM_SAMPLE = Number(process.env.SEO_INSPECT_REFORM_SAMPLE ?? 600);
+// Per-arm quota for the URL-shape experiment. Treatment is ~662 of ~35k reform
+// URLs (1.9%), so a single strided sample over all reforms would draw ~11
+// treatment URLs — far below the 200/arm the report needs to decide anything,
+// and the same 11 every run since the stride is deterministic. Sampling each
+// arm separately with its own quota is what makes the experiment decidable.
+const REFORM_SAMPLE_PER_ARM = Number(
+	process.env.SEO_INSPECT_REFORM_SAMPLE ?? 300,
+);
 
 const CACHE_PATH = join(DATA_DIR, "inspections.json");
 const ROLLUP_PATH = join(DATA_DIR, "index-coverage.json");
@@ -139,10 +144,20 @@ function buildQueue(
 	for (const p of KEY_PAGES) push(`${SITE_ORIGIN}${p}`);
 	// 2. Anything currently earning impressions.
 	for (const u of rankingUrls()) push(u);
-	// 3+4. Interleave laws and reforms so a budget cut mid-run still leaves a
-	// usable sample of both — the two cohorts are the whole comparison.
+	// 3+4. Stratify reforms by arm, each with its own quota, then interleave with
+	// laws so a budget cut mid-run still leaves a usable sample of every cohort.
+	const byArm = new Map<string, string[]>();
+	for (const u of reforms) {
+		const arm = cohortOf(u);
+		const list = byArm.get(arm);
+		if (list) list.push(u);
+		else byArm.set(arm, [u]);
+	}
+	const reformQ: string[] = [];
+	for (const [, urls] of [...byArm].sort()) {
+		reformQ.push(...staleFirst(stride(urls, REFORM_SAMPLE_PER_ARM)));
+	}
 	const lawQ = staleFirst(laws);
-	const reformQ = staleFirst(stride(reforms, REFORM_SAMPLE));
 	for (let i = 0; i < Math.max(lawQ.length, reformQ.length); i++) {
 		const l = lawQ[i];
 		const r = reformQ[i];
@@ -256,7 +271,8 @@ async function main() {
 	const queue = buildQueue(cache, laws, reforms).slice(0, BUDGET);
 
 	console.log(
-		`URL Inspection — leyes ${laws.length}, reformas ${reforms.length}, ` +
+		`URL Inspection — leyes ${laws.length}, reformas ${reforms.length} ` +
+			`(${[...new Set(reforms.map(cohortOf))].sort().join(", ")}), ` +
 			`cached ${cache.size}, queued ${queue.length} (budget ${BUDGET})`,
 	);
 	if (queue.length === 0) {

--- a/scripts/seo/inspect-urls.ts
+++ b/scripts/seo/inspect-urls.ts
@@ -231,6 +231,13 @@ function rollup(all: UrlInspection[]): IndexCoverageSummary {
 			.map((i) => ({ url: i.url, googleCanonical: i.googleCanonical ?? "" })),
 		worstOffenders: all
 			.filter((i) => i.verdict !== "PASS")
+			// Never-crawled first, then stalest: cache order would just surface
+			// whatever happened to be inspected first, which diagnoses nothing.
+			.sort(
+				(a, b) =>
+					(daysSince(b.lastCrawlTime) ?? Number.POSITIVE_INFINITY) -
+					(daysSince(a.lastCrawlTime) ?? Number.POSITIVE_INFINITY),
+			)
 			.slice(0, 100)
 			.map((i) => ({
 				url: i.url,

--- a/scripts/seo/inspect-urls.ts
+++ b/scripts/seo/inspect-urls.ts
@@ -1,0 +1,315 @@
+#!/usr/bin/env bun
+// URL Inspection sweep: which pages Google actually indexed, and why not.
+//
+//   SEO_GSC_SA_JSON=/path/to/sa.json bun run scripts/seo/inspect-urls.ts
+//   SEO_INSPECT_BUDGET=800 bun run scripts/seo/inspect-urls.ts
+//
+// Search Analytics tells us what ranks. It says nothing about the ~12k law
+// pages that never get an impression — those are invisible to it, so a corpus
+// this size needs the Inspection API to tell "not indexed" apart from "indexed
+// but never surfaced".
+//
+// Quota is 2000 inspections/day and 600/minute per property, so this cannot
+// sweep the whole corpus in one run. Instead it inspects three cohorts and
+// rotates through the corpus across runs using a persistent cache:
+//
+//   1. Key pages     — the hand-picked entry points, every run
+//   2. Ranking pages — whatever GSC currently gives impressions to
+//   3. Corpus sample — oldest-inspected law pages first, so runs rotate
+//
+// Writes:
+//   data/seo/inspections.json    full per-URL cache (append/refresh)
+//   data/seo/index-coverage.json rollup that pull-gsc.ts folds into snapshots
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+	DATA_DIR,
+	GscQuotaError,
+	type GscSnapshot,
+	gscInspect,
+	type IndexCoverageSummary,
+	SITE_ORIGIN,
+	type UrlInspection,
+} from "./lib.ts";
+
+// Stay well under the 2000/day cap: the loop may run more than once a day and
+// a burnt quota means no coverage data at all until the next reset.
+const BUDGET = Number(process.env.SEO_INSPECT_BUDGET ?? 500);
+// 600/min is the ceiling; 5 in flight with a 120ms pace lands near 300/min.
+const CONCURRENCY = Number(process.env.SEO_INSPECT_CONCURRENCY ?? 5);
+const PACE_MS = Number(process.env.SEO_INSPECT_PACE_MS ?? 120);
+// Don't re-inspect a URL we already checked recently — spend on unseen ones.
+const REFRESH_AFTER_DAYS = Number(process.env.SEO_INSPECT_REFRESH_DAYS ?? 14);
+// Reform URLs outnumber laws ~3:1; cap their share so one cohort can't eat the
+// whole budget. Sampled with a stride, so the cap still spans the full range.
+const REFORM_SAMPLE = Number(process.env.SEO_INSPECT_REFORM_SAMPLE ?? 600);
+
+const KEY_PAGES = [
+	"/",
+	"/pregunta/",
+	"/datos/",
+	"/cambios/",
+	"/cambios/recientes/",
+	"/omnibus/",
+	"/alertas/",
+	"/mi-situacion/",
+	"/sobre/",
+	"/mis-cambios/",
+];
+
+const CACHE_PATH = join(DATA_DIR, "inspections.json");
+const ROLLUP_PATH = join(DATA_DIR, "index-coverage.json");
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+function loadCache(): Map<string, UrlInspection> {
+	if (!existsSync(CACHE_PATH)) return new Map();
+	try {
+		const raw = JSON.parse(readFileSync(CACHE_PATH, "utf8")) as UrlInspection[];
+		return new Map(raw.map((i) => [i.url, i]));
+	} catch {
+		return new Map();
+	}
+}
+
+/** URLs from a published sitemap — no DB dependency. */
+async function sitemapUrls(name: string): Promise<string[]> {
+	const res = await fetch(`${SITE_ORIGIN}/${name}`);
+	if (!res.ok) {
+		console.warn(`  ! ${name}: HTTP ${res.status}`);
+		return [];
+	}
+	const xml = await res.text();
+	return [...xml.matchAll(/<loc>([^<]+)<\/loc>/g)]
+		.map((m) => m[1]?.trim().replaceAll("&amp;", "&"))
+		.filter((u): u is string => Boolean(u));
+}
+
+/**
+ * Evenly spaced sample. Reform URLs come out of the sitemap in law order, so
+ * taking the first N would inspect a handful of laws' worth of reforms and
+ * call it a corpus. Striding covers the whole range with the same budget.
+ */
+function stride<T>(items: T[], n: number): T[] {
+	if (items.length <= n) return [...items];
+	const step = items.length / n;
+	return Array.from({ length: n }, (_, i) => items[Math.floor(i * step)]!);
+}
+
+function rankingUrls(): string[] {
+	const p = join(DATA_DIR, "gsc-latest.json");
+	if (!existsSync(p)) return [];
+	try {
+		const snap = JSON.parse(readFileSync(p, "utf8")) as GscSnapshot;
+		return [
+			...(snap.topPages ?? []).map((x) => x.page),
+			...(snap.zeroClickPages ?? []).map((x) => x.page),
+		];
+	} catch {
+		return [];
+	}
+}
+
+const daysSince = (iso?: string): number | null =>
+	iso ? (Date.now() - new Date(iso).getTime()) / 864e5 : null;
+
+/** Which cohort a URL belongs to — drives the per-cohort coverage breakdown. */
+export function cohortOf(url: string): string {
+	if (url.includes("/leyes/")) return "ley";
+	if (url.includes("/cambios/reforma")) return "reforma";
+	const path = url.replace(SITE_ORIGIN, "");
+	return KEY_PAGES.includes(path) ? "clave" : "otra";
+}
+
+function buildQueue(
+	cache: Map<string, UrlInspection>,
+	laws: string[],
+	reforms: string[],
+): string[] {
+	const seen = new Set<string>();
+	const queue: string[] = [];
+	const push = (u: string) => {
+		if (!seen.has(u)) {
+			seen.add(u);
+			queue.push(u);
+		}
+	};
+
+	// Rotate within a cohort: never-inspected first, then stalest.
+	const staleFirst = (urls: string[]) =>
+		[...urls].sort((a, b) =>
+			(cache.get(a)?.inspectedAt ?? "").localeCompare(
+				cache.get(b)?.inspectedAt ?? "",
+			),
+		);
+
+	// 1. Key pages — always, they define the site's shape for Google.
+	for (const p of KEY_PAGES) push(`${SITE_ORIGIN}${p}`);
+	// 2. Anything currently earning impressions.
+	for (const u of rankingUrls()) push(u);
+	// 3+4. Interleave laws and reforms so a budget cut mid-run still leaves a
+	// usable sample of both — the two cohorts are the whole comparison.
+	const lawQ = staleFirst(laws);
+	const reformQ = staleFirst(stride(reforms, REFORM_SAMPLE));
+	for (let i = 0; i < Math.max(lawQ.length, reformQ.length); i++) {
+		const l = lawQ[i];
+		const r = reformQ[i];
+		if (l) push(l);
+		if (r) push(r);
+	}
+
+	// Drop URLs checked recently enough that a re-check buys nothing.
+	return queue.filter((u) => {
+		const age = daysSince(cache.get(u)?.inspectedAt);
+		return age === null || age >= REFRESH_AFTER_DAYS;
+	});
+}
+
+function rollup(all: UrlInspection[]): IndexCoverageSummary {
+	const tally = (pick: (i: UrlInspection) => string | undefined) => {
+		const out: Record<string, number> = {};
+		for (const i of all) {
+			const k = pick(i) ?? "UNKNOWN";
+			out[k] = (out[k] ?? 0) + 1;
+		}
+		return out;
+	};
+
+	const ages = all
+		.map((i) => daysSince(i.lastCrawlTime))
+		.filter((d): d is number => d !== null)
+		.sort((a, b) => a - b);
+	const median = ages.length
+		? Math.round((ages[Math.floor(ages.length / 2)] ?? 0) * 10) / 10
+		: null;
+
+	const passes = all.filter((i) => i.verdict === "PASS").length;
+
+	// Per-cohort rates are the actionable cut: a global 14% hides whether laws
+	// or reform pages are the ones dragging, and they need different fixes.
+	const byCohort: Record<
+		string,
+		{ sampled: number; indexed: number; rate: number }
+	> = {};
+	for (const i of all) {
+		const c = cohortOf(i.url);
+		const b = (byCohort[c] ??= { sampled: 0, indexed: 0, rate: 0 });
+		b.sampled++;
+		if (i.verdict === "PASS") b.indexed++;
+	}
+	for (const b of Object.values(byCohort)) {
+		b.rate = b.sampled ? b.indexed / b.sampled : 0;
+	}
+
+	return {
+		inspectedAt: new Date().toISOString(),
+		sampled: all.length,
+		byVerdict: tally((i) => i.verdict),
+		byCoverageState: tally((i) => i.coverageState),
+		byFetchState: tally((i) => i.pageFetchState),
+		byCohort,
+		indexedRate: all.length ? passes / all.length : 0,
+		medianCrawlAgeDays: median,
+		neverCrawled: all.filter((i) => !i.lastCrawlTime).length,
+		canonicalMismatches: all
+			.filter(
+				(i) =>
+					i.googleCanonical &&
+					i.userCanonical &&
+					i.googleCanonical !== i.userCanonical,
+			)
+			.slice(0, 50)
+			.map((i) => ({ url: i.url, googleCanonical: i.googleCanonical ?? "" })),
+		worstOffenders: all
+			.filter((i) => i.verdict !== "PASS")
+			.slice(0, 100)
+			.map((i) => ({
+				url: i.url,
+				coverageState: i.coverageState ?? "unknown",
+				lastCrawl: i.lastCrawlTime,
+			})),
+	};
+}
+
+async function main() {
+	const cache = loadCache();
+	const [laws, reforms] = await Promise.all([
+		sitemapUrls("sitemap-leyes.xml"),
+		sitemapUrls("sitemap-reformas.xml"),
+	]);
+	const queue = buildQueue(cache, laws, reforms).slice(0, BUDGET);
+
+	console.log(
+		`URL Inspection — leyes ${laws.length}, reformas ${reforms.length}, ` +
+			`cached ${cache.size}, queued ${queue.length} (budget ${BUDGET})`,
+	);
+	if (queue.length === 0) {
+		console.log("Nothing stale enough to inspect. Done.");
+		return;
+	}
+
+	let done = 0;
+	let quotaHit = false;
+
+	// Fixed-size worker pool: each worker pulls the next index off the queue.
+	let cursor = 0;
+	async function worker() {
+		while (!quotaHit) {
+			const idx = cursor++;
+			const url = queue[idx];
+			if (!url) return;
+			try {
+				const result = await gscInspect(url);
+				cache.set(url, result);
+			} catch (e) {
+				if (e instanceof GscQuotaError) {
+					quotaHit = true;
+					console.warn(`  ! quota exhausted after ${done} inspections`);
+					return;
+				}
+				cache.set(url, {
+					url,
+					inspectedAt: new Date().toISOString(),
+					error: e instanceof Error ? e.message : String(e),
+				});
+			}
+			done++;
+			if (done % 50 === 0) console.log(`  ${done}/${queue.length}`);
+			await sleep(PACE_MS);
+		}
+	}
+
+	await Promise.all(Array.from({ length: CONCURRENCY }, worker));
+
+	mkdirSync(DATA_DIR, { recursive: true });
+	const all = [...cache.values()];
+	writeFileSync(CACHE_PATH, JSON.stringify(all, null, 2));
+
+	// Roll up only over law pages + key pages that were actually inspected —
+	// the cache is the accumulated picture, which is what we want to report.
+	const summary = rollup(all.filter((i) => !i.error));
+	writeFileSync(ROLLUP_PATH, JSON.stringify(summary, null, 2));
+
+	console.log(
+		`✓ inspected ${done}  cache ${all.length}\n` +
+			`  indexed ${(summary.indexedRate * 100).toFixed(1)}%  ` +
+			`median crawl age ${summary.medianCrawlAgeDays ?? "n/a"}d  ` +
+			`never crawled ${summary.neverCrawled}\n` +
+			`  por cohorte: ${Object.entries(summary.byCohort)
+				.map(
+					([k, v]) =>
+						`${k} ${(v.rate * 100).toFixed(1)}% (${v.indexed}/${v.sampled})`,
+				)
+				.join("  ")}\n` +
+			`  coverage: ${Object.entries(summary.byCoverageState)
+				.sort((a, b) => b[1] - a[1])
+				.map(([k, v]) => `${k}=${v}`)
+				.join("  ")}`,
+	);
+}
+
+main().catch((e) => {
+	console.error(e instanceof Error ? e.message : e);
+	process.exit(1);
+});

--- a/scripts/seo/lib.ts
+++ b/scripts/seo/lib.ts
@@ -15,6 +15,9 @@ import { resolve } from "node:path";
 export const SEO_SITE = process.env.SEO_GSC_SITE ?? "sc-domain:leyabierta.es";
 export const SITE_ORIGIN =
 	process.env.SEO_SITE_ORIGIN ?? "https://leyabierta.es";
+/** Must match EXPERIMENT_YEAR in packages/web/src/lib/reform-experiment.ts. */
+export const EXPERIMENT_YEAR = process.env.SEO_EXPERIMENT_YEAR ?? "2026";
+
 export const UMAMI_WEBSITE_ID =
 	process.env.SEO_UMAMI_WEBSITE_ID ?? "58e766e3-e3bb-42bb-b4c8-993cd4f1c47c";
 
@@ -320,7 +323,15 @@ export const KEY_PAGES = [
 export function cohortOf(url: string): string {
 	if (url.includes("/leyes/")) return "ley";
 	if (url.includes("/cambios/reforma")) {
-		if (url.includes("?id=")) return "reforma-query";
+		if (url.includes("?id=")) {
+			// The verdict compares like with like: only same-year query URLs are
+			// the matched control. Older ones differ in freshness and link
+			// structure too, so they're reported apart as historical background.
+			return /[?&]date=\d{4}-\d{2}-\d{2}/.test(url) &&
+				url.includes(`date=${EXPERIMENT_YEAR}-`)
+				? "reforma-query"
+				: "reforma-query-historica";
+		}
 		// The bare shell carries no id/date — it is not a reform URL at all, and
 		// counting it as treatment would dilute the experiment's cohort.
 		return url.replace(/[?#].*$/, "").endsWith("/cambios/reforma/")

--- a/scripts/seo/lib.ts
+++ b/scripts/seo/lib.ts
@@ -297,6 +297,32 @@ export function umamiQuery(sql: string): string[][] {
 		.map((l) => l.split("\t"));
 }
 
+// Real pages only — must match src/pages/. Listing a route that only exists as
+// a 301 (e.g. the retired /omnibus/, /mis-cambios/) pollutes the rollup with
+// "Página con redirección" verdicts that look like coverage failures.
+export const KEY_PAGES = [
+	"/",
+	"/pregunta/",
+	"/datos/",
+	"/cambios/",
+	"/cambios/recientes/",
+	"/cambios/para-mi/",
+	"/alertas/",
+	"/mi-situacion/",
+	"/sobre/",
+	"/sobre/api/",
+	"/sobre/contribuir/",
+];
+
+export function cohortOf(url: string): string {
+	if (url.includes("/leyes/")) return "ley";
+	if (url.includes("/cambios/reforma")) {
+		return url.includes("?id=") ? "reforma-query" : "reforma-path";
+	}
+	const path = url.replace(SITE_ORIGIN, "");
+	return KEY_PAGES.includes(path) ? "clave" : "otra";
+}
+
 // ── Snapshot + plan contracts (shared across pull/plan/benchmark) ───────────
 export interface QueryMetric {
 	query: string;
@@ -386,7 +412,17 @@ export interface IndexCoverageSummary {
 	byFetchState: Record<string, number>;
 	/** Indexation split by page type (ley / reforma / clave) — laws and reform
 	 *  pages fail for different reasons and need different fixes. */
-	byCohort: Record<string, { sampled: number; indexed: number; rate: number }>;
+	byCohort: Record<
+		string,
+		{
+			sampled: number;
+			/** Has a `lastCrawlTime` — Google actually fetched it. */
+			crawled: number;
+			indexed: number;
+			crawlRate: number;
+			rate: number;
+		}
+	>;
 	/** Share of sampled URLs whose verdict is PASS. */
 	indexedRate: number;
 	/** Median days since Google last crawled a sampled URL (null if unknown). */

--- a/scripts/seo/lib.ts
+++ b/scripts/seo/lib.ts
@@ -116,6 +116,155 @@ export async function gscQuery(
 	return json.rows ?? [];
 }
 
+// Search Analytics caps a single response at 25k rows. Walk `startRow` until a
+// short page comes back so callers get the full table instead of a top-N slice.
+const GSC_PAGE = 25000;
+
+export async function gscQueryAll(
+	body: Record<string, unknown>,
+	maxRows = 100000,
+): Promise<GscRow[]> {
+	const out: GscRow[] = [];
+	for (let startRow = 0; startRow < maxRows; startRow += GSC_PAGE) {
+		const page = await gscQuery({
+			...body,
+			rowLimit: Math.min(GSC_PAGE, maxRows - startRow),
+			startRow,
+		});
+		out.push(...page);
+		if (page.length < GSC_PAGE) break;
+	}
+	return out;
+}
+
+// ── Sitemaps API ────────────────────────────────────────────────────────────
+export interface SitemapInfo {
+	path: string;
+	type?: string;
+	lastSubmitted?: string;
+	lastDownloaded?: string;
+	isPending?: boolean;
+	isSitemapsIndex?: boolean;
+	warnings: number;
+	errors: number;
+	// `indexed` is always 0 — Google stopped reporting it through the API years
+	// ago but still returns the field. Kept for shape fidelity; never trust it.
+	contents: { type: string; submitted: number; indexed: number }[];
+}
+
+export async function gscSitemaps(): Promise<SitemapInfo[]> {
+	const token = await gscToken();
+	const site = encodeURIComponent(SEO_SITE);
+	const res = await fetch(
+		`https://www.googleapis.com/webmasters/v3/sites/${site}/sitemaps`,
+		{ headers: { Authorization: `Bearer ${token}` } },
+	);
+	const json = (await res.json()) as {
+		sitemap?: Record<string, unknown>[];
+		error?: { message: string };
+	};
+	if (json.error) throw new Error(`GSC sitemaps error: ${json.error.message}`);
+	return (json.sitemap ?? []).map((s) => ({
+		path: String(s.path),
+		type: s.type as string | undefined,
+		lastSubmitted: s.lastSubmitted as string | undefined,
+		lastDownloaded: s.lastDownloaded as string | undefined,
+		isPending: s.isPending as boolean | undefined,
+		isSitemapsIndex: s.isSitemapsIndex as boolean | undefined,
+		warnings: Number(s.warnings ?? 0),
+		errors: Number(s.errors ?? 0),
+		contents: ((s.contents ?? []) as Record<string, unknown>[]).map((c) => ({
+			type: String(c.type),
+			submitted: Number(c.submitted ?? 0),
+			indexed: Number(c.indexed ?? 0),
+		})),
+	}));
+}
+
+// ── URL Inspection API ──────────────────────────────────────────────────────
+// Quota: 2000 inspections/day and 600/minute per property. `inspect-urls.ts`
+// owns the budgeting; this helper only enforces the per-minute pace and
+// surfaces 429s to the caller so the run can stop cleanly instead of burning
+// the daily allowance on retries.
+export interface UrlInspection {
+	url: string;
+	inspectedAt: string;
+	verdict?: string;
+	coverageState?: string;
+	robotsTxtState?: string;
+	indexingState?: string;
+	pageFetchState?: string;
+	lastCrawlTime?: string;
+	crawledAs?: string;
+	googleCanonical?: string;
+	userCanonical?: string;
+	sitemaps?: string[];
+	referringUrls?: string[];
+	mobileVerdict?: string;
+	richResultsVerdict?: string;
+	richResultTypes?: string[];
+	resultLink?: string;
+	error?: string;
+}
+
+export class GscQuotaError extends Error {}
+
+export async function gscInspect(url: string): Promise<UrlInspection> {
+	const token = await gscToken();
+	const res = await fetch(
+		"https://searchconsole.googleapis.com/v1/urlInspection/index:inspect",
+		{
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${token}`,
+				"content-type": "application/json",
+			},
+			body: JSON.stringify({
+				inspectionUrl: url,
+				siteUrl: SEO_SITE,
+				languageCode: "es-ES",
+			}),
+		},
+	);
+	if (res.status === 429) {
+		throw new GscQuotaError(`URL Inspection quota exhausted at ${url}`);
+	}
+	const json = (await res.json()) as {
+		inspectionResult?: Record<string, Record<string, unknown>>;
+		error?: { message: string };
+	};
+	const inspectedAt = new Date().toISOString();
+	if (json.error) return { url, inspectedAt, error: json.error.message };
+
+	const r = json.inspectionResult ?? {};
+	const idx = (r.indexStatusResult ?? {}) as Record<string, unknown>;
+	const rich = (r.richResultsResult ?? {}) as Record<string, unknown>;
+	return {
+		url,
+		inspectedAt,
+		verdict: idx.verdict as string | undefined,
+		coverageState: idx.coverageState as string | undefined,
+		robotsTxtState: idx.robotsTxtState as string | undefined,
+		indexingState: idx.indexingState as string | undefined,
+		pageFetchState: idx.pageFetchState as string | undefined,
+		lastCrawlTime: idx.lastCrawlTime as string | undefined,
+		crawledAs: idx.crawledAs as string | undefined,
+		googleCanonical: idx.googleCanonical as string | undefined,
+		userCanonical: idx.userCanonical as string | undefined,
+		sitemaps: idx.sitemap as string[] | undefined,
+		referringUrls: idx.referringUrls as string[] | undefined,
+		mobileVerdict: (r.mobileUsabilityResult as Record<string, unknown>)
+			?.verdict as string | undefined,
+		richResultsVerdict: rich.verdict as string | undefined,
+		richResultTypes: (
+			(rich.detectedItems ?? []) as { richResultType?: string }[]
+		)
+			.map((d) => d.richResultType)
+			.filter((t): t is string => Boolean(t)),
+		resultLink: r.inspectionResultLink as unknown as string | undefined,
+	};
+}
+
 // ── Umami: read-only query against the co-located Postgres container ────────
 // Runs on KonarServer where the umami-db container lives. For off-server runs,
 // override the argv (e.g. wrap in ssh) via SEO_UMAMI_ARGV as a JSON array.
@@ -167,26 +316,84 @@ export interface PageMetric {
 	position: number;
 }
 
+export interface GscTotals {
+	clicks: number;
+	impressions: number;
+	ctr: number;
+	position: number;
+	pagesWithImpressions: number;
+}
+
+/** A metric row keyed by a single dimension value (device, country, date, …). */
+export interface DimensionMetric {
+	key: string;
+	clicks: number;
+	impressions: number;
+	ctr: number;
+	position: number;
+}
+
+/** page × query pair — the actionable unit: which query surfaces which page. */
+export interface PageQueryMetric {
+	page: string;
+	query: string;
+	clicks: number;
+	impressions: number;
+	ctr: number;
+	position: number;
+}
+
 export interface GscSnapshot {
 	source: "gsc";
 	snapshotDate: string;
 	site: string;
 	window: { start: string; end: string };
 	prevWindow: { start: string; end: string };
-	totals: {
-		clicks: number;
-		impressions: number;
-		ctr: number;
-		position: number;
-		pagesWithImpressions: number;
-	};
-	prevTotals: GscSnapshot["totals"];
+	totals: GscTotals;
+	prevTotals: GscTotals;
 	topQueries: QueryMetric[];
 	risingQueries: QueryMetric[];
+	fallingQueries?: QueryMetric[]; // lost impressions vs the previous window
 	strikingDistance: QueryMetric[]; // position 8–20 with real impressions
 	lowCtrQueries: QueryMetric[]; // good position, weak CTR
 	topPages: PageMetric[];
 	zeroClickPages: PageMetric[]; // impressions but no clicks
+
+	// ── Added by the "full pull" (all optional so older snapshots still parse) ──
+	/** Per-day series for the current window — trend, not just an average. */
+	daily?: DimensionMetric[];
+	devices?: DimensionMetric[];
+	countries?: DimensionMetric[];
+	/** Rich-result / AI-surface breakdown (searchAppearance dimension). */
+	searchAppearance?: DimensionMetric[];
+	/** Totals per search type: web, image, video, news, discover, googleNews. */
+	searchTypes?: Record<string, GscTotals>;
+	/** Top page×query pairs — what each page actually ranks for. */
+	pageQueries?: PageQueryMetric[];
+	/** Pages that had impressions last window and none in this one. */
+	lostPages?: PageMetric[];
+	/** Submitted sitemaps with their error/warning counts. */
+	sitemaps?: SitemapInfo[];
+	/** Coverage rollup from the last inspect-urls run, if one exists. */
+	indexCoverage?: IndexCoverageSummary;
+}
+
+export interface IndexCoverageSummary {
+	inspectedAt: string;
+	sampled: number;
+	byVerdict: Record<string, number>;
+	byCoverageState: Record<string, number>;
+	byFetchState: Record<string, number>;
+	/** Indexation split by page type (ley / reforma / clave) — laws and reform
+	 *  pages fail for different reasons and need different fixes. */
+	byCohort: Record<string, { sampled: number; indexed: number; rate: number }>;
+	/** Share of sampled URLs whose verdict is PASS. */
+	indexedRate: number;
+	/** Median days since Google last crawled a sampled URL (null if unknown). */
+	medianCrawlAgeDays: number | null;
+	neverCrawled: number;
+	canonicalMismatches: { url: string; googleCanonical: string }[];
+	worstOffenders: { url: string; coverageState: string; lastCrawl?: string }[];
 }
 
 export interface UmamiSnapshot {

--- a/scripts/seo/lib.ts
+++ b/scripts/seo/lib.ts
@@ -224,6 +224,9 @@ export async function gscInspect(url: string): Promise<UrlInspection> {
 				siteUrl: SEO_SITE,
 				languageCode: "es-ES",
 			}),
+			// Without this a hung API call would stall a worker slot for the rest
+			// of the sweep — this runs unattended from cron.
+			signal: AbortSignal.timeout(15000),
 		},
 	);
 	if (res.status === 429) {
@@ -317,7 +320,12 @@ export const KEY_PAGES = [
 export function cohortOf(url: string): string {
 	if (url.includes("/leyes/")) return "ley";
 	if (url.includes("/cambios/reforma")) {
-		return url.includes("?id=") ? "reforma-query" : "reforma-path";
+		if (url.includes("?id=")) return "reforma-query";
+		// The bare shell carries no id/date — it is not a reform URL at all, and
+		// counting it as treatment would dilute the experiment's cohort.
+		return url.replace(/[?#].*$/, "").endsWith("/cambios/reforma/")
+			? "otra"
+			: "reforma-path";
 	}
 	const path = url.replace(SITE_ORIGIN, "");
 	return KEY_PAGES.includes(path) ? "clave" : "otra";

--- a/scripts/seo/pull-gsc.ts
+++ b/scripts/seo/pull-gsc.ts
@@ -5,14 +5,27 @@
 //
 // Writes data/seo/gsc-<date>.json and refreshes data/seo/gsc-latest.json.
 // GSC data lags ~2-3 days, so the window ends at today-3.
+//
+// Beyond the query/page tables the loop started with, this also pulls the daily
+// series, device/country/appearance splits, per-search-type totals, page×query
+// pairs, sitemap health, and folds in the latest index-coverage rollup written
+// by `inspect-urls.ts`. Every extra block degrades to `undefined` on API error
+// rather than failing the run — a missing dimension must not cost us the pull.
 
-import { mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import {
 	DATA_DIR,
+	type DimensionMetric,
 	type GscSnapshot,
+	type GscTotals,
 	gscQuery,
+	gscQueryAll,
+	gscSitemaps,
+	type IndexCoverageSummary,
 	isoDay,
+	type PageMetric,
+	type PageQueryMetric,
 	type QueryMetric,
 	SEO_SITE,
 	today,
@@ -26,11 +39,48 @@ const start = isoDay(LAG_DAYS + WINDOW_DAYS);
 const prevEnd = isoDay(LAG_DAYS + WINDOW_DAYS + 1);
 const prevStart = isoDay(LAG_DAYS + 2 * WINDOW_DAYS + 1);
 
-async function totalsFor(startDate: string, endDate: string, pages: number) {
+/** Run a block that may 400 on unsupported dimensions; never fail the pull. */
+async function soft<T>(
+	label: string,
+	fn: () => Promise<T>,
+): Promise<T | undefined> {
+	try {
+		return await fn();
+	} catch (e) {
+		console.warn(`  ! ${label}: ${e instanceof Error ? e.message : e}`);
+		return undefined;
+	}
+}
+
+const toDimension = (r: { keys: string[] } & Omit<DimensionMetric, "key">) => ({
+	key: r.keys[0] ?? "",
+	clicks: r.clicks,
+	impressions: r.impressions,
+	ctr: r.ctr,
+	position: r.position,
+});
+
+const toPage = (
+	r: { keys: string[] } & Omit<PageMetric, "page">,
+): PageMetric => ({
+	page: r.keys[0] ?? "",
+	clicks: r.clicks,
+	impressions: r.impressions,
+	ctr: r.ctr,
+	position: r.position,
+});
+
+async function totalsFor(
+	startDate: string,
+	endDate: string,
+	pages: number,
+	type = "web",
+): Promise<GscTotals> {
 	const rows = await gscQuery({
 		startDate,
 		endDate,
 		dimensions: [],
+		type,
 		rowLimit: 1,
 	});
 	const r = rows[0];
@@ -43,14 +93,9 @@ async function totalsFor(startDate: string, endDate: string, pages: number) {
 	};
 }
 
-async function pageCount(startDate: string, endDate: string): Promise<number> {
-	const rows = await gscQuery({
-		startDate,
-		endDate,
-		dimensions: ["page"],
-		rowLimit: 5000,
-	});
-	return rows.length;
+/** Full page table (paginated) — also the source of the page count. */
+async function allPages(startDate: string, endDate: string) {
+	return gscQueryAll({ startDate, endDate, dimensions: ["page"] }, 50000);
 }
 
 async function main() {
@@ -58,26 +103,23 @@ async function main() {
 		`GSC ${SEO_SITE}  current ${start}..${end}  prev ${prevStart}..${prevEnd}`,
 	);
 
-	// Current + previous query tables, joined by query key for movement.
+	// ── Queries: current vs previous, joined for movement ────────────────────
 	const [curQ, prevQ] = await Promise.all([
-		gscQuery({
-			startDate: start,
-			endDate: end,
-			dimensions: ["query"],
-			rowLimit: 500,
-		}),
-		gscQuery({
-			startDate: prevStart,
-			endDate: prevEnd,
-			dimensions: ["query"],
-			rowLimit: 500,
-		}),
+		gscQueryAll(
+			{ startDate: start, endDate: end, dimensions: ["query"] },
+			50000,
+		),
+		gscQueryAll(
+			{ startDate: prevStart, endDate: prevEnd, dimensions: ["query"] },
+			50000,
+		),
 	]);
-	const prevByQuery = new Map(prevQ.map((r) => [r.keys[0]!, r]));
+	const prevByQuery = new Map(prevQ.map((r) => [r.keys[0] ?? "", r]));
 	const queries: QueryMetric[] = curQ.map((r) => {
-		const prev = prevByQuery.get(r.keys[0]!);
+		const key = r.keys[0] ?? "";
+		const prev = prevByQuery.get(key);
 		return {
-			query: r.keys[0]!,
+			query: key,
 			clicks: r.clicks,
 			impressions: r.impressions,
 			ctr: r.ctr,
@@ -87,23 +129,89 @@ async function main() {
 		};
 	});
 
-	const [curPages, curPageCount, prevPageCount] = await Promise.all([
-		gscQuery({
-			startDate: start,
-			endDate: end,
-			dimensions: ["page"],
-			rowLimit: 500,
-		}),
-		pageCount(start, end),
-		pageCount(prevStart, prevEnd),
+	// ── Pages: current vs previous (previous also powers `lostPages`) ────────
+	const [curPagesRaw, prevPagesRaw] = await Promise.all([
+		allPages(start, end),
+		allPages(prevStart, prevEnd),
 	]);
+	const curPages = curPagesRaw.map(toPage);
+	const curPageKeys = new Set(curPages.map((p) => p.page));
 
 	const [totals, prevTotals] = await Promise.all([
-		totalsFor(start, end, curPageCount),
-		totalsFor(prevStart, prevEnd, prevPageCount),
+		totalsFor(start, end, curPages.length),
+		totalsFor(prevStart, prevEnd, prevPagesRaw.length),
 	]);
 
-	// Derived signals (see .goals/seo/PLAYBOOK.md priority order).
+	// ── Extra dimensions (each independently degradable) ─────────────────────
+	const [daily, devices, countries, searchAppearance, pageQueryRows, sitemaps] =
+		await Promise.all([
+			soft("daily", () =>
+				gscQuery({
+					startDate: start,
+					endDate: end,
+					dimensions: ["date"],
+					rowLimit: 500,
+				}),
+			),
+			soft("devices", () =>
+				gscQuery({
+					startDate: start,
+					endDate: end,
+					dimensions: ["device"],
+					rowLimit: 10,
+				}),
+			),
+			soft("countries", () =>
+				gscQuery({
+					startDate: start,
+					endDate: end,
+					dimensions: ["country"],
+					rowLimit: 250,
+				}),
+			),
+			// searchAppearance cannot be combined with other dimensions.
+			soft("searchAppearance", () =>
+				gscQuery({
+					startDate: start,
+					endDate: end,
+					dimensions: ["searchAppearance"],
+					rowLimit: 50,
+				}),
+			),
+			soft("pageQueries", () =>
+				gscQueryAll(
+					{ startDate: start, endDate: end, dimensions: ["page", "query"] },
+					25000,
+				),
+			),
+			soft("sitemaps", () => gscSitemaps()),
+		]);
+
+	// ── Per-search-type totals: web / image / video / news / discover ────────
+	const searchTypes: Record<string, GscTotals> = {};
+	for (const type of [
+		"web",
+		"image",
+		"video",
+		"news",
+		"googleNews",
+		"discover",
+	]) {
+		const t = await soft(`type:${type}`, async () => {
+			const pages = await gscQuery({
+				startDate: start,
+				endDate: end,
+				dimensions: ["page"],
+				type,
+				rowLimit: 25000,
+			});
+			return totalsFor(start, end, pages.length, type);
+		});
+		// Only keep surfaces we actually appear on — zeros are noise in the plan.
+		if (t && t.impressions > 0) searchTypes[type] = t;
+	}
+
+	// ── Derived signals (see .goals/seo/PLAYBOOK.md priority order) ──────────
 	const byClicks = (a: QueryMetric, b: QueryMetric) =>
 		b.clicks - a.clicks || b.impressions - a.impressions;
 
@@ -117,36 +225,63 @@ async function main() {
 		.sort((a, b) => b.impressions - a.impressions)
 		.slice(0, 30);
 
-	const risingQueries = queries
-		.filter((q) => q.impressions >= 10)
-		.map((q) => ({ q, delta: q.impressions - (q.prevImpressions ?? 0) }))
+	const withDelta = queries
+		.filter((q) => q.impressions >= 10 || (q.prevImpressions ?? 0) >= 10)
+		.map((q) => ({ q, delta: q.impressions - (q.prevImpressions ?? 0) }));
+
+	const risingQueries = withDelta
 		.filter((x) => x.delta > 0)
 		.sort((a, b) => b.delta - a.delta)
 		.slice(0, 30)
 		.map((x) => x.q);
 
-	const topPages = curPages
-		.map((r) => ({
-			page: r.keys[0]!,
-			clicks: r.clicks,
-			impressions: r.impressions,
-			ctr: r.ctr,
-			position: r.position,
-		}))
+	const fallingQueries = withDelta
+		.filter((x) => x.delta < 0)
+		.sort((a, b) => a.delta - b.delta)
+		.slice(0, 30)
+		.map((x) => x.q);
+
+	const topPages = [...curPages]
 		.sort((a, b) => b.clicks - a.clicks || b.impressions - a.impressions)
 		.slice(0, 50);
 
 	const zeroClickPages = curPages
-		.map((r) => ({
-			page: r.keys[0]!,
+		.filter((p) => p.clicks === 0 && p.impressions >= 20)
+		.sort((a, b) => b.impressions - a.impressions)
+		.slice(0, 30);
+
+	// Pages that ranked last window and vanished from this one — the signal that
+	// explains a pagesWithImpressions drop, which a totals diff alone can't.
+	const lostPages = prevPagesRaw
+		.map(toPage)
+		.filter((p) => !curPageKeys.has(p.page) && p.impressions >= 5)
+		.sort((a, b) => b.impressions - a.impressions)
+		.slice(0, 50);
+
+	const pageQueries: PageQueryMetric[] | undefined = pageQueryRows
+		?.map((r) => ({
+			page: r.keys[0] ?? "",
+			query: r.keys[1] ?? "",
 			clicks: r.clicks,
 			impressions: r.impressions,
 			ctr: r.ctr,
 			position: r.position,
 		}))
-		.filter((p) => p.clicks === 0 && p.impressions >= 20)
 		.sort((a, b) => b.impressions - a.impressions)
-		.slice(0, 30);
+		.slice(0, 500);
+
+	// Fold in the coverage rollup from the last inspect-urls run, if present.
+	const coveragePath = join(DATA_DIR, "index-coverage.json");
+	let indexCoverage: IndexCoverageSummary | undefined;
+	if (existsSync(coveragePath)) {
+		try {
+			indexCoverage = JSON.parse(
+				readFileSync(coveragePath, "utf8"),
+			) as IndexCoverageSummary;
+		} catch {
+			/* a corrupt rollup must not block the pull */
+		}
+	}
 
 	const snapshot: GscSnapshot = {
 		source: "gsc",
@@ -158,10 +293,20 @@ async function main() {
 		prevTotals,
 		topQueries: [...queries].sort(byClicks).slice(0, 50),
 		risingQueries,
+		fallingQueries,
 		strikingDistance,
 		lowCtrQueries,
 		topPages,
 		zeroClickPages,
+		daily: daily?.map(toDimension),
+		devices: devices?.map(toDimension),
+		countries: countries?.map(toDimension),
+		searchAppearance: searchAppearance?.map(toDimension),
+		searchTypes: Object.keys(searchTypes).length ? searchTypes : undefined,
+		pageQueries,
+		lostPages,
+		sitemaps,
+		indexCoverage,
 	};
 
 	mkdirSync(DATA_DIR, { recursive: true });
@@ -174,10 +319,15 @@ async function main() {
 
 	const dClicks = totals.clicks - prevTotals.clicks;
 	const dPages = totals.pagesWithImpressions - prevTotals.pagesWithImpressions;
+	const sitemapErrors = (sitemaps ?? []).reduce((n, s) => n + s.errors, 0);
 	console.log(
 		`✓ ${dated}\n  clicks ${totals.clicks} (${dClicks >= 0 ? "+" : ""}${dClicks})  ` +
 			`impressions ${totals.impressions}  pages ${totals.pagesWithImpressions} (${dPages >= 0 ? "+" : ""}${dPages})\n` +
-			`  striking-distance ${strikingDistance.length}  low-CTR ${lowCtrQueries.length}  rising ${risingQueries.length}`,
+			`  queries ${queries.length}  page×query ${pageQueries?.length ?? 0}  lost-pages ${lostPages.length}\n` +
+			`  striking-distance ${strikingDistance.length}  low-CTR ${lowCtrQueries.length}  ` +
+			`rising ${risingQueries.length}  falling ${fallingQueries.length}\n` +
+			`  surfaces ${Object.keys(searchTypes).join(", ") || "web only"}  ` +
+			`sitemaps ${sitemaps?.length ?? 0} (${sitemapErrors} errors)`,
 	);
 }
 


### PR DESCRIPTION
## El problema

Google **nunca ha rastreado ni una sola** de las ~35.000 URLs de reforma. Un barrido de 600 con la URL Inspection API encontró 339 en «Descubierta: actualmente sin indexar», 261 que Google ni conoce, y **ninguna con `lastCrawlTime`**.

No es calidad de contenido — Google no puede juzgar lo que nunca descarga. Y tampoco es la infraestructura:

- El SSR del Worker funciona: verificado en 260 URLs del sitemap, 260 correctas y 0 con `noindex`.
- El sitemap se descarga a diario (última: 2026-07-28).
- Los enlaces internos existen: cada página de ley enlaza sus reformas desde HTML estático, y **el 99,1% de las páginas de ley sí se rastrean**.

Queda la forma de la URL. 35k URLs que solo difieren en query string se leen como navegación facetada, y Google no gasta presupuesto de rastreo en eso para un dominio con nuestra autoridad.

## Qué hace este PR

En vez de migrar las 35k sobre una hipótesis sin probar, **solo las 662 reformas de 2026** pasan a `/cambios/reforma/<id>/<date>/`. Son el grupo de tratamiento; las ~34.300 restantes siguen en query params como control.

**Ambas formas se sirven siempre**, así que ningún enlace existente se rompe. El experimento solo decide cuál es canónica y cuál va al sitemap, y esa decisión vive en un único módulo (`packages/web/src/lib/reform-experiment.ts`) que importan el Worker, el sitemap y la página de ley — no pueden divergir y anunciar una URL mientras canonicalizan otra.

### Un fallo corregido por el camino

El fallback del Worker hacía `env.ASSETS.fetch(request)`. Con una URL de tipo path eso habría dado **404**, porque ese asset no existe: le habríamos servido a Google un 404 duro para una reforma que simplemente falló al renderizar. Ahora pide `SHELL_PATH` explícitamente, con un test que lo protege.

## Verificación

- Build completo: 12.370 páginas. El sitemap emite **662 con path y 34.339 con query**.
- Enlaces internos: en la Constitución, la reforma de 2026-05-20 sale con path; las de 2024 y 2011 con query.
- **19 tests nuevos**, suite completa 89/89. Incluye integración del Worker con la API simulada: una URL con path renderiza contenido real, pierde el `noindex` y se canonicaliza a sí misma.
- `tsgo` y `biome` limpios.

`wrangler dev` no sirve para probar esto (necesita la API real y su watcher de assets se atraganta con 12k ficheros), de ahí el test de integración con stubs.

## Cómo se mide

`scripts/seo/experiment-report.ts`, con umbrales fijados **antes** de medir. La métrica primaria es `crawlRate`, no `indexedRate`: Google tiene que descargar la página antes de poder juzgarla, y es en la descarga donde esta cohorte está bloqueada.

Línea base ya registrada:

```
cohorte             n    rastreadas    indexadas
ley              1178  1167 (99.1%)  155 (13.2%)
reforma-query     600      0 (0.0%)     0 (0.0%)
```

A tres semanas del despliegue (~2026-08-18):

- **Éxito:** `reforma-path` > 20% rastreadas y control < 5% → migrar las 34.300 restantes.
- **Fracaso:** `reforma-path` < 5% → la hipótesis es falsa; el bloqueo es autoridad de dominio y migrar el resto no arreglaría nada.

⚠️ Con una mediana de rastreo de 74 días en el resto del sitio, tres semanas puede quedarse corto. Si el 18 de agosto sale «cero en ambas cohortes», lo honesto es esperar más, no declarar fracaso.

## Nota sobre la rama

Va contra `main` en vez de `staging` a propósito: `staging` tiene el trabajo de BOE diario (#141) que no he verificado, y un experimento necesita desplegarse aislado para que su resultado sea interpretable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)