### PR TITLE
SEO: /pregunta/ y /datos/ al sitemap + documentar estado y experimentos

### DIFF
--- a/.goals/seo/GOAL.md
+++ b/.goals/seo/GOAL.md
@@ -1,5 +1,8 @@
 # Goal: crecimiento de tráfico orgánico de leyabierta.es
 
+> **Estado actual y experimentos en curso: [`STATUS.md`](STATUS.md).** Míralo
+> antes de tocar sitemap, Worker o URLs de reforma — hay un experimento vivo.
+
 North star de un loop autónomo y quincenal que mejora el SEO de Ley Abierta
 tomando decisiones basadas en datos reales de Google Search Console (GSC) y
 Umami. Inspirado en el diseño de `docs/async-experimentation-system.md`, pero

--- a/.goals/seo/STATUS.md
+++ b/.goals/seo/STATUS.md
@@ -52,9 +52,10 @@ páginas de ley con paths reales sí (99,1%). Hipótesis: 35k URLs que solo
 difieren en query string se leen como navegación facetada, y Google no gasta
 presupuesto de rastreo en eso para un dominio con nuestra autoridad.
 
-Las 688 reformas de 2026 se reparten por hash en dos brazos (~348 con path,
-~340 con query) para que ambos tengan la misma frescura y estructura de enlaces:
-la única diferencia sistemática es la forma de URL. Las reformas anteriores
+Las 688 reformas de 2026 se reparten por hash en dos brazos —348 con path y 340
+con query, medido sobre el sitemap desplegado— para que ambos tengan la misma
+frescura y estructura de enlaces: la única diferencia sistemática es la forma
+de URL. Las reformas anteriores
 siguen en query form y se reportan aparte, sin sustentar el veredicto.
 
 **Métrica primaria: `crawlRate`, no `indexedRate`.** Google debe descargar la
@@ -87,10 +88,18 @@ bun run scripts/seo/experiment-report.ts
 simplemente nunca ofrecidas — faltaban en el sitemap. `/pregunta/` es lo que
 más nos diferencia del BOE (responde en lenguaje llano) y era invisible.
 
-Añadidas junto con `/cambios/recientes/`. Un test
-(`src/__tests__/sitemap-coverage.test.ts`) obliga a que toda página estática
-esté en el sitemap o excluida explícitamente con su motivo, para que no vuelva
-a pasar en silencio.
+Añadidas junto con `/cambios/recientes/`. La lista vive en
+`packages/web/src/lib/site-pages.ts` y un test
+(`packages/web/src/__tests__/sitemap-coverage.test.ts`) comprueba que toda
+página estática esté en el sitemap o excluida explícitamente con su motivo, en
+ambos sentidos: una ruta excluida tampoco puede aparecer en el sitemap.
+
+> ⚠️ **El test no es gate en CI.** `deploy.yml` ejecuta `bun test || true` y
+> `pr-checks.yml` no ejecuta tests, así que un fallo no bloquea el merge ni el
+> despliegue. Vale como red para quien ejecute los tests en local, no como
+> garantía automática. Convertirlo en gate es trabajo aparte: el `|| true` está
+> ahí porque algunos tests del repo necesitan ficheros de datos que no existen
+> en CI.
 
 Sin criterio formal de éxito: es corregir una omisión, no una hipótesis. Se
 comprueba en la siguiente pasada de inspección.
@@ -106,10 +115,13 @@ comprueba en la siguiente pasada de inspección.
   que mueve esa cifra.
 - **Cero rich results.** `searchAppearance` viene vacío. El JSON-LD
   `Legislation` es correcto como dato semántico pero **Google no genera rich
-  results para ese tipo**. `Dataset` en `/datos/` y `Article`/`NewsArticle` en
-  las reformas sí son tipos soportados — pero no antes de que esas páginas
-  estén indexadas, o se optimiza algo que no existe. `FAQPage` no aplica:
-  Google lo restringió en 2023 a sitios gubernamentales y de salud.
+  results para ese tipo**. Hoy sólo emitimos `Legislation` + `BreadcrumbList`
+  en las fichas de ley y `Organization`/`WebSite` en el layout: **no hay
+  `Dataset` ni `Article` en ninguna página**. Son tipos que Google sí soporta y
+  candidatos claros (`Dataset` en `/datos/`, `Article`/`NewsArticle` en las
+  reformas), pero añadirlos antes de que esas páginas estén indexadas es
+  optimizar algo que no existe. `FAQPage` no aplica: Google lo restringió en
+  2023 a sitios gubernamentales y de salud.
 - **Autoridad de dominio.** El único backlink que Google detecta hacia la home
   es `libhunt.com`. Sin enlaces externos, el presupuesto de rastreo se queda
   corto por mucho que arreglemos lo técnico.

