### PR TITLE
fix(rag): indexar el escaneo de reconstrucción int8 (causa de la caída de hoy)

### DIFF
--- a/packages/api/src/__tests__/int8-rebuild-query-plan.test.ts
+++ b/packages/api/src/__tests__/int8-rebuild-query-plan.test.ts
@@ -1,0 +1,56 @@
+/**
+ * The int8 rebuild reads every embedding for one model in (norm_id, block_id)
+ * order. Each row carries a 16 KB vector blob, so how SQLite reaches that order
+ * is the difference between a ~20 MB streaming build and materialising ~8 GB.
+ *
+ * On 2026-08-21 there was no index covering the filter *and* the sort. SQLite
+ * satisfied `model = ?` with idx_embeddings_model and sorted the rest through a
+ * TEMP B-TREE. The API was killed mid-rebuild on every boot and sat in a restart
+ * loop; production served 502s until an index was added. The build code was
+ * never the problem — the query plan was.
+ *
+ * A unit test on buildInt8IndexFromDb cannot catch this: with a handful of test
+ * rows a TEMP B-TREE is instant and correct. Only the plan reveals it, so the
+ * plan is what this test asserts.
+ */
+
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+import { createSchema } from "../../../pipeline/src/db/schema.ts";
+
+function planFor(db: Database, sql: string): string {
+	const rows = db
+		.query<{ detail: string }, []>(`EXPLAIN QUERY PLAN ${sql}`)
+		.all();
+	return rows.map((r) => r.detail).join(" | ");
+}
+
+describe("int8 rebuild query plan", () => {
+	const REBUILD_SQL =
+		"SELECT norm_id, block_id, vector FROM embeddings WHERE model = 'qwen3-nan' ORDER BY norm_id, block_id";
+
+	test("the rebuild scan never sorts through a temp b-tree", () => {
+		const db = new Database(":memory:");
+		createSchema(db);
+
+		const plan = planFor(db, REBUILD_SQL);
+
+		// The failure mode, stated the way SQLite states it.
+		expect(plan).not.toInclude("TEMP B-TREE");
+		expect(plan).toInclude("idx_embeddings_model_order");
+	});
+
+	test("the index stays usable when the filter is a bound parameter", () => {
+		// The production call site binds the model instead of inlining it, and
+		// a bound parameter is exactly where a planner can pick differently.
+		const db = new Database(":memory:");
+		createSchema(db);
+
+		const plan = planFor(
+			db,
+			"SELECT norm_id, block_id, vector FROM embeddings WHERE model = ? ORDER BY norm_id, block_id",
+		);
+
+		expect(plan).not.toInclude("TEMP B-TREE");
+	});
+});

--- a/packages/api/src/services/db.ts
+++ b/packages/api/src/services/db.ts
@@ -89,6 +89,15 @@ export class DbService {
 			db.exec(
 				"CREATE INDEX IF NOT EXISTS idx_norms_source_url ON norms(source_url)",
 			);
+			// Unlike the two above, a missing index here is not "a slower query":
+			// the int8 rebuild sorts 494k rows carrying 16 KB vector blobs through
+			// a TEMP B-TREE (~8 GB) and the API is killed on boot, in a loop. It
+			// happened on 2026-08-21. The pipeline schema declares this index too;
+			// it is repeated here so an API that boots against a database the
+			// current ingest has not touched still rebuilds instead of crashing.
+			db.exec(
+				"CREATE INDEX IF NOT EXISTS idx_embeddings_model_order ON embeddings(model, norm_id, block_id)",
+			);
 		} catch {
 			// Read-only connection or concurrent writer — fall back to scans.
 		}

