### PR TITLE
fix(ci): pinear Bun en un solo sitio + desasignar env vars con delete

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,10 @@ version: 2
 # (read by setup-bun via `bun-version-file`). Dependabot has no updater for
 # that field, so the Docker PR below is the signal to bump it — keep the two
 # in sync by hand, they are one version on purpose.
+#
+# That is not left to discipline: scripts/__tests__/toolchain-pin.test.ts fails
+# when the Dockerfile and package.json disagree, so a Docker-only bump goes red
+# in its own PR instead of reintroducing the drift.
 
 updates:
   - package-ecosystem: github-actions

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+
+# Why this file exists: on 2026-08-21 the daily Deploy broke because the
+# workflows pinned `bun-version: latest` and Bun 1.4.0 shipped overnight,
+# changing `process.env.X = undefined` from "delete the key" to the Node
+# behaviour of coercing to the string "undefined". Pinning removes that class
+# of surprise; Dependabot is what keeps the pins from silently rotting.
+#
+# Note on Bun itself: the version lives in `package.json` -> `packageManager`
+# (read by setup-bun via `bun-version-file`). Dependabot has no updater for
+# that field, so the Docker PR below is the signal to bump it — keep the two
+# in sync by hand, they are one version on purpose.
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "ci"
+    groups:
+      actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "chore(docker)"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -122,7 +122,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: latest
+          bun-version-file: package.json
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -267,7 +267,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: latest
+          bun-version-file: package.json
 
       - name: Record start time
         id: timer

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -50,7 +50,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: latest
+          bun-version-file: package.json
 
       - run: bun install --frozen-lockfile
 
@@ -83,7 +83,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: latest
+          bun-version-file: package.json
 
       - name: Cache bun deps
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -40,7 +40,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: latest
+          bun-version-file: package.json
 
       - run: bun install --frozen-lockfile
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ── Build stage: compile the SIMD .so so gcc never reaches the runtime image ──
-FROM oven/bun:1.3.13-slim AS simd-builder
+FROM oven/bun:1.3.14-slim AS simd-builder
 
 WORKDIR /build
 
@@ -10,7 +10,7 @@ COPY packages/api/src/services/rag/vector-simd.c .
 RUN gcc -O3 -mavx2 -mfma -shared -fPIC -o vector-simd.linux-amd64.so vector-simd.c
 
 # ── Runtime stage: slim, no compiler toolchain ──
-FROM oven/bun:1.3.13-slim
+FROM oven/bun:1.3.14-slim
 
 WORKDIR /app
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
 	"type": "module",
 	"license": "AGPL-3.0-only",
 	"private": true,
+	"packageManager": "bun@1.3.14",
 	"workspaces": [
 		"packages/*"
 	],

--- a/packages/pipeline/tests/git-repo.test.ts
+++ b/packages/pipeline/tests/git-repo.test.ts
@@ -53,6 +53,17 @@ afterEach(() => {
 	rmSync(tempDir, { recursive: true, force: true });
 });
 
