### PR TITLE
SEO: deduplicar el sitemap de reformas + lectura del experimento A

### DIFF
--- a/.goals/seo/STATUS.md
+++ b/.goals/seo/STATUS.md
@@ -7,7 +7,7 @@ el loop) y [`EVAL.md`](EVAL.md) (cómo se puntúa un plan).
 > **Si vas a tocar el sitemap, el Worker o las URLs de reforma, lee primero la
 > sección de experimentos.** Hay uno vivo y un cambio despistado lo invalida.
 
-**Última actualización:** 2026-07-28
+**Última actualización:** 2026-08-21
 
 ---
 
@@ -16,36 +16,106 @@ el loop) y [`EVAL.md`](EVAL.md) (cómo se puntúa un plan).
 Medido con la URL Inspection API sobre 1.800 URLs (`scripts/seo/inspect-urls.ts`),
 no estimado:
 
-| Cohorte | Muestra | Rastreadas | Indexadas |
-|---------|---------|-----------|-----------|
-| Páginas de ley `/leyes/<id>/` | 1.178 | 99,1% | **13,2%** |
-| Reformas `/cambios/reforma/…` | 600 | **0%** | **0%** |
-| Páginas clave | 22 | 59% | 45% |
+| Cohorte | Muestra | Rastreadas | Indexadas | vs 2026-07-28 |
+|---------|---------|-----------|-----------|---------------|
+| Páginas de ley `/leyes/<id>/` | 1.173 | 98,9% | **15,9%** | +2,7 pp |
+| Reformas — brazo path | 299 | **0%** | **0%** | = |
+| Reformas — brazo query (2026) | 287 | **0%** | **0%** | = |
+| Reformas — query histórica | 22 | 100% | 86,4% | (cohorte sesgada, ver abajo) |
+| Páginas clave | 11 | 36,4% | 36,4% | — |
 
-Search Console, ventana de 28 días a 2026-07-25: 2 clics, 1.116 impresiones,
-CTR 0,18%, posición media 54.
+> La cohorte "query histórica" **no es evidencia de nada**: son las URLs que ya
+> reciben impresiones, y entran en la barrida por la cohorte de páginas con
+> ranking. Están rastreadas *porque* ya rankean. Sesgo de selección — no la uses
+> como control del experimento A.
+
+Search Console, ventana de 28 días a 2026-08-18: 1 clic, 1.111 impresiones,
+CTR 0,09%, posición media 54,5. Sin ninguna consulta en distancia de ataque
+(posición 8–20) ni con CTR bajo: todo cae entre la posición 40 y 90.
+
+### El dato que reencuadra el problema: no es el sitio, es Google
+
+Umami, mismos 28 días (893 visitas totales, +5% sobre el periodo anterior):
+
+| Fuente | Visitas |
+|--------|---------|
+| Ecosistema Bing (Bing, Yahoo, DuckDuckGo, Ecosia) | **334** |
+| Asistentes de IA (ChatGPT, Copilot, Kagi, Perplexity) | **~25** |
+| **Google** | **2** |
+
+Bing rastrea el sitio, lo indexa y manda 334 visitas. Google manda 2 con 1.111
+impresiones. Los mismos artículos que Google deja en "Rastreada: actualmente sin
+indexar" a Bing le parecen suficientemente útiles para posicionarlos.
+
+**Eso descarta la calidad de página como causa raíz y apunta a autoridad de
+dominio.** Un motor con menos exigencia de autoridad ya nos da tráfico; el que
+más exige, no. Encaja con el único backlink detectado (`libhunt.com`).
+
+El tráfico de asistentes de IA aterriza en fichas de ley concretas
+(`/leyes/BOE-A-2024-24099`, `BOE-A-2015-10565`…), no en `/pregunta/`: nos están
+citando como fuente. Valida el trabajo de agent-readiness. Está plano entre
+quincenas (~12 vs ~13), así que es un canal real pero pequeño, no una tendencia
+al alza que se pueda dar por hecha.
 
 **Son dos problemas distintos, y confundirlos lleva a arreglar lo que no es:**
 
 1. **Reformas — problema de rastreo.** Google no las descarga. Ninguna de las
