### PR TITLE
fix(rag): move embeddings off cancelled NaN to OpenRouter (query + corpus)

### DIFF
--- a/packages/api/src/scripts/embed-corpus.ts
+++ b/packages/api/src/scripts/embed-corpus.ts
@@ -1,5 +1,11 @@
 /**
- * Generate qwen3-nan embeddings for vigente norms via api.nan.builders.
+ * Generate qwen3-nan embeddings for vigente norms.
+ *
+ * The provider is whatever EMBEDDING_MODELS['qwen3-nan'] declares. NaN was
+ * cancelled on 2026-08-07, so the model now resolves to OpenRouter
+ * qwen/qwen3-embedding-8b — the identical Qwen3-Embedding-8B (4096d), so new
+ * vectors stay compatible with the existing NaN-generated store (verified
+ * cosine ≈ 0.9999 on same-format re-embeds).
  *
  * Default mode is incremental: scans the `embeddings` table for blocks that
  * already have a `qwen3-nan` row and embeds only the missing ones. Safe to
@@ -11,8 +17,7 @@
  *   bun run packages/api/src/scripts/embed-corpus.ts --limit 50          # cap chunks
  *   bun run packages/api/src/scripts/embed-corpus.ts --norm-ids ID1,ID2  # specific norms
  *
- * Auth: reads NAN_API_KEY, falls back to HERMES_API_KEY (transitional naming
- * during the OpenRouter → NaN migration; the runtime still uses HERMES_API_KEY).
+ * Auth: OPENROUTER_API_KEY (openrouter provider) or NAN_API_KEY (nan provider).
  */
 
 import { Database } from "bun:sqlite";
@@ -36,10 +41,20 @@ if (!model) throw new Error(`Unknown model key: ${MODEL_KEY}`);
 const modelId = model.id;
 const modelDimensions = model.dimensions;
 
-const NAN_URL = "https://api.nan.builders/v1/embeddings";
-const apiKey = process.env.NAN_API_KEY ?? process.env.HERMES_API_KEY;
+// Route by the model's declared provider so this batch path follows the same
+// migration as the runtime query path (embeddings.ts). openrouter reads
+// OPENROUTER_API_KEY; nan reads NAN_API_KEY.
+const isOpenRouter = model.provider === "openrouter";
+const EMBEDDINGS_URL = isOpenRouter
+	? "https://openrouter.ai/api/v1/embeddings"
+	: "https://api.nan.builders/v1/embeddings";
+const apiKey = isOpenRouter
+	? process.env.OPENROUTER_API_KEY
+	: (process.env.NAN_API_KEY ?? process.env.HERMES_API_KEY);
 if (!apiKey && !dryRun) {
-	console.error("NAN_API_KEY or HERMES_API_KEY required");
+	console.error(
+		`${isOpenRouter ? "OPENROUTER_API_KEY" : "NAN_API_KEY"} required`,
+	);
 	process.exit(1);
 }
 