--- a/.goals/seo/STATUS.md
+++ b/.goals/seo/STATUS.md
@@ -1,0 +1,117 @@
+# Estado SEO y experimentos en curso
+
+Dónde estamos, qué se está probando y cuándo se lee el resultado. Complementa
+[`GOAL.md`](GOAL.md) (objetivos), [`PLAYBOOK.md`](PLAYBOOK.md) (qué puede tocar
+el loop) y [`EVAL.md`](EVAL.md) (cómo se puntúa un plan).
+
+> **Si vas a tocar el sitemap, el Worker o las URLs de reforma, lee primero la
+> sección de experimentos.** Hay uno vivo y un cambio despistado lo invalida.
+
+**Última actualización:** 2026-07-28
+
+---
+
+## Diagnóstico actual
+
+Medido con la URL Inspection API sobre 1.800 URLs (`scripts/seo/inspect-urls.ts`),
+no estimado:
+
+| Cohorte | Muestra | Rastreadas | Indexadas |
+|---------|---------|-----------|-----------|
+| Páginas de ley `/leyes/<id>/` | 1.178 | 99,1% | **13,2%** |
+| Reformas `/cambios/reforma/…` | 600 | **0%** | **0%** |
+| Páginas clave | 22 | 59% | 45% |
+
+Search Console, ventana de 28 días a 2026-07-25: 2 clics, 1.116 impresiones,
+CTR 0,18%, posición media 54.
+
+**Son dos problemas distintos, y confundirlos lleva a arreglar lo que no es:**
+
+1. **Reformas — problema de rastreo.** Google no las descarga. Ninguna de las
+   600 muestreadas tiene `lastCrawlTime`. No se puede juzgar el contenido de una
+   página que nunca se ha visitado. → Experimento A.
+2. **Leyes — problema de valor percibido.** Google las descarga sin problema
+   (`pageFetchState: SUCCESSFUL` en 385/400) y decide no indexarlas. El texto
+   legal es idéntico al del BOE, que es la fuente autoritativa. Ningún ajuste
+   técnico arregla esto; hace falta que la página aporte algo que el BOE no da.
+
+**Corolario para priorizar:** con el 13,2% indexado, optimizar títulos, meta
+descriptions o datos estructurados de páginas que Google no indexa no mueve
+nada. Primero indexación, después presentación.
+
+---
+
+## Experimentos
+
+### A — Forma de URL de las reformas · **en curso**
+
+**Desplegado:** 2026-07-28 · **Lectura:** a partir de **2026-08-18**
+
+Las ~35k URLs `/cambios/reforma/?id=&date=` nunca se han rastreado, mientras las
+páginas de ley con paths reales sí (99,1%). Hipótesis: 35k URLs que solo
+difieren en query string se leen como navegación facetada, y Google no gasta
+presupuesto de rastreo en eso para un dominio con nuestra autoridad.
+
+Las 688 reformas de 2026 se reparten por hash en dos brazos (~348 con path,
+~340 con query) para que ambos tengan la misma frescura y estructura de enlaces:
+la única diferencia sistemática es la forma de URL. Las reformas anteriores
+siguen en query form y se reportan aparte, sin sustentar el veredicto.
+
+**Métrica primaria: `crawlRate`, no `indexedRate`.** Google debe descargar la
+página antes de poder juzgarla, y el bloqueo está en la descarga.
+
+| Resultado | Condición | Qué hacer |
+|-----------|-----------|-----------|
+| ✅ Éxito | path > 20% rastreadas **y** control < 5% | Migrar las ~34.3k restantes |
+| ❌ Fracaso | path < 5% **y** control ≥ 5% | La forma de URL no era el bloqueo; ir a enlazado y autoridad |
+| ⏳ Sin señal | ambos brazos planos | Googlebot no ha vuelto — ampliar ventana, **no** concluir |
+
+Con una mediana de rastreo de 74 días en el resto del sitio, tres semanas puede
+quedarse corto. "Cero en ambos brazos" es ausencia de datos, no evidencia
+contra la hipótesis.
+
+**Código:** `packages/web/src/lib/reform-experiment.ts`. El criterio de reparto
+lo importan el Worker, el sitemap y la ficha de ley — no puede divergir.
+**No cambies `EXPERIMENT_YEAR` ni el reparto mientras el experimento corra.**
+
+```bash
+# Leer el resultado (en KonarServer)
+cd /opt/leyabierta/seo-repo && set -a && . /opt/leyabierta/.env.seo && set +a
+SEO_INSPECT_BUDGET=600 bun run scripts/seo/inspect-urls.ts
+bun run scripts/seo/experiment-report.ts
+```
+
+### B — Descubrimiento de páginas clave · **desplegado 2026-07-28**
+
+`/datos/` y `/pregunta/` estaban en "Google no reconoce esta URL": no rechazadas,
+simplemente nunca ofrecidas — faltaban en el sitemap. `/pregunta/` es lo que
+más nos diferencia del BOE (responde en lenguaje llano) y era invisible.
+
+Añadidas junto con `/cambios/recientes/`. Un test
+(`src/__tests__/sitemap-coverage.test.ts`) obliga a que toda página estática
+esté en el sitemap o excluida explícitamente con su motivo, para que no vuelva
+a pasar en silencio.
+
+Sin criterio formal de éxito: es corregir una omisión, no una hipótesis. Se
+comprueba en la siguiente pasada de inspección.
+
+---
+
+## Abierto, sin atacar todavía
+
+- **Las 12.000 páginas de ley (13,2% indexadas).** Necesita diferenciación real
+  de contenido: que el HTML lleve por delante lo único nuestro (resúmenes
+  ciudadanos por artículo, historial de reformas, diffs entre versiones) en vez
+  de replicar articulado que el BOE ya tiene. Es el trabajo grande y el único
+  que mueve esa cifra.
+- **Cero rich results.** `searchAppearance` viene vacío. El JSON-LD
+  `Legislation` es correcto como dato semántico pero **Google no genera rich
+  results para ese tipo**. `Dataset` en `/datos/` y `Article`/`NewsArticle` en
+  las reformas sí son tipos soportados — pero no antes de que esas páginas
+  estén indexadas, o se optimiza algo que no existe. `FAQPage` no aplica:
+  Google lo restringió en 2023 a sitios gubernamentales y de salud.
+- **Autoridad de dominio.** El único backlink que Google detecta hacia la home
+  es `libhunt.com`. Sin enlaces externos, el presupuesto de rastreo se queda
+  corto por mucho que arreglemos lo técnico.
+- **El tráfico de buscadores llega de Bing**, no de Google (238 visitas vs 0 en
+  30 días de Umami). Google indexa poco y posiciona en el puesto 54.

