### PR TITLE
fix(seo): limpiar el árbol antes de cambiar de rama en seo-loop.sh

### DIFF
--- a/scripts/seo/seo-loop.sh
+++ b/scripts/seo/seo-loop.sh
@@ -64,10 +64,15 @@ echo "== SEO loop · iter ${ITER} · ${DATE} · model=${MODEL} =="
 
 # ── Fresh branch off main ───────────────────────────────────────────────────
 git fetch --quiet origin main
+# Pristine tree BEFORE switching branches. A dirty tree — tracked edits or
+# untracked files left by a previous aborted run — makes `git checkout -B` abort
+# with "would be overwritten by checkout" and, under `set -e`, kills the whole
+# run before it can reset/clean. That silently stopped the 2026-08-01 cron for
+# two weeks. So discard leftovers first, THEN switch. `git clean` without -x
+# leaves gitignored data/ + node_modules untouched.
+git reset -q --hard HEAD
+git clean -fdq
 git checkout -q -B "$BRANCH" origin/main
-# Start from a pristine tree: discard leftovers from a previous aborted run (the
-# implement step edits the working tree before we commit). `git clean` without
-# -x leaves gitignored data/ + node_modules untouched.
 git reset -q --hard origin/main
 git clean -fdq
 


### PR DESCRIPTION
El loop hacía `git checkout -B $BRANCH origin/main` **antes** del reset/clean. Si el árbol de `SEO_REPO` estaba sucio (restos de un run abortado), el checkout abortaba con *would be overwritten by checkout* y, bajo `set -e`, mataba el run entero antes de llegar al reset/clean que existe justo para eso.

**Impacto real:** el run del **1-ago** cayó así y el loop estuvo parado ~2 semanas (sin snapshot GSC nuevo, sin iteración).

**Fix:** mover la limpieza (`reset --hard` + `clean`) **antes** del checkout, para que un árbol sucio no pueda bloquear el cambio de rama. El reset/clean posterior se queda como red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)