### PR TITLE
SEO: agent-readiness check + advertise /v1/ask to AI agents

### DIFF
--- a/packages/web/src/pages/llms-full.txt.ts
+++ b/packages/web/src/pages/llms-full.txt.ts
@@ -107,6 +107,16 @@ ${rankLines}
 
 ## API REST — Referencia completa
 
+### Preguntar en lenguaje natural (RAG, recomendado)
+\`POST /v1/ask\`
+
+Cuerpo: \`{"question": "¿Cuántos días de vacaciones me corresponden?"}\`
+
+Devuelve una respuesta en lenguaje llano fundamentada en la legislación vigente, con citas verificables a artículos concretos en formato \`[BOE-A-XXXX-XXXX, Artículo N]\`. Cada cita se comprueba contra un artículo real (verificación post-hoc). Es la vía preferente para un agente: pregunta directa → respuesta citada, en vez de buscar y leer manualmente. Streaming vía SSE disponible.
+
+### Texto de cualquier ley en Markdown
+Cualquier ficha de ley sirve su texto en Markdown limpio con la cabecera \`Accept: text/markdown\` (negociación de contenido), p.ej. \`GET https://leyabierta.es/leyes/:id/\` con \`Accept: text/markdown\`. Evita parsear HTML para citar el articulado.
+
 ### Buscar leyes
 \`GET /v1/laws\`
 

--- a/packages/web/src/pages/llms.txt.ts
+++ b/packages/web/src/pages/llms.txt.ts
@@ -32,11 +32,15 @@ export const GET: APIRoute = async () => {
 - [Sobre Ley Abierta](https://leyabierta.es/sobre/): Misión, datos, metodología
 
 ## API REST
+- Preguntar (RAG): \`POST https://api.leyabierta.es/v1/ask\` con \`{"question": "..."}\` — respuesta en lenguaje llano con citas verificables a artículos concretos (\`[BOE-A-XXXX-XXXX, Artículo N]\`). Es la forma recomendada de consultar la legislación española: pregunta en lenguaje natural y recibe una respuesta fundamentada, no solo resultados de búsqueda.
 - [Buscar leyes](https://api.leyabierta.es/v1/laws?q=): Búsqueda por texto, rango, estado, materia, jurisdicción
 - [Rangos normativos](https://api.leyabierta.es/v1/ranks): Tipos de norma con conteos
 - [Materias](https://api.leyabierta.es/v1/materias): Categorías temáticas con conteos
 - [Changelog](https://api.leyabierta.es/v1/changelog): Últimas reformas con resúmenes IA
 - [Health](https://api.leyabierta.es/health): Estado del servicio
+
+## Contenido en Markdown
+- Cualquier ficha de ley devuelve su texto en Markdown limpio si se solicita con la cabecera \`Accept: text/markdown\` — p.ej. \`curl -H "Accept: text/markdown" https://leyabierta.es/leyes/BOE-A-1978-31229/\`. Pensado para que un agente cite el texto legal sin parsear HTML.
 
 ## Código fuente
 - [GitHub](https://github.com/leyabierta/leyabierta): Código fuente del proyecto (AGPL-3.0)

--- a/scripts/seo/check-agent-readiness.ts
+++ b/scripts/seo/check-agent-readiness.ts
@@ -1,0 +1,282 @@
+#!/usr/bin/env bun
+/**
+ * Agent-readiness regression check for leyabierta.es.
+ *
+ * The site is already well set up for AI agents (open robots.txt with explicit
+ * AI-bot rules + Content-Signals, llms.txt / llms-full.txt, Markdown content
+ * negotiation on law pages). The risk is not that this is undone — it's that it
+ * silently breaks: Cloudflare's "Managed robots.txt" can auto-inject AI blocks,
+ * a build can drop llms.txt, content negotiation can regress. Nothing else
+ * catches that today.
+ *
+ * This asserts the agent-facing surface still works and exits non-zero if any
+ * CRITICAL check regresses. It reads over HTTP, so run it against production.
+ * The seo-loop calls it (non-fatal) so a regression shows up in the weekly review.
+ *
+ *   bun run scripts/seo/check-agent-readiness.ts
+ *   SEO_SITE_ORIGIN=https://staging... bun run scripts/seo/check-agent-readiness.ts
+ */
+
+import { SITE_ORIGIN } from "./lib.ts";
+
+/** A stable, always-present norm (Constitución Española) for page-level checks. */
+const SAMPLE_LAW = "BOE-A-1978-31229";
+const TIMEOUT_MS = 20_000;
+
+interface Check {
+	name: string;
+	ok: boolean;
+	detail: string;
+	critical: boolean;
+}
+
+async function fetchWithTimeout(
+	url: string,
+	init: RequestInit = {},
+): Promise<Response> {
+	return fetch(url, { ...init, signal: AbortSignal.timeout(TIMEOUT_MS) });
+}
+
+const checks: Check[] = [];
+function record(
+	name: string,
+	ok: boolean,
+	detail: string,
+	critical = true,
+): void {
+	checks.push({ name, ok, detail, critical });
+}
+
+/** One robots.txt group: the user-agents it names + its path rules, in order. */
+interface RobotsGroup {
+	agents: string[];
+	rules: { dir: "allow" | "disallow"; path: string }[];
+}
+
+/**
+ * Parse robots.txt into groups. Consecutive `User-agent:` lines share the
+ * rules that follow (per the robots.txt spec). Inline `#` comments are stripped.
+ * We parse groups instead of a substring match because the regression we care
+ * about — Cloudflare's Managed robots.txt — keeps naming the AI bots but adds
+ * `Disallow: /` to their group, so `body.includes("ClaudeBot")` stays true
+ * while the bot is in fact blocked.
+ */
+function parseRobots(body: string): RobotsGroup[] {
+	const groups: RobotsGroup[] = [];
+	let current: RobotsGroup | null = null;
+	let lastWasAgent = false;
+	for (const raw of body.split("\n")) {
+		const line = raw.replace(/#.*$/, "").trim();
+		if (!line) continue;
+		const idx = line.indexOf(":");
+		if (idx === -1) continue;
+		const field = line.slice(0, idx).trim().toLowerCase();
+		const value = line.slice(idx + 1).trim();
+		if (field === "user-agent") {
+			// A UA line right after another UA line extends the same group.
+			if (!current || !lastWasAgent) {
+				current = { agents: [], rules: [] };
+				groups.push(current);
+			}
+			current.agents.push(value.toLowerCase());
+			lastWasAgent = true;
+		} else if (field === "allow" || field === "disallow") {
+			if (current) current.rules.push({ dir: field, path: value });
+			lastWasAgent = false;
+		} else {
+			// Other directives (Content-Signal, Sitemap, …) don't break the group
+			// but do end the run of user-agent lines.
+			lastWasAgent = false;
+		}
+	}
+	return groups;
+}
+
+/** The group governing `bot`: its own named group if present, else the `*` group. */
+function groupFor(groups: RobotsGroup[], bot: string): RobotsGroup | null {
+	const name = bot.toLowerCase();
+	return (
+		groups.find((g) => g.agents.includes(name)) ??
+		groups.find((g) => g.agents.includes("*")) ??
+		null
+	);
+}
+
+/** A bot is blocked if its group disallows `/` and no later rule re-allows `/`. */
+function isBlocked(group: RobotsGroup): boolean {
+	const rootRule = [...group.rules]
+		.reverse()
+		.find((r) => r.path === "/" || r.path === "");
+	// The most specific root-level rule wins; a bare `Disallow:` (empty path)
+	// means "allow all", so only `Disallow: /` counts as a block.
+	return !!rootRule && rootRule.dir === "disallow" && rootRule.path === "/";
+}
+
+/** Markers of a Cloudflare interstitial served with a 200 status. */
+function looksChallenged(res: Response, body: string): boolean {
+	if (res.headers.get("cf-mitigated")) return true;
+	return /Just a moment|challenge-platform|__cf_chl|cf-browser-verification/i.test(
+		body,
+	);
+}
+
+async function run(): Promise<void> {
+	// 1. robots.txt still opens the door to AI crawlers, with the ai-input signal.
+	try {
+		const res = await fetchWithTimeout(`${SITE_ORIGIN}/robots.txt`);
+		const body = await res.text();
+		const groups = parseRobots(body);
+		const bots = ["GPTBot", "ClaudeBot", "PerplexityBot", "Google-Extended"];
+		// A bot regresses if its effective group blocks `/` (Cloudflare Managed
+		// robots.txt names the bot AND adds Disallow: / — a substring match misses this).
+		const blocked = bots.filter((b) => {
+			const g = groupFor(groups, b);
+			return !g || isBlocked(g);
+		});
+		// Require a real Content-Signal directive line that actually says
+		// ai-input=yes (not merely the word "Content-Signal", which CF's AI Audit
+		// block keeps while flipping the value to no).
+		const hasSignal = body
+			.split("\n")
+			.some(
+				(l) =>
+					/^\s*Content-Signal\s*:/i.test(l) && /ai-input\s*=\s*yes/i.test(l),
+			);
+		const ok = res.status === 200 && blocked.length === 0 && hasSignal;
+		record(
+			"robots.txt · AI bots + Content-Signals",
+			ok,
+			res.status !== 200
+				? `HTTP ${res.status}`
+				: blocked.length
+					? `AI bots blocked (Disallow: /): ${blocked.join(", ")} — Cloudflare Managed robots.txt?`
+					: !hasSignal
+						? "no Content-Signal line with ai-input=yes"
+						: "all AI bots allowed, ai-input=yes present",
+		);
+	} catch (e) {
+		record("robots.txt · AI bots + Content-Signals", false, `error: ${e}`);
+	}
+
+	// 2. llms.txt is served, is markdown, and advertises the RAG /v1/ask endpoint.
+	try {
+		const res = await fetchWithTimeout(`${SITE_ORIGIN}/llms.txt`);
+		const ct = res.headers.get("content-type") ?? "";
+		const body = await res.text();
+		const isMd = ct.includes("markdown");
+		const hasAsk = body.includes("/v1/ask");
+		record(
+			"llms.txt · served, markdown, advertises /v1/ask",
+			res.status === 200 && isMd && body.length > 200 && hasAsk,
+			res.status !== 200
+				? `HTTP ${res.status}`
+				: !isMd
+					? `content-type ${ct}`
+					: !hasAsk
+						? "does not mention /v1/ask (our RAG differentiator)"
+						: `${body.length}b markdown`,
+		);
+	} catch (e) {
+		record(
+			"llms.txt · served, markdown, advertises /v1/ask",
+			false,
+			`error: ${e}`,
+		);
+	}
+
+	// 3. llms-full.txt is served.
+	try {
+		const res = await fetchWithTimeout(`${SITE_ORIGIN}/llms-full.txt`);
+		record(
+			"llms-full.txt · served",
+			res.status === 200,
+			`HTTP ${res.status}`,
+			false,
+		);
+	} catch (e) {
+		record("llms-full.txt · served", false, `error: ${e}`, false);
+	}
+
+	// 4. Markdown content negotiation on a law page — clean text for citation.
+	try {
+		const res = await fetchWithTimeout(`${SITE_ORIGIN}/leyes/${SAMPLE_LAW}/`, {
+			headers: { Accept: "text/markdown" },
+		});
+		const ct = res.headers.get("content-type") ?? "";
+		const body = await res.text();
+		// Guard against an HTML body mislabelled as markdown: the point of the
+		// negotiation is that agents get text, not a page to scrape.
+		const looksHtml = /^\s*<(!doctype|html)/i.test(body);
+		const ok = res.status === 200 && ct.includes("markdown") && !looksHtml;
+		record(
+			"Markdown negotiation · Accept: text/markdown on a law",
+			ok,
+			looksHtml
+				? `HTTP ${res.status} · ${ct} but body is HTML`
+				: `HTTP ${res.status} · ${ct}`,
+		);
+	} catch (e) {
+		record(
+			"Markdown negotiation · Accept: text/markdown on a law",
+			false,
+			`error: ${e}`,
+		);
+	}
+
+	// 5. An AI-bot user agent is not challenged/blocked at the edge. Cloudflare
+	// can soft-challenge with a 200 that carries a JS interstitial, so we inspect
+	// the body/headers too — a bare status check would miss it.
+	try {
+		const res = await fetchWithTimeout(`${SITE_ORIGIN}/leyes/${SAMPLE_LAW}/`, {
+			headers: { "User-Agent": "ClaudeBot/1.0 (+https://leyabierta.es)" },
+		});
+		const body = await res.text();
+		const challenged = looksChallenged(res, body);
+		record(
+			"Edge · AI-bot UA not challenged",
+			res.status === 200 && !challenged,
+			res.status !== 200
+				? `ClaudeBot UA → HTTP ${res.status} (Cloudflare bot challenge?)`
+				: challenged
+					? "ClaudeBot UA → 200 but body is a Cloudflare challenge"
+					: "ClaudeBot UA → 200",
+		);
+	} catch (e) {
+		record("Edge · AI-bot UA not challenged", false, `error: ${e}`);
+	}
+
+	// 6. sitemap is served (discovery).
+	try {
+		const res = await fetchWithTimeout(`${SITE_ORIGIN}/sitemap.xml`);
+		record(
+			"sitemap.xml · served",
+			res.status === 200,
+			`HTTP ${res.status}`,
+			false,
+		);
+	} catch (e) {
+		record("sitemap.xml · served", false, `error: ${e}`, false);
+	}
+}
+
+await run();
+
+// ── Report (Markdown so the loop can drop it straight into the weekly review) ──
+const failedCritical = checks.filter((c) => !c.ok && c.critical);
+const failedWarn = checks.filter((c) => !c.ok && !c.critical);
+
+console.log(`# Agent-readiness — ${SITE_ORIGIN}\n`);
+for (const c of checks) {
+	const mark = c.ok ? "✅" : c.critical ? "❌" : "⚠️";
+	console.log(`- ${mark} ${c.name} — ${c.detail}`);
+}
+console.log(
+	`\n${failedCritical.length === 0 ? "**PASS**" : "**FAIL**"}: ` +
+		`${checks.filter((c) => c.ok).length}/${checks.length} ok` +
+		(failedCritical.length
+			? `, ${failedCritical.length} critical regression(s)`
+			: "") +
+		(failedWarn.length ? `, ${failedWarn.length} warning(s)` : ""),
+);
+
+process.exit(failedCritical.length === 0 ? 0 : 1);

--- a/scripts/seo/seo-loop.sh
+++ b/scripts/seo/seo-loop.sh
@@ -80,6 +80,19 @@ git clean -fdq
 bun run scripts/seo/pull-gsc.ts
 bun run scripts/seo/pull-umami.ts
 
+# ── 1b. Agent-readiness regression check ────────────────────────────────────
+# Non-fatal: an AI agent surfaces more of our traffic than classic crawlers now,
+# so a silent regression (Cloudflare Managed robots.txt injecting AI blocks, a
+# dropped llms.txt, broken Markdown negotiation) is a real risk the loop should
+# surface. It reads production over HTTP; the report feeds into the weekly review
+# but never blocks the run.
+AGENT_REPORT="$SEO_DATA_DIR/agent-readiness-${DATE}.md"
+if bun run scripts/seo/check-agent-readiness.ts > "$AGENT_REPORT" 2>&1; then
+	echo "agent-readiness: PASS ($AGENT_REPORT)"
+else
+	echo "agent-readiness: FAIL — regression detected, see $AGENT_REPORT" >&2
+fi
+
 # ── 2. Plan ─────────────────────────────────────────────────────────────────
 MODEL="$MODEL" bun run scripts/seo/plan.ts
 PLAN_FILE="$(ls -t "$SEO_DATA_DIR"/plan-*-"${DATE}".json | head -1)"


### PR DESCRIPTION
## Qué

Los agentes de IA (ChatGPT, Claude, Perplexity…) ya traen una parte creciente del tráfico. La superficie que consumen — `robots.txt` con reglas para bots de IA + Content-Signals, `llms.txt`/`llms-full.txt`, negociación de Markdown en las fichas de ley — no tenía guardarraíl de regresión. Este PR lo añade y, de paso, anuncia nuestro diferencial (`POST /v1/ask`, RAG con citas) a los agentes.

## Cambios

- **`scripts/seo/check-agent-readiness.ts`** — check HTTP contra producción:
  - `robots.txt` **parseado por grupo de `User-agent`** (no `includes`): caza el caso de Cloudflare Managed robots.txt que *sigue nombrando* al bot pero le añade `Disallow: /`.
  - exige una línea `Content-Signal` real con `ai-input=yes` (no basta la palabra).
  - `llms.txt`/`llms-full.txt` servidos; `llms.txt` anuncia `/v1/ask`.
  - negociación `Accept: text/markdown` devuelve `text/markdown` **no-HTML**.
  - UA de bot de IA (ClaudeBot) no recibe soft-challenge (200 + interstitial en el body).
  - sitemap servido.
  - Sale con código ≠0 ante cualquier regresión crítica.
- **`seo-loop.sh`** — corre el check tras los snapshots, **no-fatal**, y vuelca el informe al dir de la revisión semanal.
- **`llms.txt` / `llms-full.txt`** — anuncian `POST /v1/ask` y la negociación de Markdown para que los agentes prefieran la respuesta directa citada antes que raspar HTML.

## Revisión

- Revisado adversarialmente con grok; sus 4 hallazgos críticos sobre el parser de `robots.txt` (bots nombrados pero bloqueados, señal basura, bloqueo por-bot vs `*`, challenge con 200) están corregidos y verificados con mocks de robots inyectado por CF.
- El check corre hoy en verde salvo `/v1/ask` en `llms.txt` — que es justamente el gap que este PR despliega. Pasará a verde al mergear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)