-   600 muestreadas tiene `lastCrawlTime`. No se puede juzgar el contenido de una
-   página que nunca se ha visitado. → Experimento A.
-2. **Leyes — problema de valor percibido.** Google las descarga sin problema
-   (`pageFetchState: SUCCESSFUL` en 385/400) y decide no indexarlas. El texto
-   legal es idéntico al del BOE, que es la fuente autoritativa. Ningún ajuste
-   técnico arregla esto; hace falta que la página aporte algo que el BOE no da.
+   586 muestreadas (ambos brazos) tiene `lastCrawlTime`. No se puede juzgar el
+   contenido de una página que nunca se ha visitado. → Experimento A.
+2. **Leyes — problema de autoridad, no de contenido.** Google las descarga sin
+   problema (98,9%) y decide no indexar el 84%. Bing sí las indexa y las
+   posiciona. Ningún ajuste técnico de la página arregla esto.
 
-**Corolario para priorizar:** con el 13,2% indexado, optimizar títulos, meta
+**Corolario para priorizar:** con el 15,9% indexado, optimizar títulos, meta
 descriptions o datos estructurados de páginas que Google no indexa no mueve
-nada. Primero indexación, después presentación.
+nada. Primero indexación, después presentación. Y la palanca de indexación en
+Google es autoridad — enlaces externos — no ajustes on-page.
 
 ---
 
 ## Experimentos
 
-### A — Forma de URL de las reformas · **en curso**
+### A — Forma de URL de las reformas · **en curso, ventana ampliada**
 
-**Desplegado:** 2026-07-28 · **Lectura:** a partir de **2026-08-18**
+**Desplegado:** 2026-07-28 · **Leído 2026-08-21: ⏳ SIN SEÑAL** ·
+**Próxima lectura: 2026-09-22**
+
+> #### Lectura del 2026-08-21 — no concluir, no migrar
+>
+> | Brazo | n | Rastreadas | Indexadas |
+> |-------|---|-----------|-----------|
+> | Tratamiento (path) | 299 | **0,0%** | 0,0% |
+> | Control (query 2026) | 287 | **0,0%** | 0,0% |
+>
+> Ambos brazos planos a cero, con muestra por encima del umbral de 200 que pide
+> el reporte. Es el caso "⏳ Sin señal" de la tabla de decisión: Googlebot no ha
+> vuelto a esa parte del sitio. **Ausencia de datos, no evidencia contra la
+> hipótesis. No migres las ~34k restantes.**
+>
+> **Lo que sí se movió: el descubrimiento.** 167 de 276 URLs del brazo path
+> pasaron a "Descubierta: actualmente sin indexar" (109 siguen desconocidas). En
+> la línea base ninguna reforma era siquiera conocida por Google. Eso desplaza
+> el cuello de botella de *descubrimiento* a *presupuesto de rastreo*, que es un
+> problema de autoridad de dominio — ver el diagnóstico de arriba.
+>
+> **Confusores descartados** (comprobados el 2026-08-21): ambos brazos devuelven
+> 200; los `rel=canonical` son correctos y apuntan a la forma que el sitemap
+> anuncia; el enlazado interno es simétrico (un enlace por reforma desde la
+> ficha de ley, ambos con `?from=law`, que el canonical limpia); y ninguna
+> reforma aparece en los dos brazos a la vez (377 únicas en path, 34.169 en
+> query, intersección 0).
+>
+> **Por qué 2026-09-22 y no antes:** la mediana de rastreo del sitio es de ~21
+> días, pero las reformas nunca se han rastreado, así que no hay periodicidad
+> que aplicar. Un mes más da margen a que Googlebot vuelva. Si en esa lectura
+> ambos brazos siguen a cero, cerrar como **no concluyente** y pasar a autoridad
+> de dominio: el experimento no puede decidirse si Google no rastrea, y seguir
+> esperando no lo cambia.
+
+Las ~35k URLs `/cambios/reforma/?id=&date=` nunca se han rastreado, mientras las
+páginas de ley con paths reales sí (99,1%). Hipótesis: 35k URLs que solo
+difieren en query string se leen como navegación facetada, y Google no gasta
+presupuesto de rastreo en eso para un dominio con nuestra autoridad.
 
 Las ~35k URLs `/cambios/reforma/?id=&date=` nunca se han rastreado, mientras las
 páginas de ley con paths reales sí (99,1%). Hipótesis: 35k URLs que solo