--- a/packages/pipeline/src/db/schema.ts
+++ b/packages/pipeline/src/db/schema.ts
@@ -236,6 +236,19 @@ const SCHEMA_SQL = /* sql */ `
   CREATE INDEX IF NOT EXISTS idx_embeddings_model ON embeddings(model);
   CREATE INDEX IF NOT EXISTS idx_embeddings_norm_id ON embeddings(norm_id);
 
+  -- Covers the int8 index rebuild: WHERE model = ? ORDER BY norm_id, block_id.
+  -- Without it SQLite satisfies the filter with idx_embeddings_model and then
+  -- sorts through a TEMP B-TREE — materialising ~494k rows whose payload is a
+  -- 16 KB vector blob each, about 8 GB. That defeats the streaming design of
+  -- buildInt8IndexFromDb (which otherwise peaks at ~20 MB) and the kernel kills
+  -- the API mid-rebuild, in a restart loop, on boot.
+  --
+  -- Not theoretical: it took the API down on 2026-08-21. The PRIMARY KEY cannot
+  -- serve this query — its leading column is norm_id, so "model = ?" is not a
+  -- prefix. Column order here is what matters: equality column first, then the
+  -- ORDER BY columns.
+  CREATE INDEX IF NOT EXISTS idx_embeddings_model_order ON embeddings(model, norm_id, block_id);
+
   -- RAG ask log: tracks user questions, answers, and quality metrics
   CREATE TABLE IF NOT EXISTS ask_log (
     id INTEGER PRIMARY KEY AUTOINCREMENT,


### PR DESCRIPTION
## Qué pasó

Hoy 2026-08-21 la API entró en bucle de reinicio al arrancar y sirvió **502 durante ~40 minutos**. Moría siempre a los ~50 s, a mitad de la reconstrucción del índice vectorial int8, con `ExitCode=0` y `OOMKilled=false` — la misma firma engañosa que el propio `docker-compose.yml` ya documenta para el incidente #100: el kernel mata PID 1, así que Docker nunca marca el cgroup como OOM-killed.

El disparador fue el primer arranque del contenedor después de que el pipeline de la madrugada añadiera embeddings (la DB pasó a 494.438 vectores frente a los 493.689 del índice en disco). El contenedor llevaba días sin reiniciarse, así que el desfase no se había manifestado nunca.

## Causa

`buildInt8IndexFromDb` está escrita para hacer streaming — su comentario promete un pico de «~20 MB más el blob de una fila». El código cumple. El plan de consulta no:

```
SEARCH embeddings USING INDEX idx_embeddings_model (model=?)
USE TEMP B-TREE FOR ORDER BY        <-- 494.438 filas × blob de 16 KB ≈ 8 GB
```

Ningún índice cubría el filtro **y** el orden a la vez, así que SQLite resolvía `model = ?` con `idx_embeddings_model` y ordenaba el resto en un B-tree temporal — arrastrando por él los blobs de los vectores. La PRIMARY KEY tampoco sirve: empieza por `norm_id`, así que `model = ?` no es prefijo.

## El arreglo

`idx_embeddings_model_order(model, norm_id, block_id)` — columna de igualdad primero, luego las del `ORDER BY`. Elimina el B-tree temporal.

Medido sobre la base de datos de producción (20 GB, 494.438 vectores `qwen3-nan`):

| | Antes | Después |
|---|---|---|
| Reconstrucción | muere a los ~50 s | **494.438 vectores en 100,9 s** |
| `.building` | atascado en 0 bytes | 2,03 GB completos |
| RAM del contenedor | reventaba el límite de 8 GB | **555 MB (6,8 %)** |
| API | bucle de reinicio, 502 | arranca y sirve |

Se declara en el esquema del pipeline y se repite en el bloque best-effort que `DbService` ya tenía, para que una API que arranque contra una base de datos que el ingest actual no haya tocado reconstruya en vez de caerse. Ese bloque ya tolera conexiones read-only y ocupadas.

El índice se creó directamente en producción para cortar la caída; este PR lo convierte en parte del esquema en lugar de un parche que se perdería al regenerar la base de datos.

## Por qué el test comprueba un plan de consulta

Con un puñado de filas, un B-tree temporal es instantáneo y correcto: un test unitario sobre la función de construcción no puede ver este fallo. Solo el plan lo delata.

Verificado por mutación — al quitar el índice, el test reproduce literalmente `USE TEMP B-TREE FOR ORDER BY` y falla.

## Pendiente, fuera de este PR

Un arranque que no puede reconstruir su índice debería degradarse (servir sin RAG, como permite `RAG_PRELOAD=false`) en vez de morir en bucle. Hoy la única señal fue el 502. Merece su propio issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y5CcUipfnQYCQFghADm2zh