@@ -133,7 +148,7 @@ if (dryRun) {
 	const totalChars = workBlocks.reduce((s, b) => s + b.text.length, 0);
 	const estTokens = Math.round(totalChars / 4);
 	console.log(
-		`\n[dry-run] Would embed ${workBlocks.length} chunks (~${estTokens.toLocaleString()} tokens, $0 via NaN)`,
+		`\n[dry-run] Would embed ${workBlocks.length} chunks (~${estTokens.toLocaleString()} tokens via ${model.provider ?? "nan"})`,
 	);
 	console.log(`Sample chunk:\n${workBlocks[0]?.text.slice(0, 300)}...`);
 	process.exit(0);
@@ -164,7 +179,7 @@ async function nanEmbed(texts: string[]): Promise<{
 		}
 		const reqStart = Date.now();
 		try {
-			const res = await fetch(NAN_URL, {
+			const res = await fetch(EMBEDDINGS_URL, {
 				method: "POST",
 				headers: {
 					Authorization: `Bearer ${apiKey}`,

--- a/packages/api/src/services/rag/embeddings.ts
+++ b/packages/api/src/services/rag/embeddings.ts
@@ -22,10 +22,23 @@ export interface EmbeddingModel {
 }
 
 export const EMBEDDING_MODELS: Record<string, EmbeddingModel> = {
+	/**
+	 * Prod default. The key name is HISTORICAL: the 493K corpus vectors were
+	 * first generated via NaN (api.nan.builders) under the label "qwen3-nan", and
+	 * both the SQLite `embeddings.model` column and the exported vectors.bin are
+	 * keyed by that string. Do NOT rename this key without relabeling the store —
+	 * pipeline.ts loads the vector index by EMBEDDING_MODEL_KEY.
+	 *
+	 * The MODEL is Qwen3-Embedding-8B (4096 dims, Apache 2.0). NaN was cancelled
+	 * on 2026-08-07, so the query embedding now comes from OpenRouter, which
+	 * serves the identical weights as `qwen/qwen3-embedding-8b` at the same 4096
+	 * dims. Same model → the OpenRouter query vectors are cross-compatible with
+	 * the NaN-generated store; no re-embed or vectors.bin rebuild is needed.
+	 */
 	"qwen3-nan": {
-		id: "qwen3-embedding",
+		id: "qwen/qwen3-embedding-8b",
 		dimensions: 4096,
-		provider: "nan",
+		provider: "openrouter",
 	},
 	/**
 	 * Gemini Embedding 2 — re-added as opt-in for A/B evaluation only.
@@ -102,9 +115,14 @@ export async function fetchWithRetry(
 		);
 	}
 
-	// OpenRouter path: uses the caller-provided apiKey directly (OPENROUTER_API_KEY).
+	// OpenRouter path: prefer OPENROUTER_API_KEY from the env so callers don't
+	// have to thread it (mirrors the NaN path's getNanApiKey() below). Prod's
+	// /v1/ask path already passes OPENROUTER_API_KEY here, but other callers
+	// (scripts, eval, the retrieval override signature) may thread a different or
+	// legacy key; reading the env prevents sending the wrong bearer to OpenRouter.
 	if (provider === "openrouter") {
-		if (!apiKey) {
+		const orKey = process.env.OPENROUTER_API_KEY ?? apiKey;
+		if (!orKey) {
 			throw new Error(
 				"OPENROUTER_API_KEY required for openrouter embedding provider",
 			);
@@ -117,7 +135,7 @@ export async function fetchWithRetry(
 				response = await fetch(OPENROUTER_EMBEDDINGS_URL, {
 					method: "POST",
 					headers: {
-						Authorization: `Bearer ${apiKey}`,
+						Authorization: `Bearer ${orKey}`,
 						"Content-Type": "application/json",
 						"HTTP-Referer": "https://leyabierta.es",
 						"X-Title": "Ley Abierta RAG (A/B eval)",

--- a/packages/api/src/services/rag/retrieval.ts
+++ b/packages/api/src/services/rag/retrieval.ts
@@ -622,12 +622,25 @@ export async function runRetrievalCore(
 	// 1. Analyze + embed query in parallel.
 	const analysisSpan = trace?.span("query-analysis", "llm", { question });
 	const analyzerApiKey = analyzerOverrides?.apiKey ?? apiKey;
+	// The query embedding must not take down the whole answer: if the embedding
+	// provider fails (expired key, outage), degrade to BM25-only retrieval rather
+	// than 500. `embedding: null` disables the vector leg below; BM25 still runs.
 	const [analysisResult, queryResult] = await Promise.all([
 		analyzeQuery(analyzerApiKey, question, {
 			model: analyzerOverrides?.model,
 			llmFn: analyzerOverrides?.llmFn,
 		}),
-		embedQueryFn(apiKey, embeddingModelKey, question),
+		embedQueryFn(apiKey, embeddingModelKey, question).catch(
+			(
+				err,
+			): { embedding: Float32Array | null; cost: number; tokens: number } => {
+				console.error(
+					"[rag] query embedding failed — degrading to BM25-only:",
+					err instanceof Error ? err.message : err,
+				);
+				return { embedding: null, cost: 0, tokens: 0 };
+			},
+		),
 	]);
 	const analyzed = analysisResult.query;
 	if (requestJurisdiction && !analyzed.jurisdiction) {
@@ -687,7 +700,7 @@ export async function runRetrievalCore(
 	const vectorSpan = trace?.span("vector-search", "tool", {
 		poolSize: RERANK_POOL_SIZE,
 		minSimilarity: MIN_SIMILARITY,
-		embeddingDims: queryResult.embedding.length,
+		embeddingDims: queryResult.embedding?.length ?? 0,
 	});
 
 	try {
@@ -725,7 +738,7 @@ export async function runRetrievalCore(
 			);
 			return r;
 		}),
-		(vectorIndex
+		(vectorIndex && queryResult.embedding
 			? vectorSearchPooled(
 					queryResult.embedding,
 					vectorIndex.meta,
@@ -996,7 +1009,14 @@ export async function runRetrievalCore(
 		};
 	}
 
-	if (bestScore < lowConfidenceThreshold) {
+	// The low-confidence gate only makes sense when the vector leg actually ran:
+	// bestScore is derived purely from vectorResults. If the query embedding was
+	// unavailable (provider failure → BM25-only degradation above) or the vector
+	// index is absent (circuit breaker open), bestScore is a meaningless 0 and
+	// this gate would falsely decline a perfectly good BM25 answer as
+	// "low_confidence". Skip it and return the BM25 articles we already have.
+	const vectorLegRan = !!vectorIndex && !!queryResult.embedding;
+	if (vectorLegRan && bestScore < lowConfidenceThreshold) {
 		return {
 			type: "early",
 			reason: "low_confidence",

--- a/packages/eval/test/rag-gemini-legacy.test.ts
+++ b/packages/eval/test/rag-gemini-legacy.test.ts
@@ -117,13 +117,18 @@ describe("EMBEDDING_MODELS gemini-embedding-2", () => {
 		expect(model!.provider).toBe("openrouter");
 	});
 
-	test("qwen3-nan is unchanged (prod default not affected)", async () => {
+	test("qwen3-nan prod default: Qwen3-Embedding-8B via OpenRouter, 4096 dims", async () => {
+		// NaN was cancelled on 2026-08-07; the prod query embedding moved to
+		// OpenRouter's qwen/qwen3-embedding-8b — the SAME model at the SAME 4096
+		// dims, so the existing NaN-generated store stays compatible. The key is
+		// kept ('qwen3-nan') because it labels the DB/vectors.bin store.
 		const { EMBEDDING_MODELS } = await import(
 			"../../api/src/services/rag/embeddings.ts"
 		);
 		const model = EMBEDDING_MODELS["qwen3-nan"];
 		expect(model).toBeDefined();
 		expect(model!.dimensions).toBe(4096);
-		expect(model!.provider).toBe("nan");
+		expect(model!.provider).toBe("openrouter");
+		expect(model!.id).toBe("qwen/qwen3-embedding-8b");
 	});
 });


### PR DESCRIPTION
## Qué

NaN (`api.nan.builders`) fue cancelado; su key devuelve **401**. En prod NaN solo servía **embeddings** (`qwen3-embedding`, 4096d) — analyzer/synthesis y rerank ya iban por OpenRouter/Cohere. Rompió dos cosas:
- **`/v1/ask` (`/pregunta/`) caída**: el embedding de consulta lanzaba dentro de un `Promise.all` sin guardar → 500.
- **Pipeline diario Step 3b (`embed-corpus.ts`)**: las normas nuevas dejaron de vectorizarse → leyes recién ingestadas quedaban solo en BM25, no en búsqueda vectorial.

## Cambios

1. **Repunte a OpenRouter** (`embeddings.ts`): `EMBEDDING_MODELS['qwen3-nan']` → `qwen/qwen3-embedding-8b`. **Mismo modelo** (Qwen3-Embedding-8B, 4096d), vectores cross-compatibles con la tienda ya generada por NaN: sin re-embed, sin reconstruir `vectors.bin`. Se mantiene la key `qwen3-nan` (etiqueta de la DB/store). Test actualizado.
2. **Key correcta** (`embeddings.ts`): el path `openrouter` de `fetchWithRetry` lee `OPENROUTER_API_KEY` del entorno.
3. **`embed-corpus.ts` provider-aware**: enruta por `model.provider` (URL de OpenRouter + `OPENROUTER_API_KEY`), así el embedding incremental diario de normas nuevas vuelve a funcionar.
4. **Degradación** (`retrieval.ts`): si el embedding de consulta no está disponible → BM25-only en vez de 500. Y **skip del gate `low_confidence`** cuando el leg vectorial no corrió (bestScore es solo-vectorial; un 0 declinaba en falso una respuesta BM25 válida).

## Verificación
- **Compatibilidad probada sobre datos de prod**: re-embeder artículos almacenados vía OpenRouter, en el formato exacto del corpus, da **coseno 0.9999** vs los vectores de NaN. Es el mismo modelo. (Smoke test que recomendó la revisión con grok.)
- `qwen/qwen3-embedding-8b` en OpenRouter → 4096 dims, coste ~$1e-8/token.
- tsgo + biome limpios; **suite completa verde** (pre-push hook, 862 tests).
- **Revisión adversarial con grok**: encontró el bug del gate `low_confidence` (punto 4), corregido.

## Seguimiento (no bloquea)
- `hybrid-search` (`/v1/laws`) usa el mismo `embedQuery` ya reparado, pero sin el catch de degradación → seguiría 500 si OpenRouter cae. Menor.
- Otros scripts de research (`backfill-citizen-summaries`, `compare-citizen-models`, `ab-thinking-on-off`) siguen con `HERMES_BASE_URL` = NaN. No se usan en runtime; repuntar si se reactivan.

## Deploy
Solo requiere que `code-api-1` tenga `OPENROUTER_API_KEY` (ya lo tiene) y redeploy. Sin migración de datos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)