@@ -69,7 +139,8 @@ página antes de poder juzgarla, y el bloqueo está en la descarga.
 
 Con una mediana de rastreo de 74 días en el resto del sitio, tres semanas puede
 quedarse corto. "Cero en ambos brazos" es ausencia de datos, no evidencia
-contra la hipótesis.
+contra la hipótesis. (Confirmado en la lectura del 2026-08-21: eso es
+exactamente lo que pasó.)
 
 **Código:** `packages/web/src/lib/reform-experiment.ts`. El criterio de reparto
 lo importan el Worker, el sitemap y la ficha de ley — no puede divergir.
@@ -81,6 +152,18 @@ cd /opt/leyabierta/seo-repo && set -a && . /opt/leyabierta/.env.seo && set +a
 SEO_INSPECT_BUDGET=600 bun run scripts/seo/inspect-urls.ts
 bun run scripts/seo/experiment-report.ts
 ```
+
+> **Ojo con el presupuesto de inspección.** La cola se estratifica por brazo
+> (`REFORM_SAMPLE_PER_ARM`, 300 por defecto) y `reforma-path` va primero por
+> orden alfabético, así que una única pasada de 600 se gasta entera en el brazo
+> tratamiento y deja el control sin muestra. La lectura del 2026-08-21 necesitó
+> **tres pasadas de 600** (1.800 de la cuota diaria de 2.000) para llegar a
+> n≥200 en ambos brazos. Presupuesta el día entero si vas a leer el experimento.
+>
+> También se puede leer desde local con la clave de servicio
+> (`SEO_GSC_SA_JSON=…`), pero eso arranca sin la caché `inspections.json` del
+> servidor: la mezcla de cohortes cambia y el `indexedRate` global no es
+> comparable con el del servidor. Las tasas **por cohorte** sí lo son.
 
 ### B — Descubrimiento de páginas clave · **desplegado 2026-07-28**
 
@@ -94,25 +177,39 @@ Añadidas junto con `/cambios/recientes/`. La lista vive en
 página estática esté en el sitemap o excluida explícitamente con su motivo, en
 ambos sentidos: una ruta excluida tampoco puede aparecer en el sitemap.
 
-> ⚠️ **El test no es gate en CI.** `deploy.yml` ejecuta `bun test || true` y
-> `pr-checks.yml` no ejecuta tests, así que un fallo no bloquea el merge ni el
-> despliegue. Vale como red para quien ejecute los tests en local, no como
-> garantía automática. Convertirlo en gate es trabajo aparte: el `|| true` está
-> ahí porque algunos tests del repo necesitan ficheros de datos que no existen
-> en CI.
+> ✅ **El test es gate en CI desde el 2026-07-28** (PR #146). `pr-checks.yml`
+> ejecuta `bun test` sin `|| true` en el job "Lint & test", y `deploy.yml`
+> también. Un fallo bloquea el merge y el despliegue. (Este aviso decía lo
+> contrario hasta el 2026-08-21; era cierto cuando se escribió y se quedó
+> obsoleto al mergear #146.)
 
 Sin criterio formal de éxito: es corregir una omisión, no una hipótesis. Se
 comprueba en la siguiente pasada de inspección.
+
+**Comprobado el 2026-08-21:** las cinco páginas están servidas (200) y presentes
+en `sitemap-leyes.xml`, junto con las dos hubs temáticas de #149. Las páginas
+clave siguen en 36,4% indexadas sobre n=11 — muestra demasiado pequeña para
+leer nada. Las consultas que suben en GSC (`ley de empleo` 23 imp.,
+`ley impuesto renta personas físicas` 11 imp. en posición 41) mapean contra las
+hubs, pero se desplegaron hace días: es demasiado pronto para atribuirlo.
 
 ---
 
 ## Abierto, sin atacar todavía
 
-- **Las 12.000 páginas de ley (13,2% indexadas).** Necesita diferenciación real
-  de contenido: que el HTML lleve por delante lo único nuestro (resúmenes
-  ciudadanos por artículo, historial de reformas, diffs entre versiones) en vez
-  de replicar articulado que el BOE ya tiene. Es el trabajo grande y el único
-  que mueve esa cifra.
+- **Autoridad de dominio — ahora la prioridad número uno.** Los datos de Umami
+  del 2026-08-21 (Bing 334 visitas, Google 2) descartan la calidad de página
+  como causa raíz: el contenido le vale a Bing, a los asistentes de IA y no a
+  Google. Lo que nos falta es lo que Google pondera y Bing no tanto: enlaces
+  externos. Hoy Google detecta **un** backlink hacia la home (`libhunt.com`).
+  Sin eso, ni el presupuesto de rastreo ni la indexación se mueven, y el resto
+  de la lista de abajo son optimizaciones sobre páginas que Google no indexa.
+- **Las 12.000 páginas de ley (15,9% indexadas).** Diferenciación de contenido:
+  que el HTML lleve por delante lo único nuestro (resúmenes ciudadanos por
+  artículo, historial de reformas, diffs entre versiones) en vez de replicar
+  articulado que el BOE ya tiene. Sigue siendo trabajo grande y que merece la
+  pena, pero ojo con la atribución: Bing ya indexa y posiciona estas mismas
+  páginas sin esa diferenciación, así que no es lo que bloquea a Google.
 - **Cero rich results.** `searchAppearance` viene vacío. El JSON-LD
   `Legislation` es correcto como dato semántico pero **Google no genera rich
   results para ese tipo**. Hoy sólo emitimos `Legislation` + `BreadcrumbList`
@@ -122,8 +219,10 @@ comprueba en la siguiente pasada de inspección.
   reformas), pero añadirlos antes de que esas páginas estén indexadas es
   optimizar algo que no existe. `FAQPage` no aplica: Google lo restringió en
   2023 a sitios gubernamentales y de salud.
-- **Autoridad de dominio.** El único backlink que Google detecta hacia la home
-  es `libhunt.com`. Sin enlaces externos, el presupuesto de rastreo se queda
-  corto por mucho que arreglemos lo técnico.
-- **El tráfico de buscadores llega de Bing**, no de Google (238 visitas vs 0 en
-  30 días de Umami). Google indexa poco y posiciona en el puesto 54.
+- **Sitemaps: pendiente de verificar.** El 2026-08-21 se reenvió
+  `sitemap-reformas.xml` (`scripts/seo/resubmit-sitemap.ts`) para forzar
+  revalidación: seguía reportando 160 errores de "fecha inválida" semanas
+  después de desplegar el filtro `isPlausibleReformDate`, con `lastSubmitted`
+  congelado en 2026-07-22. Google no recalcula al instante — **volver a mirar
+  el contador de errores a partir del 2026-08-24**. Si sigue en 160, el fix no
+  cubre todos los casos y hay que volver a mirar los datos, no el sitemap.

--- a/packages/web/src/__tests__/reform-sitemap.test.ts
+++ b/packages/web/src/__tests__/reform-sitemap.test.ts
@@ -1,0 +1,102 @@
+// Guards sitemap-reformas.xml's URL selection. The duplicate case is the one
+// with history: on 2026-08-21 the deployed sitemap carried 35,104 entries for
+// 34,546 distinct URLs — 558 redundant <loc>s across 380 laws, because a law
+// amended by two different norms on the same day has two `reformas[]` entries
+// that collapse to a single id+date URL.
+import { describe, expect, test } from "bun:test";
+import {
+	type ReformSitemapLaw,
+	reformSitemapEntries,
+} from "../lib/reform-sitemap.ts";
+
+const OPTS = {
+	siteUrl: "https://leyabierta.es",
+	todayIso: "2026-08-21",
+	maxYear: 2027,
+};
+
+const law = (over: Partial<ReformSitemapLaw> = {}): ReformSitemapLaw => ({
+	identificador: "BOE-A-1992-28740",
+	fecha_publicacion: "1992-11-27",
+	reformas: [],
+	...over,
+});
+
+describe("reformSitemapEntries", () => {
+	test("emits one entry per reform", () => {
+		const entries = reformSitemapEntries(
+			[law({ reformas: [{ fecha: "1999-01-14" }, { fecha: "2003-11-12" }] })],
+			OPTS,
+		);
+		expect(entries).toHaveLength(2);
+	});
+
+	test("collapses same-day reforms of one law into a single URL", () => {
+		const entries = reformSitemapEntries(
+			[
+				law({
+					reformas: [
+						{ fecha: "2003-11-12" },
+						{ fecha: "2003-11-12" },
+						{ fecha: "2003-11-12" },
+					],
+				}),
+			],
+			OPTS,
+		);
+		expect(entries).toHaveLength(1);
+	});
+
+	test("never emits a duplicate <loc> across the whole corpus", () => {
+		const entries = reformSitemapEntries(
+			[
+				law({ reformas: [{ fecha: "2003-11-12" }, { fecha: "2003-11-12" }] }),
+				law({
+					identificador: "BOE-A-2015-11724",
+					fecha_publicacion: "2015-10-02",
+					reformas: [{ fecha: "2021-05-05" }, { fecha: "2021-05-05" }],
+				}),
+			],
+			OPTS,
+		);
+		const locs = entries.map((e) => e.loc);
+		expect(new Set(locs).size).toBe(locs.length);
+	});
+
+	test("skips the original version — that's the law page, not a reform", () => {
+		const entries = reformSitemapEntries(
+			[law({ reformas: [{ fecha: "1992-11-27" }, { fecha: "1999-01-14" }] })],
+			OPTS,
+		);
+		expect(entries).toHaveLength(1);
+		expect(entries[0]?.loc).toContain("1999-01-14");
+	});
+
+	test("drops the corrupt year-2929 pipeline dates Google rejected", () => {
+		const entries = reformSitemapEntries(
+			[law({ reformas: [{ fecha: "2929-11-19" }, { fecha: "1999-01-14" }] })],
+			OPTS,
+		);
+		expect(entries).toHaveLength(1);
+		expect(entries[0]?.lastmod).toBe("1999-01-14");
+	});
+
+	test("clamps a future lastmod to today", () => {
+		const entries = reformSitemapEntries(
+			[law({ reformas: [{ fecha: "2026-12-31" }] })],
+			OPTS,
+		);
+		expect(entries[0]?.lastmod).toBe("2026-08-21");
+	});
+
+	test("escapes ampersands so the XML stays well-formed", () => {
+		// Query-form URLs carry &date=; a bare & would break the sitemap.
+		const entries = reformSitemapEntries(
+			[law({ reformas: [{ fecha: "1999-01-14" }] })],
+			OPTS,
+		);
+		const loc = entries[0]?.loc ?? "";
+		if (loc.includes("?id=")) expect(loc).toContain("&amp;date=");
+		expect(loc).not.toMatch(/&(?!amp;)/);
+	});
+});

--- a/packages/web/src/lib/reform-sitemap.ts
+++ b/packages/web/src/lib/reform-sitemap.ts
@@ -1,0 +1,66 @@
+/**
+ * Which reform URLs belong in sitemap-reformas.xml.
+ *
+ * Extracted from the route so the selection rules — skip the original version,
+ * drop corrupt dates, clamp future lastmods, and emit each URL once — can be
+ * tested without an Astro build. The route only turns these into XML.
+ */
+
+import { reformCanonicalPath } from "./reform-experiment.ts";
+import { clampLastmod, isPlausibleReformDate } from "./sitemap-dates.ts";
+
+export interface ReformSitemapEntry {
+	loc: string;
+	lastmod: string;
+}
+
+/** The slice of a law's frontmatter this module needs. */
+export interface ReformSitemapLaw {
+	identificador: string;
+	fecha_publicacion: string;
+	reformas: { fecha: string }[];
+}
+
+export function reformSitemapEntries(
+	laws: ReformSitemapLaw[],
+	opts: { siteUrl: string; todayIso: string; maxYear: number },
+): ReformSitemapEntry[] {
+	const entries: ReformSitemapEntry[] = [];
+	// A law can be amended by two different norms on the same day, so `reformas[]`
+	// holds several entries sharing one date. The URL carries only id + date, so
+	// those collapse to the same <loc> — 558 redundant entries as of 2026-08-21,
+	// across 380 laws. Duplicates buy nothing and eat headroom against the
+	// 50k-URL sitemap limit.
+	const seen = new Set<string>();
+
+	for (const law of laws) {
+		for (const reforma of law.reformas) {
+			// The original version's "reforma" entry shares the law's publication
+			// date — it's not a change, it's the law coming into existence. Skip it;
+			// that content lives at /leyes/<id>/, not /cambios/reforma/.
+			if (reforma.fecha === law.fecha_publicacion) continue;
+			// Drop corrupt pipeline dates (e.g. year 2929) — Google rejected the
+			// whole sitemap over 160 such "Invalid date" lastmods, keeping ~35k
+			// reform URLs out of the index.
+			if (!isPlausibleReformDate(reforma.fecha, opts.maxYear)) continue;
+
+			// Path form for the experiment cohort, query form for the rest. The
+			// sitemap must advertise exactly the URL the worker calls canonical,
+			// or we'd be asking Google to index a URL that points elsewhere.
+			const loc =
+				`${opts.siteUrl}${reformCanonicalPath(law.identificador, reforma.fecha)}`.replace(
+					/&(?!amp;)/g,
+					"&amp;",
+				);
+			if (seen.has(loc)) continue;
+			seen.add(loc);
+			// lastmod must never be in the future (Google flags it as invalid).
+			entries.push({
+				loc,
+				lastmod: clampLastmod(reforma.fecha, opts.todayIso),
+			});
+		}
+	}
+
+	return entries;
+}

--- a/packages/web/src/pages/sitemap-reformas.xml.ts
+++ b/packages/web/src/pages/sitemap-reformas.xml.ts
@@ -10,7 +10,10 @@
  *
  * One of two child sitemaps referenced by the /sitemap.xml index.
  *
- * TODO: reformas count (~44k) fits under the 50k-URL sitemap protocol limit
+ * Which URLs qualify lives in lib/reform-sitemap.ts so the rules are testable
+ * without a build; this file only renders them.
+ *
+ * TODO: reformas count (~34.5k) fits under the 50k-URL sitemap protocol limit
  * today, but doesn't have much headroom. If it grows past ~48k, split this
  * file by year (sitemap-reformas-2024.xml, sitemap-reformas-2025.xml, ...)
  * and update the index in sitemap.xml.ts accordingly.
@@ -18,8 +21,7 @@
 
 import { getCollection } from "astro:content";
 import type { APIRoute } from "astro";
-import { reformCanonicalPath } from "../lib/reform-experiment.ts";
-import { clampLastmod, isPlausibleReformDate } from "../lib/sitemap-dates.ts";
+import { reformSitemapEntries } from "../lib/reform-sitemap.ts";
 
 export const prerender = true;
 
@@ -30,38 +32,19 @@ const MAX_YEAR = new Date().getUTCFullYear() + 1;
 export const GET: APIRoute = async () => {
 	const laws = await getCollection("laws");
 
-	const urls: string[] = [];
+	const entries = reformSitemapEntries(
+		laws.map((l) => l.data),
+		{ siteUrl: SITE_URL, todayIso: TODAY_ISO, maxYear: MAX_YEAR },
+	);
 
-	for (const law of laws) {
-		const d = law.data;
-		for (const reforma of d.reformas) {
-			// The original version's "reforma" entry shares the law's publication
-			// date — it's not a change, it's the law coming into existence. Skip it;
-			// that content lives at /leyes/<id>/, not /cambios/reforma/.
-			if (reforma.fecha === d.fecha_publicacion) continue;
-			// Drop corrupt pipeline dates (e.g. year 2929) — Google rejected the
-			// whole sitemap over 160 such "Invalid date" lastmods, keeping ~35k
-			// reform URLs out of the index.
-			if (!isPlausibleReformDate(reforma.fecha, MAX_YEAR)) continue;
-
-			// lastmod must never be in the future (Google flags it as invalid).
-			const lastmod = clampLastmod(reforma.fecha, TODAY_ISO);
-			// Path form for the experiment cohort, query form for the rest. The
-			// sitemap must advertise exactly the URL the worker calls canonical,
-			// or we'd be asking Google to index a URL that points elsewhere.
-			const loc =
-				`${SITE_URL}${reformCanonicalPath(d.identificador, reforma.fecha)}`.replace(
-					/&(?!amp;)/g,
-					"&amp;",
-				);
-			urls.push(`  <url>
+	const urls = entries.map(
+		({ loc, lastmod }) => `  <url>
     <loc>${loc}</loc>
     <lastmod>${lastmod}</lastmod>
     <changefreq>never</changefreq>
     <priority>0.5</priority>
-  </url>`);
-		}
-	}
+  </url>`,
+	);
 
 	const xml = `<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">