+// Assigning `undefined` to a process.env key coerces it to the truthy string
+// "undefined" (Bun >= 1.4, matching Node). Only `delete` actually unsets it.
+function restoreTZ(origTZ: string | undefined) {
+	if (origTZ === undefined) {
+		// biome-ignore lint/performance/noDelete: `delete` is the only way to unset an env var
+		delete process.env.TZ;
+	} else {
+		process.env.TZ = origTZ;
+	}
+}
+
 describe("GitRepo", () => {
 	describe("init", () => {
 		test("creates a git repo", async () => {
@@ -490,11 +501,7 @@ describe("Idempotency and TZ-stability", () => {
 		try {
 			await writeCommit(repoA, info);
 		} finally {
-			if (origTZ === undefined) {
-				process.env.TZ = undefined;
-			} else {
-				process.env.TZ = origTZ;
-			}
+			restoreTZ(origTZ);
 		}
 
 		// Repo B — run with TZ=UTC
@@ -502,11 +509,7 @@ describe("Idempotency and TZ-stability", () => {
 		try {
 			await writeCommit(repoB, info);
 		} finally {
-			if (origTZ === undefined) {
-				process.env.TZ = undefined;
-			} else {
-				process.env.TZ = origTZ;
-			}
+			restoreTZ(origTZ);
 		}
 
 		const datesA = readAuthorDates(repoA);

--- a/packages/web/src/__tests__/analytics.test.ts
+++ b/packages/web/src/__tests__/analytics.test.ts
@@ -69,6 +69,15 @@ function uninstallWindow() {
 	(globalThis as { navigator?: unknown }).navigator = undefined;
 }
 
+// `import.meta.env` aliases `process.env`, whose values are coerced to strings.
+// Assigning `undefined` yields the truthy string "undefined" (Bun >= 1.4, matching
+// Node), so the variable must be removed with `delete` to simulate "not set".
+function clearWebsiteId() {
+	// biome-ignore lint/performance/noDelete: `delete` is the only way to unset an env var
+	delete (import.meta.env as { PUBLIC_UMAMI_WEBSITE_ID?: string })
+		.PUBLIC_UMAMI_WEBSITE_ID;
+}
+
 // ---------- track() ----------
 
 describe("track()", () => {
@@ -184,9 +193,7 @@ describe("sendOutboundClick()", () => {
 		).PUBLIC_UMAMI_WEBSITE_ID = "test-uuid";
 	});
 	afterEach(() => {
-		(
-			import.meta.env as { PUBLIC_UMAMI_WEBSITE_ID?: string }
-		).PUBLIC_UMAMI_WEBSITE_ID = undefined;
+		clearWebsiteId();
 		uninstallWindow();
 	});
 
@@ -217,9 +224,7 @@ describe("sendOutboundClick()", () => {
 	});
 
 	it("is a no-op when website ID env var is missing", () => {
-		(
-			import.meta.env as { PUBLIC_UMAMI_WEBSITE_ID?: string }
-		).PUBLIC_UMAMI_WEBSITE_ID = undefined;
+		clearWebsiteId();
 		const beacon = mock(() => true);
 		(
 			globalThis as unknown as { navigator: { sendBeacon: typeof beacon } }

--- a/packages/web/src/__tests__/build-manifest-integration.test.ts
+++ b/packages/web/src/__tests__/build-manifest-integration.test.ts
@@ -48,6 +48,13 @@ const FULL_MANIFEST = {
 	},
 };
 
+// Assigning `undefined` to a process.env key coerces it to the truthy string
+// "undefined" (Bun >= 1.4, matching Node). Only `delete` actually unsets it.
+function clearManifestPath() {
+	// biome-ignore lint/performance/noDelete: `delete` is the only way to unset an env var
+	delete process.env.BUILD_MANIFEST_PATH;
+}
+
 beforeEach(() => {
 	mkdirSync(TEST_DIR, { recursive: true });
 	delete require.cache[require.resolve("../lib/manifest.ts")];
@@ -56,7 +63,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-	process.env.BUILD_MANIFEST_PATH = undefined;
+	clearManifestPath();
 	if (existsSync(TEST_DIR)) {
 		rmSync(TEST_DIR, { recursive: true });
 	}
@@ -119,7 +126,7 @@ describe("Build manifest integration", () => {
 	});
 
 	it("falls back to null when no manifest is present", () => {
-		process.env.BUILD_MANIFEST_PATH = undefined;
+		clearManifestPath();
 		const manifest = loadManifest();
 		expect(manifest).toBeNull();
 	});

--- a/packages/web/src/__tests__/manifest.test.ts
+++ b/packages/web/src/__tests__/manifest.test.ts
@@ -36,6 +36,13 @@ const VALID_MANIFEST = {
 	},
 };
 
+// Assigning `undefined` to a process.env key coerces it to the truthy string
+// "undefined" (Bun >= 1.4, matching Node). Only `delete` actually unsets it.
+function clearManifestPath() {
+	// biome-ignore lint/performance/noDelete: `delete` is the only way to unset an env var
+	delete process.env.BUILD_MANIFEST_PATH;
+}
+
 beforeEach(() => {
 	mkdirSync(TEST_DIR, { recursive: true });
 	// Clear module cache to reset the _manifest singleton
@@ -45,7 +52,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-	process.env.BUILD_MANIFEST_PATH = undefined;
+	clearManifestPath();
 	if (existsSync(TEST_DIR)) {
 		rmSync(TEST_DIR, { recursive: true });
 	}
@@ -53,7 +60,7 @@ afterEach(() => {
 
 describe("loadManifest()", () => {
 	it("returns null when BUILD_MANIFEST_PATH is not set", () => {
-		process.env.BUILD_MANIFEST_PATH = undefined;
+		clearManifestPath();
 		expect(loadManifest()).toBeNull();
 	});
 

--- a/scripts/__tests__/toolchain-pin.test.ts
+++ b/scripts/__tests__/toolchain-pin.test.ts
@@ -1,0 +1,71 @@
+/**
+ * The Bun version is a single number that has to hold in three places at once:
+ * package.json (read by setup-bun in CI), the Dockerfile (the API runtime), and
+ * the lockfile that both consume. When those drift, the failure never looks like
+ * a version problem — it looks like an unrelated test breaking, or
+ * `--frozen-lockfile` refusing a lockfile nobody touched.
+ *
+ * It has happened twice:
+ *   - 2026-05-12 (#91): image on `1-slim` resolved to 1.3.11, lockfile written
+ *     by 1.3.13 -> frozen-lockfile aborted the Deploy.
+ *   - 2026-08-21: workflows on `bun-version: latest` picked up Bun 1.4.0 the
+ *     morning it shipped, which changed `process.env.X = undefined` from
+ *     deleting the key to storing the string "undefined". The daily deploy of
+ *     the legislation went red on an analytics test.
+ *
+ * Both times the pin was fixed only in the layer that hurt. These tests make the
+ * drift itself the failure, so it surfaces in a PR instead of at 06:31 in the
+ * deploy that publishes new laws.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+const ROOT = new URL("../../", import.meta.url).pathname;
+
+const pkg = await Bun.file(`${ROOT}package.json`).json();
+const dockerfile = await Bun.file(`${ROOT}Dockerfile`).text();
+
+describe("Bun version pin", () => {
+	// setup-bun parses this field as `packageManager.split("bun@")[1]` and then
+	// validates it strictly. A Corepack-style hash suffix (`bun@1.3.14+sha512.…`)
+	// survives that split, fails validation, and the action falls back to
+	// `latest` — silently restoring the exact behaviour this pin exists to stop.
+	// The pin is fail-open, so the format is the thing worth guarding.
+	test("package.json declares an exact version with no hash suffix", () => {
+		expect(pkg.packageManager).toMatch(/^bun@\d+\.\d+\.\d+$/);
+	});
+
+	test("every Dockerfile stage uses the version from package.json", () => {
+		const version = pkg.packageManager.split("bun@")[1];
+		const tags = [...dockerfile.matchAll(/^FROM\s+oven\/bun:(\S+)/gm)].map(
+			(m) => m[1],
+		);
+
+		expect(tags.length).toBeGreaterThan(0);
+		for (const tag of tags) {
+			expect(tag).toBe(`${version}-slim`);
+		}
+	});
+});
+
+describe("CI workflows", () => {
+	test("no workflow tracks a floating Bun version", async () => {
+		const dir = `${ROOT}.github/workflows`;
+		const offenders: string[] = [];
+
+		for (const name of Array.from(
+			new Bun.Glob("*.yml").scanSync({ cwd: dir }),
+		)) {
+			const body = await Bun.file(`${dir}/${name}`).text();
+			// `latest`, `1`, `1.3` — anything that can resolve to a version the
+			// lockfile and the image have never seen.
+			for (const [, value] of body.matchAll(/^\s*bun-version:\s*(\S+)/gm)) {
+				if (value && !/^\d+\.\d+\.\d+$/.test(value)) {
+					offenders.push(`${name}: ${value}`);
+				}
+			}
+		}
+
+		expect(offenders).toEqual([]);
+	});
+});


### PR DESCRIPTION
## Qué pasaba

El **Deploy** diario disparado por `leyes-updated` falla desde hoy 2026-08-21 (runs [32454718543](https://github.com/leyabierta/leyabierta/actions/runs/32454718543) 06:31 y [32457791403](https://github.com/leyabierta/leyabierta/actions/runs/32457791403) 07:14). Sin ningún commit desde el 2026-08-07. El job `lint` es dependencia de `deploy-api` y `deploy-web`, así que **la web no se reconstruye con las leyes nuevas**: el pipeline del VPS sigue generando datos que no llegan a producción.

Un único test rojo: `sendOutboundClick() > is a no-op when website ID env var is missing`.

## Causa

`bun-version: latest` + Bun 1.4.0 publicado esta madrugada.

| Run | Bun | Resultado |
|---|---|---|
| 2026-08-20 06:31 | 1.3.14 | ✅ |
| 2026-08-21 06:31 / 07:14 | 1.4.0 | ❌ |

Bun 1.4.0 alinea `process.env` con Node: asignar `undefined` ahora coacciona al string truthy `"undefined"` en vez de borrar la clave. `import.meta.env` es un alias de `process.env`, así que el test que simulaba "variable no configurada" le pasaba `"undefined"` a `sendOutboundClick()`, que supera el guard de falsy y dispara el beacon.

Verificado ejecutando ambos binarios sobre el mismo árbol:

```
1.3.14 → undefined    (borra la clave)
1.4.0  → "undefined"  (string truthy)
```

Sólo estaban rotos los tests. El guard de producción está bien: Astro sustituye la variable estáticamente en build.

## Qué cambia

**1. `delete` para desasignar env vars en tests** — 7 sitios en 4 ficheros, encapsulados en helpers con `biome-ignore` para `performance/noDelete`. Sin esa supresión, `bun run format` reescribiría el fix de vuelta al bug.

Sólo fallaba el de analytics. Los otros eran bombas latentes que pasaban por accidente:

- `manifest.test.ts` / `build-manifest-integration.test.ts` — `BUILD_MANIFEST_PATH` valía `"undefined"`; el test pasaba sólo porque un fichero con ese nombre tampoco existe.
- `git-repo.test.ts` — dejaba `TZ` en la zona horaria inválida `"undefined"`, justo en el test que verifica la estabilidad de fechas de commit entre zonas.

**2. Pin de Bun en un solo sitio.** `packageManager` en el `package.json` raíz pasa a ser la fuente única de verdad, leída por `setup-bun` vía `bun-version-file` en los 5 pasos de workflow, y replicada en el Dockerfile.

Es el mismo modo de fallo que #91 (2026-05-12), que pineó sólo el Dockerfile y dejó los workflows en `latest`. Tres meses después volvió por la otra puerta. Las tres capas habían derivado a tres versiones distintas:

| Capa | Antes | Ahora |
|---|---|---|
| Docker | 1.3.13 | 1.3.14 |
| Local | 1.3.14 | 1.3.14 |
| CI | 1.4.0 (`latest`) | 1.3.14 |

**3. `.github/dependabot.yml`** (github-actions + docker, semanal) para que los pins se suban en un PR donde una rotura aparece en review, y no en el deploy diario de la legislación. Dependabot no tiene updater para el campo `packageManager`, así que el PR de Docker es la señal para subir ambos a mano — queda escrito en el propio fichero.

Nos quedamos en **1.3.14**, la versión que escribió `bun.lock`. Pasar a 1.4.0 es una decisión aparte.

## Verificación

- Suite completa con 1.3.14 (hook pre-push): **862 tests, 0 fail**
- Los 4 ficheros tocados con el binario **1.4.0** (el que rompía): todos verdes
- `biome check`: 0 warnings nuevos (los 8 restantes son preexistentes en `packages/eval`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y5CcUipfnQYCQFghADm2zh

## Añadido tras review adversarial

La review señaló que el pin **es fail-open** y que el propio Dependabot lo desharía:

1. `setup-bun` parsea el campo como `packageManager.split("bun@")[1]` y lo valida en estricto. Un hash estilo Corepack (`bun@1.3.14+sha512.…`) sobrevive al split, falla la validación y la action **cae de vuelta a `latest`** — justo lo que este PR intenta impedir.
2. Dependabot no tiene updater para `packageManager`, así que su primer PR de Docker sube solo la imagen y vuelve a separar CI y runtime. El comentario del `dependabot.yml` pide subir ambos, pero un comentario no es un check.

`scripts/__tests__/toolchain-pin.test.ts` convierte las tres formas de deriva en build rojo: `packageManager` no exacto, stage del Dockerfile que discrepa, y cualquier workflow que reintroduzca un `bun-version` flotante.

Verificado por mutación — inyectada cada una y comprobado que falla la aserción correspondiente:

| Mutación | Resultado |
|---|---|
| `bun@1.3.14+sha512.abc` | 2 fail ✅ |
| Dockerfile a `1.4.0-slim` (bump solo de imagen) | 1 fail ✅ |
| Vuelta a `bun-version: latest` | 1 fail ✅ |
| Sin mutar | 3 pass ✅ |

**No incluido, por quedar fuera del alcance:** la review propuso añadir `package-ecosystem: bun` para que Dependabot actualice también las dependencias de `bun.lock`. Es una decisión de política de dependencias distinta de arreglar el pin del toolchain, y merece su propio PR.