--- a/packages/web/src/__tests__/sitemap-coverage.test.ts
+++ b/packages/web/src/__tests__/sitemap-coverage.test.ts
@@ -1,75 +1,96 @@
-// Guards against the failure that hid /datos/ and /pregunta/ from Google for
-// months: a page exists under src/pages/ but nobody remembers to add it to the
-// sitemap, and there is no error anywhere — the page is simply never offered
-// to a crawler. A URL Inspection sweep on 2026-07-28 found both at "Google no
-// reconoce esta URL".
+// Guards the failure that hid /datos/ and /pregunta/ from Google: a page
+// exists, works, and is indexable, but nobody ever tells a crawler about it —
+// and nothing errors. A URL Inspection sweep on 2026-07-28 found both at
+// "Google no reconoce esta URL".
 //
-// So: every static page must be either listed in the sitemap or explicitly
-// excluded here with a reason. Adding a page and forgetting both fails this.
+// Asserts against SECONDARY_PAGES / SITEMAP_EXCLUDED directly, not against the
+// text of sitemap-leyes.xml.ts. Matching source text would pass on a route that
+// only survives inside a comment while the emitted sitemap has no such entry —
+// the very bug this is here to catch.
 import { describe, expect, test } from "bun:test";
-import { readdirSync, readFileSync, statSync } from "node:fs";
+import { readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
+import { SECONDARY_PAGES, SITEMAP_EXCLUDED } from "../lib/site-pages.ts";
 
 const PAGES_DIR = new URL("../pages", import.meta.url).pathname;
-const SITEMAP_SRC = join(PAGES_DIR, "sitemap-leyes.xml.ts");
 
-/** Routes that must NOT be in the sitemap, and why. */
-const INTENTIONALLY_EXCLUDED = new Map([
-	["/404/", "error page"],
-	[
-		"/cambios/para-mi/",
-		"personalised client-side; empty without the visitor's filters",
-	],
-	[
-		"/cambios/reforma/",
-		"bare shell carries noindex; real URLs in sitemap-reformas.xml",
-	],
-	["/alertas/gestionar/", "transactional, reached with a one-time token"],
-	["/alertas/confirmar/", "transactional, reached with a one-time token"],
-	["/alertas/cancelar/", "transactional, reached with a one-time token"],
-	[
-		"/alertas/seguir/confirmar/",
-		"transactional, reached with a one-time token",
-	],
-]);
+/** Page files Astro turns into routes. */
+const PAGE_EXTENSIONS = [".astro", ".md", ".mdx", ".html"];
 
-/** Static .astro routes under src/pages, as site paths. Skips dynamic ones. */
+/**
+ * Static routes under src/pages, as site paths.
+ *
+ * Dynamic routes ([id].astro) are skipped — they have their own sitemaps. So is
+ * anything under a dynamic directory (leyes/[id]/algo.astro): it expands to one
+ * route per id, which can't live in a hand-maintained list either. Known limit
+ * of this guard — if such a page is ever added, it needs its own sitemap and a
+ * check of its own.
+ */
 function staticRoutes(dir = PAGES_DIR, prefix = ""): string[] {
 	const out: string[] = [];
 	for (const entry of readdirSync(dir)) {
 		const full = join(dir, entry);
 		if (statSync(full).isDirectory()) {
-			// [id] / [fecha] segments are dynamic — they get their own sitemaps.
-			if (!entry.startsWith("["))
-				out.push(...staticRoutes(full, `${prefix}${entry}/`));
+			out.push(...staticRoutes(full, `${prefix}${entry}/`));
 			continue;
 		}
-		if (!entry.endsWith(".astro") || entry.startsWith("[")) continue;
-		const name = entry.replace(/\.astro$/, "");
+		const ext = PAGE_EXTENSIONS.find((e) => entry.endsWith(e));
+		if (!ext) continue;
+		const name = entry.slice(0, -ext.length);
+		// A dynamic *file* ([id].astro) is a route template, not a page.
+		if (name.startsWith("[")) continue;
+		// ...but a static file under a dynamic directory still is one.
+		if (prefix.includes("[")) continue;
 		out.push(name === "index" ? `/${prefix}` : `/${prefix}${name}/`);
 	}
 	return out;
 }
 
+const sitemapPaths = new Set(SECONDARY_PAGES.map((p) => p.path));
+
 describe("sitemap covers every static page", () => {
 	test("no page is silently missing from the sitemap", () => {
-		const sitemap = readFileSync(SITEMAP_SRC, "utf8");
 		const missing = staticRoutes()
-			.filter((r) => !INTENTIONALLY_EXCLUDED.has(r))
-			// "/" is emitted separately from the secondaryPages list.
+			// "/" is emitted separately from the SECONDARY_PAGES list.
 			.filter((r) => r !== "/")
-			.filter((r) => !sitemap.includes(`"${r}"`));
+			.filter((r) => !sitemapPaths.has(r) && !SITEMAP_EXCLUDED.has(r));
 
 		expect(missing).toEqual([]);
+	});
+
+	// The other direction: an excluded route must actually be absent. Without
+	// this, adding /cambios/reforma/ to the sitemap while leaving it on the
+	// exclusion list passes both checks and offers Google a noindex shell.
+	test("excluded routes are not in the sitemap", () => {
+		const contradictory = [...SITEMAP_EXCLUDED.keys()].filter((r) =>
+			sitemapPaths.has(r),
+		);
+		expect(contradictory).toEqual([]);
 	});
 
 	// Keeps the exclusion list honest: a route deleted from src/pages should be
 	// dropped from here too, or the list slowly becomes fiction.
 	test("every exclusion refers to a page that still exists", () => {
 		const routes = new Set(staticRoutes());
-		const stale = [...INTENTIONALLY_EXCLUDED.keys()].filter(
-			(r) => !routes.has(r),
-		);
+		const stale = [...SITEMAP_EXCLUDED.keys()].filter((r) => !routes.has(r));
 		expect(stale).toEqual([]);
+	});
+
+	// A sitemap entry pointing at a page that no longer exists is a 404 handed
+	// to Google on purpose.
+	test("every sitemap entry refers to a page that exists", () => {
+		const routes = new Set(staticRoutes());
+		const dangling = [...sitemapPaths].filter((r) => !routes.has(r));
+		expect(dangling).toEqual([]);
+	});
+
+	// A bare "excluded" with no reason is how a list like this rots: nobody
+	// dares remove an entry they can't justify.
+	test("every exclusion states a reason", () => {
+		for (const [route, reason] of SITEMAP_EXCLUDED) {
+			expect(reason.trim().length, `${route} needs a reason`).toBeGreaterThan(
+				5,
+			);
+		}
 	});
 });

--- a/packages/web/src/__tests__/sitemap-coverage.test.ts
+++ b/packages/web/src/__tests__/sitemap-coverage.test.ts
@@ -1,0 +1,75 @@
+// Guards against the failure that hid /datos/ and /pregunta/ from Google for
+// months: a page exists under src/pages/ but nobody remembers to add it to the
+// sitemap, and there is no error anywhere — the page is simply never offered
+// to a crawler. A URL Inspection sweep on 2026-07-28 found both at "Google no
+// reconoce esta URL".
+//
+// So: every static page must be either listed in the sitemap or explicitly
+// excluded here with a reason. Adding a page and forgetting both fails this.
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+const PAGES_DIR = new URL("../pages", import.meta.url).pathname;
+const SITEMAP_SRC = join(PAGES_DIR, "sitemap-leyes.xml.ts");
+
+/** Routes that must NOT be in the sitemap, and why. */
+const INTENTIONALLY_EXCLUDED = new Map([
+	["/404/", "error page"],
+	[
+		"/cambios/para-mi/",
+		"personalised client-side; empty without the visitor's filters",
+	],
+	[
+		"/cambios/reforma/",
+		"bare shell carries noindex; real URLs in sitemap-reformas.xml",
+	],
+	["/alertas/gestionar/", "transactional, reached with a one-time token"],
+	["/alertas/confirmar/", "transactional, reached with a one-time token"],
+	["/alertas/cancelar/", "transactional, reached with a one-time token"],
+	[
+		"/alertas/seguir/confirmar/",
+		"transactional, reached with a one-time token",
+	],
+]);
+
+/** Static .astro routes under src/pages, as site paths. Skips dynamic ones. */
+function staticRoutes(dir = PAGES_DIR, prefix = ""): string[] {
+	const out: string[] = [];
+	for (const entry of readdirSync(dir)) {
+		const full = join(dir, entry);
+		if (statSync(full).isDirectory()) {
+			// [id] / [fecha] segments are dynamic — they get their own sitemaps.
+			if (!entry.startsWith("["))
+				out.push(...staticRoutes(full, `${prefix}${entry}/`));
+			continue;
+		}
+		if (!entry.endsWith(".astro") || entry.startsWith("[")) continue;
+		const name = entry.replace(/\.astro$/, "");
+		out.push(name === "index" ? `/${prefix}` : `/${prefix}${name}/`);
+	}
+	return out;
+}
+
+describe("sitemap covers every static page", () => {
+	test("no page is silently missing from the sitemap", () => {
+		const sitemap = readFileSync(SITEMAP_SRC, "utf8");
+		const missing = staticRoutes()
+			.filter((r) => !INTENTIONALLY_EXCLUDED.has(r))
+			// "/" is emitted separately from the secondaryPages list.
+			.filter((r) => r !== "/")
+			.filter((r) => !sitemap.includes(`"${r}"`));
+
+		expect(missing).toEqual([]);
+	});
+
+	// Keeps the exclusion list honest: a route deleted from src/pages should be
+	// dropped from here too, or the list slowly becomes fiction.
+	test("every exclusion refers to a page that still exists", () => {
+		const routes = new Set(staticRoutes());
+		const stale = [...INTENTIONALLY_EXCLUDED.keys()].filter(
+			(r) => !routes.has(r),
+		);
+		expect(stale).toEqual([]);
+	});
+});

--- a/packages/web/src/lib/reform-experiment.ts
+++ b/packages/web/src/lib/reform-experiment.ts
@@ -21,7 +21,7 @@
  * success and would justify migrating the other 34k on a false premise.
  *
  * So the split is *within* 2026: each reform is assigned to path or query form
- * by a hash of its identity, giving two arms of ~331 that are identical in
+ * by a hash of its identity, giving two arms of ~340 that are identical in
  * freshness, link structure and law mix. The only systematic difference left is
  * the URL shape, which is the thing under test. Pre-2026 reforms stay on the
  * query form and are reported separately as historical background, never as the

--- a/packages/web/src/lib/site-pages.ts
+++ b/packages/web/src/lib/site-pages.ts
@@ -1,0 +1,67 @@
+/**
+ * The site's static pages and their sitemap status, as data.
+ *
+ * This lives apart from `sitemap-leyes.xml.ts` because that file imports
+ * `astro:content`, which only resolves during a build — so a test can't import
+ * it and has to fall back to reading the source as text. Text matching is not
+ * good enough here: a route mentioned in a comment would satisfy it while the
+ * sitemap goes out without the entry, which is exactly the failure this is
+ * meant to catch.
+ *
+ * Both the sitemap route and the coverage test import these arrays, so the test
+ * checks the same values the sitemap actually emits.
+ */
+
+export interface SitemapEntry {
+	path: string;
+	changefreq: string;
+	priority: string;
+}
+
+/**
+ * Every indexable page that isn't a law or a reform. Keep in sync with
+ * src/pages/ — a page missing here is a page Google may never discover. On
+ * 2026-07-28 a URL Inspection sweep found /datos/ and /pregunta/ at "Google no
+ * reconoce esta URL": not rejected, simply never offered.
+ */
+export const SECONDARY_PAGES: SitemapEntry[] = [
+	{ path: "/cambios/", changefreq: "daily", priority: "0.6" },
+	{ path: "/cambios/recientes/", changefreq: "daily", priority: "0.7" },
+	// The clearest thing this site does that boe.es does not: answer a question
+	// in plain language. It was invisible to Google until 2026-07-28.
+	{ path: "/pregunta/", changefreq: "weekly", priority: "0.8" },
+	{ path: "/datos/", changefreq: "weekly", priority: "0.6" },
+	{ path: "/sobre/", changefreq: "monthly", priority: "0.5" },
+	{ path: "/sobre/contribuir/", changefreq: "monthly", priority: "0.4" },
+	{ path: "/sobre/apoyar/", changefreq: "monthly", priority: "0.4" },
+	{ path: "/sobre/api/", changefreq: "monthly", priority: "0.4" },
+	{ path: "/alertas/", changefreq: "monthly", priority: "0.5" },
+	{ path: "/mi-situacion/", changefreq: "monthly", priority: "0.5" },
+	{ path: "/privacidad/", changefreq: "yearly", priority: "0.2" },
+	{ path: "/cookies/", changefreq: "yearly", priority: "0.2" },
+	{ path: "/aviso-legal/", changefreq: "yearly", priority: "0.2" },
+];
+
+/**
+ * Static routes that must NOT appear in the sitemap, with the reason. The
+ * coverage test enforces this in both directions: these can't be missing from
+ * here, and they can't show up in SECONDARY_PAGES either.
+ */
+export const SITEMAP_EXCLUDED = new Map<string, string>([
+	["/404/", "error page; carries noindex and has nothing to rank for"],
+	[
+		"/cambios/para-mi/",
+		"personalised client-side; renders empty without the visitor's own filters",
+	],
+	[
+		"/cambios/reforma/",
+		"bare shell carries noindex; real reform URLs live in sitemap-reformas.xml",
+	],
+	["/alertas/gestionar/", "transactional, reached with a one-time token"],
+	["/alertas/confirmar/", "transactional, reached with a one-time token"],
+	["/alertas/cancelar/", "transactional, reached with a one-time token"],
+	[
+		"/alertas/seguir/confirmar/",
+		"transactional, reached with a one-time token",
+	],
+]);

--- a/packages/web/src/pages/sitemap-leyes.xml.ts
+++ b/packages/web/src/pages/sitemap-leyes.xml.ts
@@ -6,6 +6,7 @@
 
 import { getCollection } from "astro:content";
 import type { APIRoute } from "astro";
+import { SECONDARY_PAGES } from "../lib/site-pages.ts";
 
 export const prerender = true;
 
@@ -14,43 +15,13 @@ const SITE_URL = "https://leyabierta.es";
 export const GET: APIRoute = async () => {
 	const laws = await getCollection("laws");
 
-	// Every indexable page that isn't a law or a reform. Keep in sync with
-	// src/pages/ — a page missing here is a page Google may never discover.
-	// On 2026-07-28 a URL Inspection sweep found /datos/ and /pregunta/ at
-	// "Google no reconoce esta URL": not rejected, simply never offered.
-	//
-	// Deliberately absent:
-	//   /cambios/para-mi/  personalised client-side; renders empty without the
-	//                      visitor's own filters, so indexing it means thin content
-	//   /alertas/{gestionar,confirmar,cancelar,seguir/confirmar}
-	//                      transactional, reached with a one-time token
-	//   /cambios/reforma/  the bare shell carries noindex; real reform URLs live
-	//                      in sitemap-reformas.xml
-	const secondaryPages = [
-		{ path: "/cambios/", changefreq: "daily", priority: "0.6" },
-		{ path: "/cambios/recientes/", changefreq: "daily", priority: "0.7" },
-		// The clearest thing this site does that boe.es does not: answer a
-		// question in plain language. It was invisible to Google until now.
-		{ path: "/pregunta/", changefreq: "weekly", priority: "0.8" },
-		{ path: "/datos/", changefreq: "weekly", priority: "0.6" },
-		{ path: "/sobre/", changefreq: "monthly", priority: "0.5" },
-		{ path: "/sobre/contribuir/", changefreq: "monthly", priority: "0.4" },
-		{ path: "/sobre/apoyar/", changefreq: "monthly", priority: "0.4" },
-		{ path: "/sobre/api/", changefreq: "monthly", priority: "0.4" },
-		{ path: "/alertas/", changefreq: "monthly", priority: "0.5" },
-		{ path: "/mi-situacion/", changefreq: "monthly", priority: "0.5" },
-		{ path: "/privacidad/", changefreq: "yearly", priority: "0.2" },
-		{ path: "/cookies/", changefreq: "yearly", priority: "0.2" },
-		{ path: "/aviso-legal/", changefreq: "yearly", priority: "0.2" },
-	];
-
 	const urls = [
 		`  <url>
     <loc>${SITE_URL}/</loc>
     <changefreq>daily</changefreq>
     <priority>1.0</priority>
   </url>`,
-		...secondaryPages.map(
+		...SECONDARY_PAGES.map(
 			(p) => `  <url>
     <loc>${SITE_URL}${p.path}</loc>
     <changefreq>${p.changefreq}</changefreq>

--- a/packages/web/src/pages/sitemap-leyes.xml.ts
+++ b/packages/web/src/pages/sitemap-leyes.xml.ts
@@ -14,8 +14,25 @@ const SITE_URL = "https://leyabierta.es";
 export const GET: APIRoute = async () => {
 	const laws = await getCollection("laws");
 
+	// Every indexable page that isn't a law or a reform. Keep in sync with
+	// src/pages/ — a page missing here is a page Google may never discover.
+	// On 2026-07-28 a URL Inspection sweep found /datos/ and /pregunta/ at
+	// "Google no reconoce esta URL": not rejected, simply never offered.
+	//
+	// Deliberately absent:
+	//   /cambios/para-mi/  personalised client-side; renders empty without the
+	//                      visitor's own filters, so indexing it means thin content
+	//   /alertas/{gestionar,confirmar,cancelar,seguir/confirmar}
+	//                      transactional, reached with a one-time token
+	//   /cambios/reforma/  the bare shell carries noindex; real reform URLs live
+	//                      in sitemap-reformas.xml
 	const secondaryPages = [
 		{ path: "/cambios/", changefreq: "daily", priority: "0.6" },
+		{ path: "/cambios/recientes/", changefreq: "daily", priority: "0.7" },
+		// The clearest thing this site does that boe.es does not: answer a
+		// question in plain language. It was invisible to Google until now.
+		{ path: "/pregunta/", changefreq: "weekly", priority: "0.8" },
+		{ path: "/datos/", changefreq: "weekly", priority: "0.6" },
 		{ path: "/sobre/", changefreq: "monthly", priority: "0.5" },
 		{ path: "/sobre/contribuir/", changefreq: "monthly", priority: "0.4" },
 		{ path: "/sobre/apoyar/", changefreq: "monthly", priority: "0.4" },

--- a/scripts/seo/README.md
+++ b/scripts/seo/README.md
@@ -3,7 +3,8 @@
 An autonomous, biweekly loop that grows organic traffic to leyabierta.es from
 real Google Search Console + Umami data. It proposes changes, has `claude -p`
 implement them, verifies the build, and **opens a PR** — it never deploys on its
-own. Governance lives in [`.goals/seo/`](../../.goals/seo/).
+own. Governance lives in [`.goals/seo/`](../../.goals/seo/); current numbers and
+running experiments in [`.goals/seo/STATUS.md`](../../.goals/seo/STATUS.md).
 
 ```
 inspect-urls.ts ─► index-coverage.json ─┐


### PR DESCRIPTION
## El problema

Un barrido con la URL Inspection API encontró estas páginas en **«Google no reconoce esta URL»**:

| Página | Estado |
|---|---|
| `/datos/` | ❌ Google no la conoce |
| `/pregunta/` | ❌ Google no la conoce |

No están rechazadas ni penalizadas: **nunca se las hemos ofrecido**. No estaban en ningún sitemap. `/cambios/recientes/` tampoco; se indexó solo porque los enlaces internos llevaron a Google hasta ella.

`/pregunta/` es lo que más nos diferencia del BOE — responde en lenguaje llano, que es justo lo que boe.es no hace — y era invisible para Google.

## El cambio

Las tres al sitemap. Y como el modo de fallo es que **una página puede existir, funcionar y ser indexable mientras nadie se lo dice a ningún crawler, sin que nada dé error**, el arreglo viene con un test.

`sitemap-coverage.test.ts` recorre `src/pages/` y exige que toda ruta estática esté en el sitemap **o** en una lista de exclusión con su motivo:

- `/cambios/para-mi/` — personalizada client-side, sin los filtros del visitante renderiza vacío
- `/alertas/{gestionar,confirmar,cancelar,seguir/confirmar}` — transaccionales, con token de un solo uso
- `/cambios/reforma/` — el shell lleva `noindex`; las URLs reales están en `sitemap-reformas.xml`

El test también falla si una exclusión nombra una página que ya no existe, para que la lista no se convierta en ficción con el tiempo.

## Documentación

Nuevo `.goals/seo/STATUS.md`, junto a `GOAL.md` y `PLAYBOOK.md`:

- **Baseline medido**, no estimado: leyes 99,1% rastreadas / 13,2% indexadas; reformas 0% / 0%
- **Los dos problemas son distintos** y confundirlos lleva a arreglar lo que no es: las reformas no se rastrean; las leyes se rastrean y no se indexan
- **Experimento A** (forma de URL) con fecha de lectura (2026-08-18) y criterios prefijados
- **Experimento B** (este PR)
- **Lo que sigue abierto**: diferenciación de las 12k leyes, rich results, autoridad de dominio

Enlazado desde `GOAL.md` y el README de scripts, con un aviso arriba: quien vaya a tocar el sitemap, el Worker o las URLs de reforma debe saber que hay un experimento vivo antes de cambiar nada.

## Nota de alcance

Esto **no** arregla el 13,2% de indexación de las leyes. Ese es un problema de valor percibido frente al BOE y necesita diferenciación de contenido, no ajustes técnicos. Aquí solo se corrige una omisión: páginas que nunca llegaron a ofrecerse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)