--- a/scripts/seo/lib.ts
+++ b/scripts/seo/lib.ts
@@ -35,11 +35,22 @@ export const isoDay = (offsetDays = 0): string =>
 export const today = (): string => isoDay(0);
 
 // ── GSC auth: signed JWT → access token (no google-auth-library) ────────────
-let cachedToken: { token: string; exp: number } | null = null;
+/** Read-only scope: everything the loop does except submitting a sitemap. */
+export const GSC_SCOPE_READONLY =
+	"https://www.googleapis.com/auth/webmasters.readonly";
+/** Write scope: only needed to (re)submit a sitemap. */
+export const GSC_SCOPE_WRITE = "https://www.googleapis.com/auth/webmasters";
 
-export async function gscToken(): Promise<string> {
+// Keyed by scope: a readonly token must never be handed to a write call, and a
+// cache that ignored the scope would do exactly that.
+const cachedTokens = new Map<string, { token: string; exp: number }>();
+
+export async function gscToken(
+	scope: string = GSC_SCOPE_READONLY,
+): Promise<string> {
 	const nowSec = Math.floor(Date.now() / 1000);
-	if (cachedToken && cachedToken.exp > nowSec + 60) return cachedToken.token;
+	const cached = cachedTokens.get(scope);
+	if (cached && cached.exp > nowSec + 60) return cached.token;
 	if (!GSC_SA_JSON) {
 		throw new Error(
 			"SEO_GSC_SA_JSON is not set (path to the GSC service-account key JSON).",
@@ -55,7 +66,7 @@ export async function gscToken(): Promise<string> {
 		);
 	const claims = {
 		iss: key.client_email,
-		scope: "https://www.googleapis.com/auth/webmasters.readonly",
+		scope,
 		aud: "https://oauth2.googleapis.com/token",
 		iat: nowSec,
 		exp: nowSec + 3600,
@@ -83,7 +94,7 @@ export async function gscToken(): Promise<string> {
 			`GSC token error: ${json.error_description ?? JSON.stringify(json)}`,
 		);
 	}
-	cachedToken = { token: json.access_token, exp: nowSec + 3600 };
+	cachedTokens.set(scope, { token: json.access_token, exp: nowSec + 3600 });
 	return json.access_token;
 }
 

--- a/scripts/seo/resubmit-sitemap.ts
+++ b/scripts/seo/resubmit-sitemap.ts
@@ -1,0 +1,68 @@
+/**
+ * Resubmit a sitemap to Search Console to force revalidation.
+ *
+ * Google caches a sitemap's error state and does not necessarily clear it when
+ * the underlying file is fixed: `lastSubmitted` stays frozen at the original
+ * submission while `lastDownloaded` advances, and the stale error count keeps
+ * being reported. A PUT to the Sitemaps API re-registers the sitemap and makes
+ * Google re-evaluate it from scratch.
+ *
+ * This was needed on 2026-08-21: sitemap-reformas.xml still reported 160
+ * "Invalid date" errors from corrupt pipeline years (e.g. 2929) weeks after
+ * `isPlausibleReformDate` had filtered them out and the fix was deployed.
+ *
+ * Usage:
+ *   bun run scripts/seo/resubmit-sitemap.ts sitemap-reformas.xml
+ *   bun run scripts/seo/resubmit-sitemap.ts            # all child sitemaps
+ */
+
+import {
+	GSC_SCOPE_WRITE,
+	gscSitemaps,
+	gscToken,
+	SEO_SITE,
+	SITE_ORIGIN,
+} from "./lib.ts";
+
+async function resubmit(feedpath: string): Promise<void> {
+	// Submitting needs the write scope; the rest of the loop is readonly.
+	const token = await gscToken(GSC_SCOPE_WRITE);
+	const site = encodeURIComponent(SEO_SITE);
+	const feed = encodeURIComponent(feedpath);
+	const res = await fetch(
+		`https://www.googleapis.com/webmasters/v3/sites/${site}/sitemaps/${feed}`,
+		{ method: "PUT", headers: { Authorization: `Bearer ${token}` } },
+	);
+	// A successful PUT returns 204 No Content.
+	if (!res.ok) {
+		throw new Error(
+			`resubmit ${feedpath} failed: ${res.status} ${await res.text()}`,
+		);
+	}
+}
+
+const args = process.argv.slice(2);
+const targets = args.length
+	? args.map((a) => (a.startsWith("http") ? a : `${SITE_ORIGIN}/${a}`))
+	: (await gscSitemaps()).filter((s) => !s.isSitemapsIndex).map((s) => s.path);
+
+if (!targets.length) {
+	console.error("no sitemaps to resubmit");
+	process.exit(1);
+}
+
+console.log(`Reenviando ${targets.length} sitemap(s) a ${SEO_SITE}`);
+for (const t of targets) {
+	await resubmit(t);
+	console.log(`  ✓ ${t}`);
+}
+
+// Read back so the run reports what Google now holds, not just that the PUT
+// succeeded. Error counts are not recomputed instantly — expect the old number
+// here and re-check in a day or two.
+console.log("\nEstado tras el reenvío:");
+for (const s of await gscSitemaps()) {
+	console.log(
+		`  ${s.path}  errors=${s.errors} warnings=${s.warnings} lastSubmitted=${s.lastSubmitted?.slice(0, 10) ?? "-"}`,
+	);
+}


### PR DESCRIPTION
Sale de la revisión SEO del 2026-08-21.

## 1. Dedup del sitemap de reformas

El sitemap desplegado servía **35.104 entradas para 34.546 URLs distintas**: 558 `<loc>` duplicados repartidos por 380 leyes.

No es un bug de datos. Una ley modificada por dos normas distintas el mismo día tiene dos entradas legítimas en `reformas[]`, y como la URL sólo lleva id + fecha, colapsan en la misma. Duplicar un `<loc>` no aporta nada y consume margen contra el límite de 50k del protocolo, que el TODO del propio fichero ya señalaba como ajustado.

La selección de URLs pasa a `lib/reform-sitemap.ts` para poder testearla sin levantar un build de Astro; la ruta sólo renderiza. Con eso el guard es real: **7 tests** cubren las fechas repetidas, el año 2929 corrupto, el clamp de `lastmod` futuro y el escapado de `&`.

## 2. Reenvío de sitemaps a Search Console

`sitemap-reformas.xml` seguía reportando **160 errores de "fecha inválida"** semanas después de desplegar `isPlausibleReformDate`, con `lastSubmitted` congelado en 2026-07-22 aunque `lastDownloaded` avanzaba. Google cachea el estado de error y no lo recalcula solo: hace falta un PUT a la Sitemaps API.

Enviar necesita el scope `webmasters`, no el `webmasters.readonly` que pedía la lib. `gscToken` acepta ahora el scope como parámetro y **la caché de tokens se indexa por scope** — una caché que lo ignorase entregaría un token de sólo lectura a una llamada de escritura.

Ya ejecutado contra producción el 2026-08-21: `lastSubmitted` avanza. Los 160 errores tardan en recalcularse; hay que volver a mirar a partir del 2026-08-24.

## 3. STATUS.md

**Experimento A (forma de URL de las reformas): SIN SEÑAL.**

| Brazo | n | Rastreadas | Indexadas |
|-------|---|-----------|-----------|
| Tratamiento (path) | 299 | 0,0% | 0,0% |
| Control (query 2026) | 287 | 0,0% | 0,0% |

Ambos brazos planos con muestra por encima del umbral. Es ausencia de datos, no evidencia contra la hipótesis: **no se migran las ~34k restantes.** Próxima lectura el 2026-09-22. Sí se movió el descubrimiento: 167 de 276 URLs path pasaron a "Descubierta: actualmente sin indexar", donde antes ninguna reforma era conocida.

**El dato que reencuadra el diagnóstico** viene de Umami: **Bing manda 334 visitas, Google 2.** Los mismos artículos que Google deja en "Rastreada: actualmente sin indexar" a Bing le valen para indexar y posicionar. La causa raíz no es el valor del contenido frente al BOE — es autoridad de dominio, donde tenemos un único backlink. La lista de pendientes queda reordenada en consecuencia.

También documentadas dos trampas metodológicas que casi me cuelan un falso positivo: la cohorte `reforma-query-historica` está sesgada por selección (entra por tener impresiones, así que está rastreada *porque* ya rankea), y el presupuesto de inspección se agota entero en el brazo tratamiento si sólo haces una pasada.

De paso se corrige un aviso obsoleto que afirmaba que los tests no eran gate en CI: lo son desde #146.

## Verificación

- `bunx tsgo --noEmit` limpio en los ficheros tocados
- `bun run check` sin errores
- Tests a CI (no ejecutados en local)