### PR TITLE
feat(seo): hubs temáticas fiscalidad + empleo (consolida #116/#147)

### DIFF
--- a/packages/web/src/lib/site-pages.ts
+++ b/packages/web/src/lib/site-pages.ts
@@ -27,6 +27,11 @@ export interface SitemapEntry {
 export const SECONDARY_PAGES: SitemapEntry[] = [
 	{ path: "/cambios/", changefreq: "daily", priority: "0.6" },
 	{ path: "/cambios/recientes/", changefreq: "daily", priority: "0.7" },
+	// Topic hubs: new indexable pages that link into the corpus and target
+	// rising queries (fiscalidad/IVA, empleo). Register here or they repeat the
+	// /datos/ + /pregunta/ invisibility this list exists to prevent.
+	{ path: "/temas/fiscalidad/", changefreq: "weekly", priority: "0.7" },
+	{ path: "/temas/empleo/", changefreq: "weekly", priority: "0.7" },
 	// The clearest thing this site does that boe.es does not: answer a question
 	// in plain language. It was invisible to Google until 2026-07-28.
 	{ path: "/pregunta/", changefreq: "weekly", priority: "0.8" },

--- a/packages/web/src/pages/temas/empleo/index.astro
+++ b/packages/web/src/pages/temas/empleo/index.astro
@@ -1,0 +1,188 @@
+---
+import { getCollection } from "astro:content";
+import Base from "../../../layouts/Base.astro";
+import { safeJsonLd } from "../../../lib/escape";
+
+// ── Hub page: legislación laboral y de empleo ──────────────────────────────
+// Groups the main Spanish labour/employment laws into a single topical entity
+// so Google understands the "legislación laboral" cluster and to strengthen
+// internal linking towards the individual norm pages. Targets the rising query
+// "ley de empleo" (which currently lands on the home page, pos ~72).
+//
+// This is a *curated* hub, not a programmatic dump: each entry is a well-known
+// labour law referenced by its BOE id and rendered only if it actually exists
+// in the corpus, always using the real title from its frontmatter (never a
+// hardcoded/invented one). Any id not present in `getCollection("laws")` is
+// silently dropped, so we never emit a broken link or a made-up title. We
+// deliberately avoid a broad keyword filter over `materias`/titles because it
+// floods the list with low-quality matches (spam-like) and drops flagship
+// norms that carry no `materias`.
+
+const laws = await getCollection("laws");
+
+// Dedup by identificador (data-integrity invariant: one norm, one entry).
+const byId = new Map<string, (typeof laws)[number]["data"]>();
+for (const e of laws) {
+	if (!byId.has(e.data.identificador)) byId.set(e.data.identificador, e.data);
+}
+
+// Curated groups of major Spanish labour and employment legislation. Order
+// within each group is intentional (most-consulted first).
+const GROUPS: { heading: string; ids: string[] }[] = [
+	{
+		heading: "Normas laborales fundamentales",
+		ids: [
+			"BOE-A-2015-11430", // RDLeg 2/2015 — Estatuto de los Trabajadores
+			"BOE-A-2023-5365", //  Ley 3/2023 — de Empleo
+			"BOE-A-2007-13409", // Ley 20/2007 — Estatuto del trabajo autónomo
+			"BOE-A-1985-16660", // LO 11/1985 — Libertad sindical
+		],
+	},
+	{
+		heading: "Seguridad Social y empleo público",
+		ids: [
+			"BOE-A-2015-11724", // RDLeg 8/2015 — Ley General de la Seguridad Social
+			"BOE-A-2015-11719", // RDLeg 5/2015 — Estatuto Básico del Empleado Público
+		],
+	},
+	{
+		heading: "Prevención, sanciones y jurisdicción",
+		ids: [
+			"BOE-A-1995-24292", // Ley 31/1995 — Prevención de riesgos laborales
+			"BOE-A-2000-15060", // RDLeg 5/2000 — Infracciones y sanciones en el orden social
+			"BOE-A-2011-15936", // Ley 36/2011 — Jurisdicción social
+		],
+	},
+];
+
+// Resolve each curated id against the corpus; drop any that isn't present so we
+// never emit a broken link or a made-up title.
+const resolvedGroups = GROUPS.map((g) => ({
+	heading: g.heading,
+	items: g.ids.map((id) => byId.get(id)).filter((d): d is NonNullable<typeof d> => !!d),
+})).filter((g) => g.items.length > 0);
+
+const totalLaboral = resolvedGroups.reduce((n, g) => n + g.items.length, 0);
+
+const MONTHS = ['enero','febrero','marzo','abril','mayo','junio','julio','agosto','septiembre','octubre','noviembre','diciembre'];
+function formatDate(iso: string): string {
+	if (!iso || !/^\d{4}-\d{2}-\d{2}$/.test(iso)) return '';
+	const [y, m, d] = iso.split('-');
+	return `${parseInt(d!, 10)} de ${MONTHS[parseInt(m!, 10) - 1]} de ${y}`;
+}
+---
+
+<Base
+	title="Legislación laboral y de empleo en España"
+	description={`Las principales leyes laborales y de empleo en España consolidadas: el Estatuto de los Trabajadores, la Ley de Empleo, la Seguridad Social y la prevención de riesgos, con su texto completo y su historial de cambios.`}
+	ogTitle="Legislación laboral y de empleo en España"
+	canonicalUrl="/temas/empleo/"
+>
+	<script type="application/ld+json" set:html={safeJsonLd({
+		"@context": "https://schema.org",
+		"@type": "BreadcrumbList",
+		"itemListElement": [
+			{ "@type": "ListItem", "position": 1, "name": "Inicio", "item": "https://leyabierta.es/" },
+			{ "@type": "ListItem", "position": 2, "name": "Legislación laboral y de empleo", "item": "https://leyabierta.es/temas/empleo/" }
+		]
+	})} />
+
+	<style>
+		.tema-wrap { max-width: 680px; margin: 0 auto; padding: 40px 24px 64px; }
+		.tema-kicker {
+			font-family: var(--font-mono);
+			font-size: 11px;
+			text-transform: uppercase;
+			letter-spacing: 2.4px;
+			color: var(--text-muted);
+			margin-bottom: 12px;
+			font-weight: 500;
+		}
+		.tema-wrap h1 {
+			font-family: var(--font-serif);
+			font-size: 36px;
+			font-weight: 700;
+			line-height: 1.15;
+			color: var(--text);
+			margin: 0 0 6px;
+			letter-spacing: -0.4px;
+		}
+		@media (max-width: 640px) { .tema-wrap h1 { font-size: 28px; } }
+		.tema-subtitle {
+			font-size: 16px;
+			color: var(--text-muted);
+			margin-bottom: 32px;
+			line-height: 1.55;
+		}
+		.tema-wrap h2 {
+			font-family: var(--font-serif);
+			font-size: 19px;
+			font-weight: 600;
+			color: var(--text);
+			margin: 36px 0 14px;
+			padding-bottom: 8px;
+			border-bottom: 1px solid var(--border-light);
+		}
+		.tema-wrap p { font-size: 15px; line-height: 1.7; color: var(--text-secondary); margin: 0 0 14px; }
+
+		.tema-list { list-style: none; padding: 0; margin: 0; }
+		.tema-list li { padding: 14px 0; border-bottom: 1px solid var(--border-light); }
+		.tema-list a { font-family: var(--font-serif); font-size: 16px; font-weight: 600; color: var(--text); }
+		.tema-list a:hover { color: var(--accent); text-decoration: none; }
+		.tema-meta { font-size: 13px; color: var(--text-muted); margin-top: 3px; }
+		.tema-id { font-family: var(--font-mono); font-size: 11px; }
+
+		.tema-note { font-size: 13px; color: var(--text-muted); font-style: italic; margin-top: 28px; }
+		.tema-empty { font-size: 15px; color: var(--text-muted); }
+	</style>
+
+	<div class="tema-wrap prose">
+		<div class="tema-kicker">TEMA · TRABAJO Y EMPLEO</div>
+		<h1>Legislación laboral y de empleo en España</h1>
+		<p class="tema-subtitle">
+			Las leyes que regulan el trabajo y el empleo en España, reunidas en un solo
+			lugar: el Estatuto de los Trabajadores, la Ley de Empleo, la Seguridad
+			Social, la prevención de riesgos y el empleo público.
+		</p>
+
+		<p>
+			El marco laboral español se articula en torno a un conjunto de leyes que
+			definen los derechos y deberes de trabajadores y empresas: qué es un
+			contrato, cómo funciona un despido, qué protección da la Seguridad Social o
+			cómo se previenen los riesgos en el trabajo. Aquí reunimos las principales
+			normas laborales consolidadas, con su texto completo y su historial de
+			cambios enlazado. Todos los textos proceden del
+			<a href="https://www.boe.es" target="_blank" rel="noopener">BOE</a> y se
+			actualizan cada día.
+		</p>
+
+		{resolvedGroups.map((g) => (
+			<>
+				<h2>{g.heading}</h2>
+				<ul class="tema-list">
+					{g.items.map((d) => (
+						<li>
+							<a href={`/leyes/${d.identificador}/`}>{d.titulo}</a>
+							<div class="tema-meta">
+								{formatDate(d.fecha_publicacion)}
+								{d.ultima_actualizacion && d.ultima_actualizacion !== d.fecha_publicacion && (
+									<> · actualizada el {formatDate(d.ultima_actualizacion)}</>
+								)}
+								{' '}· <span class="tema-id">{d.identificador}</span>
+							</div>
+						</li>
+					))}
+				</ul>
+			</>
+		))}
+
+		{totalLaboral === 0 && (
+			<p class="tema-empty">Aún no hay normas laborales indexadas en esta sección.</p>
+		)}
+
+		<p class="tema-note">
+			Ley Abierta informa, no asesora. Ante una duda laboral concreta, consulta el
+			texto oficial en el BOE o a un profesional.
+		</p>
+	</div>
+</Base>

--- a/packages/web/src/pages/temas/empleo/index.astro
+++ b/packages/web/src/pages/temas/empleo/index.astro
@@ -30,7 +30,7 @@ for (const e of laws) {
 // within each group is intentional (most-consulted first).
 const GROUPS: { heading: string; ids: string[] }[] = [
 	{
-		heading: "Normas laborales fundamentales",
+		heading: "Leyes laborales fundamentales",
 		ids: [
 			"BOE-A-2015-11430", // RDLeg 2/2015 — Estatuto de los Trabajadores
 			"BOE-A-2023-5365", //  Ley 3/2023 — de Empleo
@@ -150,7 +150,7 @@ function formatDate(iso: string): string {
 			definen los derechos y deberes de trabajadores y empresas: qué es un
 			contrato, cómo funciona un despido, qué protección da la Seguridad Social o
 			cómo se previenen los riesgos en el trabajo. Aquí reunimos las principales
-			normas laborales consolidadas, con su texto completo y su historial de
+			leyes laborales consolidadas, con su texto completo y su historial de
 			cambios enlazado. Todos los textos proceden del
 			<a href="https://www.boe.es" target="_blank" rel="noopener">BOE</a> y se
 			actualizan cada día.
@@ -177,7 +177,7 @@ function formatDate(iso: string): string {
 		))}
 
 		{totalLaboral === 0 && (
-			<p class="tema-empty">Aún no hay normas laborales indexadas en esta sección.</p>
+			<p class="tema-empty">Aún no hay leyes laborales indexadas en esta sección.</p>
 		)}
 
 		<p class="tema-note">

--- a/packages/web/src/pages/temas/fiscalidad/index.astro
+++ b/packages/web/src/pages/temas/fiscalidad/index.astro
@@ -1,0 +1,184 @@
+---
+import { getCollection } from "astro:content";
+import Base from "../../../layouts/Base.astro";
+import { safeJsonLd } from "../../../lib/escape";
+
+// ── Hub page: legislación fiscal ──────────────────────────────────────────
+// Groups the main Spanish tax laws into a single topical entity so Google
+// understands the "legislación fiscal" cluster and to strengthen internal
+// linking towards the individual norm pages.
+//
+// This is a *curated* hub, not a programmatic dump: each entry is a well-known
+// tax law referenced by its BOE id and rendered only if it actually exists in
+// the corpus, always using the real title from its frontmatter (never a
+// hardcoded/invented one). We deliberately avoid a broad keyword filter over
+// `materias`/titles because that floods the list with hundreds of
+// double-taxation treaties (low-quality, spam-like) and because some flagship
+// norms (e.g. the IVA law) carry no `materias` at all — a keyword filter would
+// drop exactly the laws citizens search for.
+
+const laws = await getCollection("laws");
+
+// Dedup by identificador (data-integrity invariant: one norm, one entry).
+const byId = new Map<string, (typeof laws)[number]["data"]>();
+for (const e of laws) {
+	if (!byId.has(e.data.identificador)) byId.set(e.data.identificador, e.data);
+}
+
+// Curated groups of major Spanish tax legislation. Order within each group is
+// intentional (most-consulted first).
+const GROUPS: { heading: string; ids: string[] }[] = [
+	{
+		heading: "Impuestos principales",
+		ids: [
+			"BOE-A-1992-28740", // Ley 37/1992 — IVA
+			"BOE-A-2006-20764", // Ley 35/2006 — IRPF
+			"BOE-A-2014-12328", // Ley 27/2014 — Impuesto sobre Sociedades
+			"BOE-A-1992-28741", // Ley 38/1992 — Impuestos Especiales
+		],
+	},
+	{
+		heading: "Otros impuestos",
+		ids: [
+			"BOE-A-2004-4527", // RDLeg 5/2004 — IRNR
+			"BOE-A-1991-14392", // Ley 19/1991 — Patrimonio
+			"BOE-A-1987-28141", // Ley 29/1987 — Sucesiones y Donaciones
+			"BOE-A-1993-25359", // RDLeg 1/1993 — ITP y AJD
+		],
+	},
+	{
+		heading: "Marco tributario general",
+		ids: [
+			"BOE-A-2003-23186", // Ley 58/2003 — General Tributaria
+		],
+	},
+];
+
+// Resolve each curated id against the corpus; drop any that isn't present so we
+// never emit a broken link or a made-up title.
+const resolvedGroups = GROUPS.map((g) => ({
+	heading: g.heading,
+	items: g.ids.map((id) => byId.get(id)).filter((d): d is NonNullable<typeof d> => !!d),
+})).filter((g) => g.items.length > 0);
+
+const totalFiscal = resolvedGroups.reduce((n, g) => n + g.items.length, 0);
+
+const MONTHS = ['enero','febrero','marzo','abril','mayo','junio','julio','agosto','septiembre','octubre','noviembre','diciembre'];
+function formatDate(iso: string): string {
+	if (!iso || !/^\d{4}-\d{2}-\d{2}$/.test(iso)) return '';
+	const [y, m, d] = iso.split('-');
+	return `${parseInt(d!, 10)} de ${MONTHS[parseInt(m!, 10) - 1]} de ${y}`;
+}
+---
+
+<Base
+	title="Legislación fiscal en España — leyes de impuestos"
+	description={`Las principales leyes fiscales españolas consolidadas: IVA, IRPF, impuestos especiales, sociedades y el marco tributario general, con su texto completo y su historial de cambios.`}
+	ogTitle="Legislación fiscal en España — IVA, IRPF e impuestos"
+	canonicalUrl="/temas/fiscalidad/"
+>
+	<script type="application/ld+json" set:html={safeJsonLd({
+		"@context": "https://schema.org",
+		"@type": "BreadcrumbList",
+		"itemListElement": [
+			{ "@type": "ListItem", "position": 1, "name": "Inicio", "item": "https://leyabierta.es/" },
+			{ "@type": "ListItem", "position": 2, "name": "Legislación fiscal", "item": "https://leyabierta.es/temas/fiscalidad/" }
+		]
+	})} />
+
+	<style>
+		.tema-wrap { max-width: 680px; margin: 0 auto; padding: 40px 24px 64px; }
+		.tema-kicker {
+			font-family: var(--font-mono);
+			font-size: 11px;
+			text-transform: uppercase;
+			letter-spacing: 2.4px;
+			color: var(--text-muted);
+			margin-bottom: 12px;
+			font-weight: 500;
+		}
+		.tema-wrap h1 {
+			font-family: var(--font-serif);
+			font-size: 36px;
+			font-weight: 700;
+			line-height: 1.15;
+			color: var(--text);
+			margin: 0 0 6px;
+			letter-spacing: -0.4px;
+		}
+		@media (max-width: 640px) { .tema-wrap h1 { font-size: 28px; } }
+		.tema-subtitle {
+			font-size: 16px;
+			color: var(--text-muted);
+			margin-bottom: 32px;
+			line-height: 1.55;
+		}
+		.tema-wrap h2 {
+			font-family: var(--font-serif);
+			font-size: 19px;
+			font-weight: 600;
+			color: var(--text);
+			margin: 36px 0 14px;
+			padding-bottom: 8px;
+			border-bottom: 1px solid var(--border-light);
+		}
+		.tema-wrap p { font-size: 15px; line-height: 1.7; color: var(--text-secondary); margin: 0 0 14px; }
+
+		.tema-list { list-style: none; padding: 0; margin: 0; }
+		.tema-list li { padding: 14px 0; border-bottom: 1px solid var(--border-light); }
+		.tema-list a { font-family: var(--font-serif); font-size: 16px; font-weight: 600; color: var(--text); }
+		.tema-list a:hover { color: var(--accent); text-decoration: none; }
+		.tema-meta { font-size: 13px; color: var(--text-muted); margin-top: 3px; }
+		.tema-id { font-family: var(--font-mono); font-size: 11px; }
+
+		.tema-note { font-size: 13px; color: var(--text-muted); font-style: italic; margin-top: 28px; }
+		.tema-empty { font-size: 15px; color: var(--text-muted); }
+	</style>
+
+	<div class="tema-wrap prose">
+		<div class="tema-kicker">TEMA · IMPUESTOS</div>
+		<h1>Legislación fiscal en España</h1>
+		<p class="tema-subtitle">
+			Las leyes que regulan los impuestos en España, reunidas en un solo lugar:
+			IVA, IRPF, impuestos especiales, sociedades y el marco tributario general.
+		</p>
+
+		<p>
+			El sistema tributario español se articula en torno a un conjunto de leyes
+			que definen qué impuestos existen, quién los paga y cómo se calculan. Aquí
+			reunimos las principales leyes fiscales consolidadas, con su texto completo
+			y su historial de cambios enlazado. Todos los textos proceden del
+			<a href="https://www.boe.es" target="_blank" rel="noopener">BOE</a> y se
+			actualizan cada día.
+		</p>
+
+		{resolvedGroups.map((g) => (
+			<>
+				<h2>{g.heading}</h2>
+				<ul class="tema-list">
+					{g.items.map((d) => (
+						<li>
+							<a href={`/leyes/${d.identificador}/`}>{d.titulo}</a>
+							<div class="tema-meta">
+								{formatDate(d.fecha_publicacion)}
+								{d.ultima_actualizacion && d.ultima_actualizacion !== d.fecha_publicacion && (
+									<> · actualizada el {formatDate(d.ultima_actualizacion)}</>
+								)}
+								{' '}· <span class="tema-id">{d.identificador}</span>
+							</div>
+						</li>
+					))}
+				</ul>
+			</>
+		))}
+
+		{totalFiscal === 0 && (
+			<p class="tema-empty">Aún no hay leyes fiscales indexadas en esta sección.</p>
+		)}
+
+		<p class="tema-note">
+			Ley Abierta informa, no asesora. Ante una duda fiscal concreta, consulta el
+			texto oficial en el BOE o a un profesional.
+		</p>
+	</div>
+</Base>


### PR DESCRIPTION
Consolida lo **útil y alineado con indexación** de las iteraciones 1 y 2 del loop SEO (#116, #147) en un cambio limpio, y descarta el churn de meta/alias que esos PRs arrastraban.

## Por qué no mergear #116/#147 tal cual
- **#147 fallaba su propio gate**: creó `/temas/empleo/` sin registrarla en el sitemap → 3 páginas huérfanas (la misma invisibilidad `/datos/`+`/pregunta/` que el gate existe para cazar).
- **Se pisaban** entre sí (`index.astro`, `leyes/[id].astro`) y **#116** está rancio (21-jul, conflicto probable con #145).
- Según [`STATUS.md`](.goals/seo/STATUS.md): con **13,2% indexado**, optimizar títulos/meta de páginas que Google no indexa **no mueve nada**. Primero indexación.

## Qué entra
- **`/temas/fiscalidad/`** (de #116) y **`/temas/empleo/`** (de #147): hubs curadas y agrupadas sobre las grandes leyes fiscales y laborales, con enlazado interno real y atacando queries en alza (IVA, Ley de Empleo). Páginas nuevas indexables — descubribilidad, no presentación. Filtran ids ausentes de `getCollection("laws")` → sin enlaces rotos.
- Ambas **registradas en `SECONDARY_PAGES`** → el gate de sitemap pasa (5/5).

## Qué se deja fuera (a propósito)
- **Alias de título + meta de home** de #116/#147 — bajo apalancamiento hasta que mejore la indexación.
- **Enlazado interno norma→reforma** de #116: hardcodea URLs query-form, lo que **confundiría el experimento vivo** de forma de URL (reformas 2026 repartidas path/query, lee el **18-ago**). Diferido hasta que el experimento lea.

## Verificación
- Gate de cobertura del sitemap: **5/5 pass** (era el que fallaba en #147).
- tsgo + biome limpios. Build astro lo valida CI.

Closes #116
Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)