### PR TITLE
CI: ejecutar los tests como gate en PRs y despliegues

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -130,8 +130,13 @@ jobs:
       - name: Lint
         run: bun run check
 
+      # No `|| true`. It was added because boe-mapping.test.ts threw when the
+      # gitignored 24 GB leyabierta.db was absent; that test now skips cleanly
+      # instead, so a failure here is a real failure and must stop the deploy.
+      # main auto-propagates to production — swallowing test results meant
+      # nothing verified the code that ships.
       - name: Test
-        run: bun test || true # Some tests require data files not in CI
+        run: bun test
 
   # ============================================
   # API: Build Docker image, push to GHCR,

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -43,7 +43,7 @@ concurrency:
 
 jobs:
   check:
-    name: Lint
+    name: Lint & test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -57,9 +57,13 @@ jobs:
       - name: Biome
         run: bun run check
 
-      # Tests are not run as a gate yet: see #81 (git-repo.test.ts has
-      # 2 preexisting failures around idempotency and TZ-stability).
-      # Re-enable once #81 is fixed.
+      # Gate since 2026-07-28. Was disabled for #81 (git-repo.test.ts idempotency
+      # + TZ-stability), which is closed, and for boe-mapping.test.ts throwing
+      # when the gitignored leyabierta.db is absent, which now skips cleanly.
+      # Nothing in CI validated behaviour before this — Biome doesn't run tests
+      # and deploy.yml swallowed them with `|| true`.
+      - name: Test
+        run: bun test
 
   build-and-smoke:
     name: Build web & smoke

--- a/packages/eval/test/boe-mapping.test.ts
+++ b/packages/eval/test/boe-mapping.test.ts
@@ -5,15 +5,23 @@
 
 import { Database } from "bun:sqlite";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { mapCitation, mapCitations } from "../src/boe-mapping.ts";
 
 const DB_PATH = join(import.meta.dir, "../../../data/leyabierta.db");
 
+// These tests query the real leyabierta.db (24 GB, gitignored — present on the
+// server and in a full local checkout, absent in fresh worktrees/CI). Skip
+// cleanly when it isn't there rather than throwing in beforeAll, which would
+// fail the whole suite (and block the pre-push hook) for an environmental
+// reason unrelated to the code under test.
+const DB_AVAILABLE = existsSync(DB_PATH);
+
 let db: Database;
 
 beforeAll(() => {
-	db = new Database(DB_PATH, { readonly: true });
+	if (DB_AVAILABLE) db = new Database(DB_PATH, { readonly: true });
 });
 
 afterAll(() => {
@@ -186,7 +194,7 @@ const cases: Array<[string, string, string | null, string]> = [
 	],
 ];
 
-describe("mapCitation", () => {
+describe.skipIf(!DB_AVAILABLE)("mapCitation", () => {
 	for (const [desc, raw, expectedId, expectedConf] of cases) {
 		test(desc, () => {
 			const result = mapCitation(raw, opts());
@@ -208,7 +216,7 @@ describe("mapCitation", () => {
 	}
 });
 
-describe("mapCitations", () => {
+describe.skipIf(!DB_AVAILABLE)("mapCitations", () => {
 	test("processes array of citations", () => {
 		const results = mapCitations(
 			["Ley 37/1992", "CE", "Ley Orgánica 4/2000"],


### PR DESCRIPTION
## El problema

**Nada en CI validaba comportamiento.** `pr-checks.yml` ejecutaba solo Biome, y `deploy.yml` ejecutaba `bun test || true`. Un test que fallara no bloqueaba ni el merge ni el despliegue — y `main` se propaga automáticamente a producción.

Todos los tests del repo eran decorativos desde el punto de vista del CI. Incluidos los 26 del experimento de URLs que acabamos de desplegar.

Salió a la luz revisando el PR #145: documenté que un test "obliga" a que cierto fallo no se repita, y resultó que no obligaba nada.

## Los dos motivos ya no existen

**`pr-checks.yml`** apuntaba al issue **#81** (`git-repo.test.ts`, idempotencia y estabilidad de zona horaria). **#81 está cerrado** y esos tests pasan.

**`deploy.yml`** llevaba `|| true` por `boe-mapping.test.ts`, que abría la `leyabierta.db` de 24 GB (gitignored) en `beforeAll` y lanzaba excepción donde no existe. El fix ya estaba en `staging`; lo he traído con cherry-pick (`083d2b0`). Ahora se salta limpiamente, que es justo lo que su propio comentario decía que hacía:

> *Uses the real leyabierta.db (read-only). If DB is absent the tests are skipped.*

## Verificado, no supuesto

No di por hecho qué fallaba. Fui al log del último `bun test` en CI (run del deploy de #144) y **de toda la suite, `boe-mapping` era el único fallo**. El resto pasaba o se saltaba con sus propias guardas:

```
1 tests failed:
(fail) (unnamed)   ← packages/eval/test/boe-mapping.test.ts:16
```

Los tests que dependen de datos pesados (índice vectorial int8, adaptadores de eval) ya se saltan solos cuando falta el fichero.

## Efecto

- Un test roto ahora **bloquea el merge** y **para el despliegue**.
- El coste es un job de ~30 s en cada PR.

Este PR es su propia prueba: si la suite no pasa en CI, no se mergea.

🤖 Generated with [Claude Code](https://claude.com/claude-code)